### PR TITLE
Maven approach doesn't do diff scans

### DIFF
--- a/docs/semgrep-supply-chain/setup-maven.md
+++ b/docs/semgrep-supply-chain/setup-maven.md
@@ -30,6 +30,7 @@ The **general steps** to enable Semgrep Supply Chain to correctly parse Maven pr
 :::caution
 * Ensure that Maven is installed in the build environment that is used to generate the dependency trees.
 * Ensure that you generate dependency trees before running Semgrep.
+* This approach works for full scans. It does not work for [diff-aware scans](/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform/#diff-aware-scanning) unless the generated file is also tracked by git.
 :::
 
 You can perform the general steps in a local environment for testing. The following screenshot displays the commands running in a local environment:


### PR DESCRIPTION
Our current approach for scanning Maven dependency trees does not work with diff scans as described. This change adds that in the caution box so folks are aware of the limitation.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
