### PR TITLE
Moved Rust to GA for cross function

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -8,15 +8,15 @@
 | TypeScript | GA | GA | GA |
 | Kotlin     | GA | GA | Beta |   
 | C#         | GA | GA | -- |
-| Ruby       | GA | GA | -- |                      
+| Ruby       | GA | GA | -- |  
+| Rust       | GA | GA | -- |
 | JSX        | GA | GA | -- |                       
 | PHP        | GA | GA | -- |                   
 | Python     | GA | GA | -- |                        
-| Scala      | GA | GA | -- |     
+| Scala      | GA | GA | -- | 
 | JSON       | GA | -- | -- |                    
 | Terraform  | GA | -- | -- |      
 | Apex       | _Pro Engine Only_   | Beta | -- |
-| Rust       | GA | Experimental | -- |
 | Generic    | GA | -- | -- |  
 | Swift      | Beta | -- | -- |     
 | Bash       | Experimental | -- | -- |  


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

Moving Rust to GA for cross-function, now that it's a GA language in OSS. 

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
