### PR TITLE
Azure: Add note about TFVC repos not working with semgrep ci

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -348,6 +348,10 @@ The following configuration creates a CI job that runs an SCA scan using Semgrep
 
 ## Azure Pipelines
 
+:::info
+Scanning a project with the `semgrep ci` command requires the project to be version-controlled by Git. If you have Azure Repos that are version-controlled with [Team Foundations Version Control](https://learn.microsoft.com/en-us/azure/devops/repos/tfvc/what-is-tfvc?view=azure-devops), they would have to be migrated to Git to be scanned with `semgrep ci` and report results to the Semgrep Cloud Platform.
+:::
+
 To add Semgrep into Azure Pipelines:
 
 1. Access the YAML pipeline editor within Azure Pipelines by following the [YAML pipeline editor](https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/yaml-pipeline-editor?view=azure-devops#edit-a-yaml-pipeline) guide.

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -349,7 +349,7 @@ The following configuration creates a CI job that runs an SCA scan using Semgrep
 ## Azure Pipelines
 
 :::info
-Scanning a project with the `semgrep ci` command requires the project to be version-controlled by Git. If you have Azure Repos that are version-controlled with [Team Foundations Version Control](https://learn.microsoft.com/en-us/azure/devops/repos/tfvc/what-is-tfvc?view=azure-devops), they would have to be migrated to Git to be scanned with `semgrep ci` and report results to the Semgrep Cloud Platform.
+Scanning a project with the `semgrep ci` command requires the project to be version-controlled by Git. If you have Azure Repos that are version-controlled with [Team Foundations Version Control](https://learn.microsoft.com/en-us/azure/devops/repos/tfvc/what-is-tfvc?view=azure-devops), they must be migrated to Git to be scanned with `semgrep ci` and have results reported to the Semgrep Cloud Platform.
 :::
 
 To add Semgrep into Azure Pipelines:


### PR DESCRIPTION
Adds an info box for folks using Azure to note that (typically older) repos that are controlled with Team Foundations Version Control would have to be migrated to git to work with semgrep ci.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications 
