### PR TITLE
Fix IntelliJ description to say OSS only

### DIFF
--- a/docs/extensions/semgrep-intellij.md
+++ b/docs/extensions/semgrep-intellij.md
@@ -39,7 +39,7 @@ $ python3 -m pip install semgrep
 4. See Semgrep findings: Hold the pointer over the code that has the red underline.
 
 :::info Feature maturity
-Semgrep's IntelliJ extensions are in **public beta**. Please join the [Semgrep community Slack workspace](http://go.semgrep.dev/slack) and let the Semgrep team know if you encounter any issues.
+Semgrep's IntelliJ extensions are in **public beta**. Currently, the IntelliJ extension only supports Semgrep OSS - it doesn't support Semgrep Supply Chain, Secrets, Pro rules, or Pro Engine. Please join the [Semgrep community Slack workspace](http://go.semgrep.dev/slack) and let the Semgrep team know if you encounter any issues.
 :::
 
 ## Supported Jet Brains products


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
