### PR TITLE
fix dangling anchors because the heading was modified

### DIFF
--- a/docs/contributing/contributing-rules.md
+++ b/docs/contributing/contributing-rules.md
@@ -35,7 +35,7 @@ To contribute and publish rules to the Semgrep Registry through Semgrep Cloud Pl
 1. Fill in the required and optional fields.
 1. Click <i className="fa-solid fa-circle-check inline_svg"></i> **Continue**, and then click <i className="fa-solid fa-code-pull-request inline_svg"></i> **Create PR**.
 
-This workflow automatically creates a pull request in the GitHub [Semgrep Registry](https://github.com/returntocorp/semgrep-rules). Find more about the Semgrep Registry by reading the [Rule writing](#rule-writing) and [Tests](#tests) sections.
+This workflow automatically creates a pull request in the GitHub [Semgrep Registry](https://github.com/returntocorp/semgrep-rules). Find more about the Semgrep Registry by reading the [Rule writing](#writing-a-rule-for-semgrep-registry) and [Tests](#tests) sections.
 
 You can also publish rules as private rules outside of Semgrep Registry. These rules are not included in the Semgrep Registry, but they are accessible to your Semgrep organisation. See the [Private rules](/writing-rules/private-rules/) documentation for more information.
 
@@ -47,7 +47,7 @@ Fork our repository and make a pull request. Sign our Contributor License Agreem
 
 Pull requests require the approval of at least one maintainer and successfully passed [CI jobs](https://github.com/returntocorp/semgrep-rules/actions).
 
-Find more about the Semgrep Registry by reading the [Rule writing](#rule-writing) and [Tests](#tests) sections.
+Find more about the Semgrep Registry by reading the [Rule writing](#writing-a-rule-for-semgrep-registry) and [Tests](#tests) sections.
 
 ## Writing a rule for Semgrep Registry
 

--- a/docs/ignoring-files-folders-code.md
+++ b/docs/ignoring-files-folders-code.md
@@ -22,7 +22,7 @@ All Semgrep environments (CLI, CI, and Semgrep Cloud Platform) adhere to user-de
 | Method  | Usage    | Examples |
 |:--------|:---------|:---------|
 | To ignore blocks of code: `nosemgrep` | Create a comment, followed by a space (` `), followed by `nosemgrep` at the first line or preceding line of the pattern match. This generates a finding that is automatically ignored. | ` // nosemgrep` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `// nosemgrep: rule-id` <br /> `# nosemgrep` |
-| To ignore files and folders: `.semgrepignore` | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining files and folders in `.semgrepignore`](#defining-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/returntocorp/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
+| To ignore files and folders: `.semgrepignore` | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#defining-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/returntocorp/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
 
 ## Understanding Semgrep defaults
 
@@ -68,7 +68,7 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 |:---- |:------ |
 | To scan all files within Semgrep's scope each time you run Semgrep (only files within `.git` are ignored). | Create an empty `.semgrepignore` file in your repository root directory or in your project's working directory. An empty `.semgrepignore` will make Semgrep scan paths in `.gitignore`. |
 | To ignore files and folders in `.gitignore`. | Add `:include .gitignore` to your `.semgrepignore` file. |
-| To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file or [define them through Semgrep Cloud Platform](#defining-files-and-folders-in-semgrep-cloud-platform).|
+| To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file or [define them through Semgrep Cloud Platform](#defining-ignored-files-and-folders-in-semgrep-cloud-platform).|
 | To ignore specific code blocks each time you run a scan. | Create a comment with the word `nosemgrep`. |
 | To ignore files or folders for a particular scan. | Run Semgrep with the flag `--exclude` followed by the pattern or file to be excluded. See [CLI reference](../cli-reference/).
 | To include files or folders for a particular scan. | Run Semgrep with the flag `--include` followed by the  pattern or file to be included. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, still resulting in the file's exclusion. |

--- a/docs/semgrep-supply-chain/ignoring-deps.md
+++ b/docs/semgrep-supply-chain/ignoring-deps.md
@@ -24,7 +24,7 @@ Object.entries(frontMatter).filter(
 
 There are several methods to restrict code files or lock files from generating dependency findings.
 
-Create a `.semgrepignore` file in your repository's root directory and define code files and lock files to ignore. For more information, see [Ignoring files, folders, and code](/ignoring-files-folders-code/#defining-files-and-folders-in-semgrep-cloud-platform).
+Create a `.semgrepignore` file in your repository's root directory and define code files and lock files to ignore. For more information, see [Ignoring files, folders, and code](/ignoring-files-folders-code/#defining-ignored-files-and-folders-in-semgrep-cloud-platform).
 
 Refer to the following table to see which goal best suits your need:
 

--- a/docs/writing-rules/experiments/extract-mode.md
+++ b/docs/writing-rules/experiments/extract-mode.md
@@ -103,7 +103,7 @@ The `extract` key is required in extract mode. The value must be a metavariable 
 
 ### `dest-language`
 
-The `dest-language` key is required in extract mode. The value must be a [language tag](/writing-rules/rule-syntax/#language-extensions-and-tags).
+The `dest-language` key is required in extract mode. The value must be a [language tag](/writing-rules/rule-syntax/#language-extensions-and-languages-key-values).
 
 ### `transform`
 

--- a/src/components/reference/_required-rule-fields.mdx
+++ b/src/components/reference/_required-rule-fields.mdx
@@ -5,7 +5,7 @@ All required fields must be present at the top-level of a rule, immediately unde
 | `id`          | `string` | Unique, descriptive identifier, for example: `no-unused-variable`        |
 | `message`     | `string` | Message that includes why Semgrep matched this pattern and how to remediate it. See also [Rule messages](/contributing/contributing-to-semgrep-rules-repository/#rule-messages). |
 | `severity`    | `string` | One of the following values: `INFO` (Low severity), `WARNING` (Medium severity), or `ERROR` (High severity). The `severity` key specifies how critical are the issues that a rule potentially detects. Note: Semgrep Supply Chain differs, as its rules use CVE assignments for severity. For more information, see [Filters](/semgrep-supply-chain/triage-and-remediation/#filters) section in Semgrep Supply Chain documentation. |
-| `languages`   | `array`  | See [language extensions and tags](/writing-rules/rule-syntax/#language-extensions-and-tags) |
+| `languages`   | `array`  | See [language extensions and tags](/writing-rules/rule-syntax/#language-extensions-and-languages-key-values) |
 | [`pattern`](#pattern)_\*_     | `string` | Find code matching this expression |
 | [`patterns`](#patterns)_\*_   | `array`  | Logical AND of multiple patterns |
 | [`pattern-either`](#pattern-either)_\*_ | `array`  | Logical OR of multiple patterns |


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

Changed a bunch of anchors and tags that were dangling because the original heading was modified.

In one case, also changed the text of a link (added `ignored`) to the new heading text.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [X] Redirects are added if the PR changes page URLs
- [X] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
