### PR TITLE
fix semgrep publish typo

### DIFF
--- a/docs/writing-rules/private-rules.md
+++ b/docs/writing-rules/private-rules.md
@@ -55,7 +55,7 @@ If the directory contains test cases for the rules, Semgrep uploads them as well
 You can also change the visibility of the rules. For instance, to publish the rules as unlisted (which does not require authentication but will not be displayed in the public registry):
 
 ```sh
-semgrep publish --visiblity=unlisted myrules/
+semgrep publish --visibility=unlisted myrules/
 ```
 
 For more details, run `semgrep publish --help`.


### PR DESCRIPTION
`semgrep publish --visiblity=unlisted` to `semgrep publish --visibility=unlisted`

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
