### PR TITLE
update WSL admonition

### DIFF
--- a/docs/semgrep-code/semgrep-pro-engine-intro.md
+++ b/docs/semgrep-code/semgrep-pro-engine-intro.md
@@ -108,6 +108,9 @@ To update Semgrep Pro Engine to the latest version, follow these steps:
     <TabItem value='Windows Subsystem for Linux (WSL)'>
 
     ```bash
+    # ensure that you have Python 3.8 or later installed
+    # on WSL before proceeding
+    
     python3 -m pip install --upgrade semgrep
     ```
 


### PR DESCRIPTION
changing the [WSL instructions](https://semgrep.dev/docs/semgrep-code/semgrep-pro-engine-intro/#updating-semgrep-pro-engine-in-cli) to remind users they need Python 3.8 installed there as well (and to make it so that the code blocks for Linux and WSL aren't identical which then makes it look like the tabs are broken)

### Please ensure

- [ ] A technical writer reviews the content or PR
