### PR TITLE
update Support Languages doc with Hack

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -66,7 +66,7 @@ Their differences are outlined in the following table:
 | Feature  | GA | Beta | Experimental
 |----------|---------------|------------------| ----- |
 | Parse Rate  | 99%+ | 95%+ | 90%+ | 
-| Number of rules  | 10+ | 5+ | 0+ | 
+| Number of rules  | 10+ | 5+ | 0+. Query the [Registry](https://semgrep.dev/r) to see if any rules exist for your language. | 
 | Semgrep syntax | Regexp, equivalence, deep expression operators, types and typing. All features supported in Beta. | Complete metavariable support, metavariable equality. All features supported in Experimental. | Syntax, ellipsis operator, basic metavariable functionality.|
 | Support | Highest quality support by the Semgrep team. Reported issues are resolved promptly. | Supported by the Semgrep team. Reported issues are fixed after GA languages. | There are limitations to this language's functionality. Reported issues are tracked and prioritized with best effort.|
 

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -26,7 +26,8 @@
 | Cairo      | Experimental | -- | -- | 
 | Clojure    | Experimental | -- | -- |  
 | Dart       | Experimental | -- | -- |   
-| Dockerfile | Experimental | -- | -- |   
+| Dockerfile | Experimental | -- | -- |
+| Hack       | Experimental | -- | -- |   
 | HTML       | Experimental | -- | -- |      
 | Jsonnet    | Experimental | -- | -- | 
 | Julia      | Experimental | -- | -- |   


### PR DESCRIPTION
- Adds Hack to supported languages list and labels as experimental.
- Adds note about querying Registry for rules if the language is experimental.

### Please ensure

- [x] A technical writer reviews the content or PR