### PR TITLE
add dart support in SSC

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -98,13 +98,34 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
     <th>License detection support</th>
     <th>Time period of reachability rule coverage for CVEs/GHSAs</th>
 </tr></thead>
-<tbody><tr>
+<tbody>
+<tr>
+   <td>C#</td>
+   <td>NuGet</td>
+   <td><code>packages.lock.json</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+   <td rowspan="17">Since May 2022</td>
+</tr>
+<tr>
    <td>Go</td>
    <td>Go modules (<code>go mod</code>)</td>
    <td><code>go.mod</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✔️</td>
-   <td rowspan="15">Since May 2022</td>
+  </tr>
+<tr rowspan="2">
+   <td rowspan="2">Java</td>
+   <td>Gradle</td>
+   <td><code>gradle.lockfile</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+  </tr>
+  <tr>
+   <td>Maven</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
   </tr>
   <tr>
    <td rowspan="3">JavaScript or TypeScript</td>
@@ -154,32 +175,26 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
    <td style={{"text-align": "center"}}>GA</td>
    <td>✔️</td>
   </tr>
-<tr rowspan="2">
-   <td rowspan="2">Java</td>
-   <td>Gradle</td>
-   <td><code>gradle.lockfile</code></td>
-   <td style={{"text-align": "center"}}>GA</td>
-   <td>✔️</td>
-  </tr>
   <tr>
-   <td>Maven</td>
-   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
-   <td style={{"text-align": "center"}}>GA</td>
-   <td>✔️</td>
-  </tr>
-<tr>
-   <td>C#</td>
-   <td>NuGet</td>
-   <td><code>packages.lock.json</code></td>
-   <td style={{"text-align": "center"}}>GA</td>
-   <td>✔️</td>
-</tr>
-<tr>
    <td>Rust</td>
    <td>Cargo</td>
    <td><code>cargo.lock</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
    <td>✔️</td>
+</tr>
+<tr>
+   <td>Dart</td>
+   <td>Pub</td>
+   <td><code>pubspec.lock</code></td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>❌</td>
+</tr>
+<tr>
+   <td>Kotlin</td>
+   <td>Maven</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>❌</td>
 </tr>
 <tr>
    <td>PHP</td>
@@ -189,9 +204,9 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
    <td>❌</td>
 </tr>
 <tr>
-   <td>Dart</td>
-   <td>Pub</td>
-   <td><code>pubspec.lock</code></td>
+   <td>Scala</td>
+   <td>Maven</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
    <td>❌</td>
 </tr>

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -104,7 +104,7 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
    <td><code>go.mod</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✔️</td>
-   <td rowspan="14">Since May 2022</td>
+   <td rowspan="15">Since May 2022</td>
   </tr>
   <tr>
    <td rowspan="3">JavaScript or TypeScript</td>
@@ -185,6 +185,13 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
    <td>PHP</td>
    <td>Composer</td>
    <td><code>composer.lock</code></td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>❌</td>
+</tr>
+<tr>
+   <td>Dart</td>
+   <td>Pub</td>
+   <td><code>pubspec.lock</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
    <td>❌</td>
 </tr>


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

![dart-support](https://github.com/semgrep/semgrep-docs/assets/20766840/74cdb455-5619-4d62-9592-7d2254730ee8)

Yo @andy-r2c! Can you confirm `pubspec.lock` and if we have license detection for Dart? :pray: 
