### PR TITLE
Be explicit about what constitutes GitHub / SaaS

### DIFF
--- a/docs/semgrep-cloud-platform/getting-started.md
+++ b/docs/semgrep-cloud-platform/getting-started.md
@@ -94,7 +94,7 @@ This process creates an **organization account**, which your team members in Git
 4. Click **Create**.
 5. Your organization is created and you are prompted to start a scan. Instead of starting a scan, click **<i class="fa-solid fa-gear"></i> Settings** in the navigation menu.
 6. Click **Source code managers**.
-7. Select the source code manager that contains the org to connect to Semgrep Cloud Platform.
+7. Select the source code manager that contains the org to connect to Semgrep Cloud Platform. For GitHub Enterprise Cloud, select **Connect to GitHub**.
 ![Source code manager tab](/img/source-code-manager.png#md-width)
 8. Follow the steps to connect your source code manager. You can review permissions needed by Semgrep in [Requested permissions for GitHub and GitLab](#requested-permissions-for-github-and-gitlab).
 9. Optional: Refer to the instructions in [SSO configuration](/semgrep-cloud-platform/sso/) to set up SSO for your organization.

--- a/src/components/concept/_platform-signin-intro.md
+++ b/src/components/concept/_platform-signin-intro.md
@@ -1,5 +1,5 @@
 Signing in to Semgrep Cloud Platform requires a GitHub account, GitLab account, or SSO. This guide focuses on GitHub and GitLab sign-ins. See [SSO Configuration](/semgrep-cloud-platform/sso/) for information on single sign-on.
 
 :::info Prerequisite
-A GitHub or GitLab SaaS account. The account is used to confirm your identity.
+A GitHub or GitLab SaaS account. The account can be associated with any subscription level, including GitHub Enterprise Cloud or GitLab Ultimate. The account is used to confirm your identity.
 :::

--- a/src/components/concept/_platform-signin-intro.md
+++ b/src/components/concept/_platform-signin-intro.md
@@ -1,5 +1,5 @@
 Signing in to Semgrep Cloud Platform requires a GitHub account, GitLab account, or SSO. This guide focuses on GitHub and GitLab sign-ins. See [SSO Configuration](/semgrep-cloud-platform/sso/) for information on single sign-on.
 
 :::info Prerequisite
-A GitHub or GitLab SaaS account. The account can be associated with any subscription level, including GitHub Enterprise Cloud or GitLab Ultimate. The account is used to confirm your identity.
+A GitHub.com or GitLab.com SaaS account. The account can be associated with any subscription level, including GitHub Enterprise Cloud or GitLab Ultimate, as long as it is cloud-hosted. The account is used to confirm your identity.
 :::


### PR DESCRIPTION
Sometimes folks are confused about whether GitHub Enterprise Cloud is a SaaS thing, so make it explicit. (This might also help the AI know how to answer questions about setup with GHEC.) While doing that we also wanted to make it clear for GitLab - but GitLab has three types of hosting (cloud, SM, and Dedicated) and I believe only cloud/.com will work, so we adjusted a bit further.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
