### PR TITLE
corrections to older messages

### DIFF
--- a/docs/release-notes/october-2023.md
+++ b/docs/release-notes/october-2023.md
@@ -25,7 +25,7 @@ tags:
 ### Added
 - Added a button to **Remove** source code manager (SCM) apps. This is helpful when you have a misconfigured SCM app, such as GitHub's `semgrep-app`, and want to reinstall it. <!--(10688)--> To remove an SCM, click **<i class="fa-solid fa-gear"></i> Settings > Source code managers**.
     ![Remove your source code manager](/img/settings-scm-remove.png)
-- Added Semgrep Assistant to the new onboarding flow. <!--(10716) -->
+- Added Semgrep Assistant to the new **Getting started** guide in the onboarding flow. <!--(10716) -->
 - **OpenAPI:** Renamed instances of r2c to Semgrep. <!--(10685) -->
 - **CLI login:** New users are now directed to create a Semgrep org when they are logging in for the first time to Semgrep Cloud Platform from the CLI. <!-- (10596) -->
 

--- a/docs/release-notes/september-2023.md
+++ b/docs/release-notes/september-2023.md
@@ -40,7 +40,7 @@ tags:
 
 ### Added
 
-- UX: Added a new **onboarding** flow. This onboarding flow streamlines the following steps to ensure that users are able to quickly add repositories for scanning with Semgrep: <!-- #10473 -->
+- UX: Added a new **onboarding** flow. This onboarding flow streamlines the following steps to ensure that users are able to quickly set up Semgrep scans: <!-- #10473 -->
 	- **Deployment creation**. The Semgrep team has made improvements to Semgrep account creation and connecting your source code manager, such as GitHub or GitLab. 
 	- **Onboarding checklist.** This helps you troubleshoot and resolve any issues early on in your journey.
 	- **Tour of features**. Make the most of your Semgrep experience by learning what features are available to you.
@@ -49,6 +49,7 @@ tags:
 ### Changed
 
 - **SCM configuration:** Improved the **Delete message** when deleting SCMs, so that you are aware of the implications of removing an SCM. Many major Semgrep features rely on a connection with your source code manager, so take care when deleting SCMs.
+- **GitHub:** Semgrep no longer automatically associates a new user's Semgrep organization with their personal GitHub account. New users can still connect their Semgrep organization with their personal account.
 
 ### Fixed
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content **(n/a)**
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

I wrote some corrections to our existing release notes:

1. Oct 2023 - Added Semgrep Assistant onboarding - we never explained which part of the onboarding flow, so I clarified that it's in the [Getting started guide; the user still has to set up other parts](https://www.notion.so/semgrep/Existing-Semgrep-Assistant-Signup-Steps-5b8d39d8dfea4b5193ad21224d7c9fdf).
2. Based on discussions last week, the personal GitHub to Semgrep org auto connection was [changed](https://semgrepinc.slack.com/archives/D064BEUCFFF/p1704305365388649) for the new Onboarding flow, and for posterity I am noting down this behavior change.
3. Lastly, we say "Add your repositories to Semgrep" but the implied 1-click auto-setup behavior is [exclusive to GHA](https://semgrepinc.slack.com/archives/C02PV1VVAUR/p1704474004591439), so I toned down the claims a bit.