### PR TITLE
corrected table based on feedback

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -105,7 +105,7 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
    <td><code>packages.lock.json</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✔️</td>
-   <td rowspan="17">Since May 2022</td>
+   <td rowspan="12">Since May 2022</td>
 </tr>
 <tr>
    <td>Go</td>
@@ -138,13 +138,13 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
    <td>Yarn, Yarn 2, Yarn 3</td>
    <td><code>yarn.lock</code></td>
    <td style={{"text-align": "center"}}>GA</td>
-   <td>❌</td>
+   <td>--</td>
   </tr>
   <tr>
    <td>pnpm</td>
    <td><code>pnpm-lock.yaml</code></td>
    <td style={{"text-align": "center"}}>GA</td>
-   <td>❌</td>
+   <td>--</td>
   </tr>
   <tr>
    <td rowspan="4">Python</td>
@@ -181,34 +181,35 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
    <td><code>cargo.lock</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
    <td>✔️</td>
+   <td rowspan="5">Not applicable due to reachability support level</td>
 </tr>
 <tr>
    <td>Dart</td>
    <td>Pub</td>
    <td><code>pubspec.lock</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
-   <td>❌</td>
+   <td>--</td>
 </tr>
 <tr>
    <td>Kotlin</td>
    <td>Maven</td>
    <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
-   <td>❌</td>
+   <td>--</td>
 </tr>
 <tr>
    <td>PHP</td>
    <td>Composer</td>
    <td><code>composer.lock</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
-   <td>❌</td>
+   <td>--</td>
 </tr>
 <tr>
    <td>Scala</td>
    <td>Maven</td>
    <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
-   <td>❌</td>
+   <td>--</td>
 </tr>
   </tbody>
 </table>


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR **(nano-sized pr)**


Feedback:
> ...language support graph for SCA is confusing. At first glance it feels like we are saying Kotlin has reachability support because the :x: is only for License Detection and there is no :x: for Time Period of Reachability Rule Coverage.

Agreed, it erroneously says "Since May 2022" for all package managers, including those which don't have any reachability rules. Reachability rules for these package managers should be n/a.

> the :x: feels like a very loud "no" where a blank communicates the same, but leaves room for "soon" 
Also agreed, and considering that the language table uses `--`, I went with those for consistency.