### PR TITLE
Add clarity on what Semgrep Assistant does in PR/MR vs Slack

### DIFF
--- a/docs/semgrep-code/semgrep-assistant-code.md
+++ b/docs/semgrep-code/semgrep-assistant-code.md
@@ -196,7 +196,7 @@ Semgrep Assistant can analyze if your finding is a true or false positive. The a
 
 ### Suggest autofix code snippets to resolve the finding
 
-Semgrep Assistant can suggest [autofix](/writing-rules/autofix/) code snippets for Semgrep rules which do not have human-written autofix suggestions. This feature is only active in PR/MR comments.
+Semgrep Assistant can suggest [autofix](/writing-rules/autofix/) code snippets for Semgrep rules which do not have human-written autofix suggestions. This feature is only active in PR and MR comments.
 
 To enable autofix by Semgrep Assistant, perform the following steps:
 

--- a/docs/semgrep-code/semgrep-assistant-code.md
+++ b/docs/semgrep-code/semgrep-assistant-code.md
@@ -192,7 +192,7 @@ The following are recommendations users can receive from Semgrep Assistant.
 
 ### Analyze if a finding is a true or false positive
 
-Semgrep Assistant can analyze if your finding is a true or false positive. The accuracy of its recommendations is roughly 60% and varies based on the language and framework you are using. This is its default use case. This feature is active in both PR/MR comments and Slack notifications.
+Semgrep Assistant can analyze if your finding is a true or false positive. The accuracy of its recommendations is roughly 60% and varies based on the language and framework you are using. This is its default use case. This feature is active in both PR and MR comments and Slack notifications.
 
 ### Suggest autofix code snippets to resolve the finding
 

--- a/docs/semgrep-code/semgrep-assistant-code.md
+++ b/docs/semgrep-code/semgrep-assistant-code.md
@@ -192,11 +192,11 @@ The following are recommendations users can receive from Semgrep Assistant.
 
 ### Analyze if a finding is a true or false positive
 
-Semgrep Assistant can analyze if your finding is a true or false positive. The accuracy of its recommendations is roughly 60% and varies based on the language and framework you are using. This is its default use case.
+Semgrep Assistant can analyze if your finding is a true or false positive. The accuracy of its recommendations is roughly 60% and varies based on the language and framework you are using. This is its default use case. This feature is active in both PR/MR comments and Slack notifications.
 
 ### Suggest autofix code snippets to resolve the finding
 
-Semgrep Assistant can suggest [autofix](/writing-rules/autofix/) code snippets for Semgrep rules which do not have human-written autofix suggestions.
+Semgrep Assistant can suggest [autofix](/writing-rules/autofix/) code snippets for Semgrep rules which do not have human-written autofix suggestions. This feature is only active in PR/MR comments.
 
 To enable autofix by Semgrep Assistant, perform the following steps:
 


### PR DESCRIPTION
Clarify that Assistant doesn't supply autofixes in Slack.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team