### PR TITLE
Explain permissions required for private repositories when using GHAS

### DIFF
--- a/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
+++ b/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
@@ -72,7 +72,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - run: semgrep scan --sarif > semgrep.sarif
+      - run: semgrep ci --sarif > semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
+++ b/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
@@ -13,7 +13,7 @@ If you run the alternate job and it fails with a "resource not accessible by int
 
 ## The workflow or job does not have sufficient permissions
 
-Semgrep findings in a private repository can only populate in the GitHub Advanced Security Dashboard if the correct permissions are set using the `permissions` key. See an example below.
+Semgrep findings in a private repository can only populate in the GitHub Advanced Security Dashboard if the correct permissions are set using the `permissions` key. See the following example.
 
 ## The workflow permissions in your repository's Actions settings are set to read-only
 

--- a/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
+++ b/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
@@ -11,7 +11,7 @@ When scanning with Semgrep in CI, findings automatically populate in Semgrep Clo
 
 If you run the alternate job and it fails with a "resource not accessible by integration" error, there are two possible causes.
 
-## Your repository's default workflow permissions are set to read-only
+## Your repository's workflow permissions are set to read-only
 
 Repository-level workflow permissions are set to `read-only` (default) unless they've previously been changed. Use of the `permissions` key within the workflow file does not override this setting.
 
@@ -45,7 +45,6 @@ on:
     branches: ["master", "main"]
   schedule:
     - cron: '20 17 * * *' # Sets Semgrep to scan every day at 17:20 UTC.
-    # It is recommended to change the schedule to a random time.
 
 jobs:
   semgrep:
@@ -56,7 +55,6 @@ jobs:
       # A Docker image with Semgrep installed. Do not change this.
       image: returntocorp/semgrep
 
-    # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')
     permissions:
       # required for all workflows

--- a/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
+++ b/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
@@ -23,7 +23,7 @@ To update this setting:
 Target permissions
 
 :::info 
-Changing the repository's default workflow permissions changes the permissions for all workflows in that repository. For more granular permissions, set the `permissions` key at the workflow or job level in the `semgrep.yml` workflow file. Learn more about the `permissions` key at [Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#setting-the-github_token-permissions-for-all-jobs-in-a-workflow), or review the example workflow-level permissions below.
+Changing the repository's default workflow permissions changes the permissions for all workflows in that repository. Use of the `permissions` key will not override this setting, so updating it is a required step. Learn more about the `permissions` key at [Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#setting-the-github_token-permissions-for-all-jobs-in-a-workflow), or review the example workflow-level permissions below.
 :::
 
 ## The workflow or job does not have the correct permissions in a private repository

--- a/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
+++ b/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
@@ -11,15 +11,11 @@ When scanning with Semgrep in CI, findings automatically populate in Semgrep Clo
 
 If you run the alternate job and it fails with a "resource not accessible by integration" error, there are two possible causes.
 
-## The workflow or job does not have sufficient permissions
+## Your repository's default workflow permissions are set to read-only
 
-Semgrep findings in a private repository can only populate in the GitHub Advanced Security Dashboard if the correct permissions are set using the `permissions` key. See the following example.
+Repository-level workflow permissions are set to `read-only` (default) unless they've previously been changed. Use of the `permissions` key within the workflow file does not override this setting.
 
-## The workflow permissions in your repository's Actions settings are set to read-only
-
-Workflow permissions are set to `read-only` (default) unless they've previously been changed. The job requires `write` permissions to be successful.
-
-To change permissions:
+To update this setting:
 1. Navigate to your organization or repository in GitHub.
 2. Click **Settings > Actions > General > Workflow permissions**.
 
@@ -30,6 +26,10 @@ Target permissions
 Changing the repository's default workflow permissions changes the permissions for all workflows in that repository. For more granular permissions, set the `permissions` key at the workflow or job level in the `semgrep.yml` workflow file. Learn more about the `permissions` key at [Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#setting-the-github_token-permissions-for-all-jobs-in-a-workflow), or review the example workflow-level permissions below.
 :::
 
+## The workflow or job does not have the correct permissions in a private repository
+
+In order for Semgrep findings in a private repository to appear on the GitHub Advanced Security Dashboard, you must ensure that the appropriate permissions are configured at the workflow level using the permissions key. See the following example.
+
 ### Example job configuration with `permissions` key
 
 This job only requires `write` permissions for `security-events`.
@@ -39,23 +39,17 @@ This job only requires `write` permissions for `security-events`.
 name: Semgrep
 
 on:
-  # Scan changed files in PRs (diff-aware scanning):
   pull_request: {}
-  # Scan on-demand through GitHub Actions interface:
   workflow_dispatch: {}
-  # Scan mainline branches and report all findings:
   push:
     branches: ["master", "main"]
-  # Schedule the CI job (this method uses cron syntax):
   schedule:
     - cron: '20 17 * * *' # Sets Semgrep to scan every day at 17:20 UTC.
     # It is recommended to change the schedule to a random time.
 
 jobs:
   semgrep:
-    # User definable name of this GitHub Actions job.
     name: semgrep/ci 
-    # If you are self-hosting, change the following `runs-on` value: 
     runs-on: ubuntu-latest
 
     container:

--- a/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
+++ b/docs/kb/semgrep-ci/github-upload-findings-in-security-dashboard.md
@@ -28,7 +28,7 @@ Changing the repository's default workflow permissions changes the permissions f
 
 ## The workflow or job does not have the correct permissions in a private repository
 
-In order for Semgrep findings in a private repository to appear on the GitHub Advanced Security Dashboard, you must ensure that the appropriate permissions are configured at the workflow level using the permissions key. See the following example.
+In order for Semgrep findings in a private repository to appear on the GitHub Advanced Security Dashboard, you must ensure that the appropriate permissions are configured at the workflow level using the `permissions` key. See the following example.
 
 ### Example job configuration with `permissions` key
 


### PR DESCRIPTION
The previous version of this doc indicated that it wasn't possible to run this job in private repositories. This update clarifies that it is possible if the permissions are set appropriately.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
