### PR TITLE
corrected the command to install semgrep-core

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -118,7 +118,7 @@ make core-test
 Finally, to update the `semgrep-core` binary used by `semgrep`, run
 
 ```
-make core-install
+make copy-core-for-cli
 ```
 
 ### Testing `semgrep-core`


### PR DESCRIPTION
The command to install `semgrep core` has been removed since August 2023 (https://github.com/semgrep/semgrep/pull/8512), but the doc wasn't updated. The equivalent command to use is `make copy-core-for-cli`.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
