### PR TITLE
workaround for docs to sidebar association issues

### DIFF
--- a/docs/cli-reference-oss.md
+++ b/docs/cli-reference-oss.md
@@ -1,0 +1,101 @@
+---
+slug: cli-reference-oss
+append_help_link: true
+description: "Reference for the Semgrep command-line interface including options and exit code behavior."
+tags:
+    - Semgrep CLI
+    - Semgrep Code
+    - Team & Enterprise Tier
+hide_title: true
+title: CLI reference
+---
+
+import MoreHelp from "/src/components/MoreHelp"
+import CLIHelpOutput from '/src/components/reference/_cli-help-output.md'
+import CLIHelpScanOutput from '/src/components/reference/_cli-help-scan-output.md'
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
+
+# CLI reference
+
+This document provides the outputs of the `semgrep --help` and `semgrep scan --help` commands of the [Semgrep command-line interface (CLI)](https://github.com/semgrep/semgrep). In addition, this page also gives an overview of the Semgrep CLI exit codes.
+
+## Semgrep commands
+
+For a list of available commands, run the following command:
+
+```bash
+semgrep --help
+```
+
+Command output:
+
+<CLIHelpOutput />
+
+## Semgrep scan command options
+
+To list all available `semgrep scan` options, run the following command:
+
+```bash
+semgrep scan --help
+```
+
+Command output:
+
+<CLIHelpScanOutput />
+
+## Ignoring Files
+
+The Semgrep command line tool supports a `.semgrepignore` file that follows `.gitignore` syntax and is used to skip files and directories during scanning. This is commonly used to avoid vendored and test related code. For a complete example, see the [.semgrepignore file on Semgrep’s source code](https://github.com/semgrep/semgrep/blob/develop/.semgrepignore).
+
+In addition to `.semgrepignore` there are several methods to set up ignore patterns. See [Ignoring files, folders, or code](../ignoring-files-folders-code).
+
+## Connecting to Semgrep Registry through a proxy
+
+Semgrep uses the Python3 `requests` library. Set the following environment variables to point to your proxy:
+
+<pre>
+export HTTP_PROXY="<span className="placeholder">HTTP_PROXY_URL</span>"<br />
+export HTTPS_PROXY="<span className="placeholder">HTTPS_PROXY_URL</span>"
+</pre>
+
+For example:
+
+<pre>
+export HTTP_PROXY="http://10.10.1.10:3128" <br />
+export HTTPS_PROXY="http://10.10.1.10:1080"
+</pre>
+
+## Exit codes
+
+<!-- Source code reference - the exit codes are located in the Semgrep repository - https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/error.py. -->
+
+Semgrep can finish with the following exit codes:
+
+- **0**: Semgrep ran successfully and found no errors (or did find errors, but the `--error` flag is **not** being used).
+- **1**: Semgrep ran successfully and found issues in your code (while using the `--error` flag).
+- **2**: Semgrep failed.
+- **3**: Invalid syntax of the scanned language. This error occurs only while using the `--strict` flag.
+- **4**: Semgrep encountered an invalid pattern in the rule schema.
+- **5**: Semgrep configuration is not valid YAML.
+- **7**: At least one rule in the configuration is invalid.
+- **8**: Semgrep does not understand specified language.
+- **13**: The API key is invalid.
+- **14**: Semgrep scan failed.
+
+<!-- REMOVED STATUSES (NOT USED ANYMORE)
+- 4: Semgrep encountered an invalid pattern.
+- 6: Rule with `pattern-where-python` found but `--dangerously-allow-arbitrary-code-execution-from-rules` was not set. See `--dangerously-allow-arbitrary-code-execution-from-rules`. (Note: `pattern-where-python` is no longer supported in Semgrep, so this applies only to legacy Semgrep versions).
+- 9: Semgrep exceeded match timeout. See `--timeout`.
+- 10: Semgrep exceeded maximum memory while matching. See `--max-memory`.
+- 11: Semgrep encountered a lexical error when running rule on a file.
+- 12: Semgrep found too many matches.
+-->
+
+<MoreHelp />

--- a/docs/ignore-oss.md
+++ b/docs/ignore-oss.md
@@ -1,23 +1,19 @@
 ---
-slug: ignoring-files-folders-code
+slug: ignore-oss 
 append_help_link: true
 title: Ignoring files, folders, and code
 description: "This documents various methods to skip or ignore files or folders that are not relevant to a Semgrep scan."
+hide_title: true
 ---
 
-<!-- Updates to this doc may or affect ignore-oss -->
+<!-- Updates to this doc may or affect Ignoring files, folders, and code -->
 
 import MoreHelp from "/src/components/MoreHelp"
 import IgnoreIndividualFindingNoGrouping from "/src/components/procedure/_ignore-individual-finding-no-grouping.mdx"
 
 # Ignoring files, folders, or parts of code
 
-This document describes two types of ignore operations:
-
-* **Ignoring as exclusion.** Exclude or skip specific **files and folders** from the scope of Semgrep scans in your repository or working directory. Ignoring in this context means that Semgrep does not generate findings for the ignored files and folders.
-* **Ignoring as triage action**. Ignore specific parts of code that would have generated a finding. Ignoring in this context means that Semgrep generates a finding record and automatically triages it as **Ignored**, a triage state.
-
-All Semgrep environments (CLI, CI, and Semgrep Cloud Platform) adhere to user-defined or Semgrep-defined ignore patterns.
+Exclude or skip specific **files and folders** from the scope of Semgrep scans in your repository or working directory. Ignoring in this context means that Semgrep does not generate findings for the ignored files and folders.
 
 ## Reference summary
 
@@ -70,7 +66,7 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 |:---- |:------ |
 | To scan all files within Semgrep's scope each time you run Semgrep (only files within `.git` are ignored). | Create an empty `.semgrepignore` file in your repository root directory or in your project's working directory. An empty `.semgrepignore` will make Semgrep scan paths in `.gitignore`. |
 | To ignore files and folders in `.gitignore`. | Add `:include .gitignore` to your `.semgrepignore` file. |
-| To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file or [define them through Semgrep Cloud Platform](#defining-ignored-files-and-folders-in-semgrep-cloud-platform).|
+| To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file.|
 | To ignore specific code blocks each time you run a scan. | Create a comment with the word `nosemgrep`. |
 | To ignore files or folders for a particular scan. | Run Semgrep with the flag `--exclude` followed by the pattern or file to be excluded. See [CLI reference](../cli-reference/).
 | To include files or folders for a particular scan. | Run Semgrep with the flag `--include` followed by the  pattern or file to be included. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, still resulting in the file's exclusion. |
@@ -91,27 +87,6 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 Unsupported patterns are silently removed from the pattern list (this is done so that `.gitignore` files may be included without raising errors). The removal is logged.
 
 For a description of `.gitignore` syntax, see [.gitignore documentation](https://git-scm.com/docs/gitignore).
-
-## Defining ignored files and folders in Semgrep Cloud Platform
-
-Another method for users to define ignore patterns is through a Project in Semgrep Cloud Platform. These patterns follow the same syntax as `.semgrepignore` in the preceding section.
-
-To define files and folders in Semgrep Cloud Platform:
-
-1. Sign in to [Semgrep Cloud Platform](https://semgrep.dev/login?return_path=/manage/projects).
-2. From the Dashboard Sidebar, select **[Projects](https://semgrep.dev/orgs/-/projects)** > **[Project name]**.
-3. Select the name of the project to modify, and then click the respective <i class="fa-solid fa-gear"></i> **gear** icon in the Settings column.
-4. Enter files and folders to ignore in the **Path Ignores** box.
-
-Including files and folders through this method is **additive**. When Semgrep Cloud Platform makes a scan, it looks for a `.semgrepignore` within the repository. If no `.semgrepignore` file is found, Semgrep temporarily creates one and adds items from Semgrep Cloud Platform's Path Ignores. Adding items to the **Path Ignores** box does not override default Semgrep ignore patterns.
-
-You can also add files to `.semgrepignore` while triaging individual findings in the **No grouping** view on the Findings page:
-
-<IgnoreIndividualFindingNoGrouping />
-
-:::note
-Add files to `.semgrepignore` in the fifth step of the procedure described above. 
-:::
 
 ## Ignoring code through nosemgrep
 
@@ -183,14 +158,8 @@ bad_func3(   // nosemgrep: configs.rule-id-3, configs.rule-id-4
 Previous annotations for ignoring code inline, such as `nosem`, are deprecated.
 :::
 
-## Disabling rules on Semgrep Cloud Platform
-
-Semgrep Cloud Platform users can disable rules and rulesets through the Policies page. See [Disabling rules](/semgrep-code/policies#disabling-rules) and [Removing rulesets](/semgrep-code/findings#removing-rulesets).
-
 ## Known issues
 
 ### `--no-git-ignore` is overridden due to default ignore patterns (.semgrepignore) ([#4537](https://github.com/semgrep/semgrep/issues/4537))
 
 To fix this, create an empty .semgrepignore file. If the scan is a one-off event, delete the .semgrepignore file to restore default ignore patterns.
-
-<MoreHelp />

--- a/docs/prerequisites-oss.md
+++ b/docs/prerequisites-oss.md
@@ -1,0 +1,40 @@
+---
+slug: prerequisites-oss
+append_help_link: true
+title: Prerequisites
+hide_title: true
+description: Required software or services to run various Semgrep products.
+tags:
+  - Deployment
+---
+
+# Prerequisites
+
+This document details the required software or services to run Semgrep products.
+
+## Overall
+
+A programming language must be supported by Semgrep for your chosen product.
+
+| Product              | Scan type | Link   |
+| -------              | ------    | ------ |
+| Semgrep OSS          | SAST      | [Supported languages](/supported-languages/#language-maturity)  |
+| Semgrep Code         | SAST      | [Supported languages](/supported-languages/#language-maturity)  |
+| Semgrep Supply Chain | SCA       | [Supported languages](/supported-languages/#semgrep-supply-chain)       |
+| Semgrep Secrets      | Secrets   | Language-agnostic       |
+
+<!-- Update Secrets with service validators once available -->
+
+## Semgrep command-line tool
+
+These requirements apply to both Semgrep Pro and Semgrep OSS.
+
+### Software
+
+- Python 3.8 or later installed on the machine you are running Semgrep on.
+
+### Operating system
+
+- macOS
+- Linux
+- Windows Subsystem for Linux (WSL)

--- a/docs/supported-languages-oss.md
+++ b/docs/supported-languages-oss.md
@@ -1,0 +1,293 @@
+---
+slug: supported-languages-oss
+append_help_link: true
+description: >-
+  Semgrep supports more than two dozen languages. Learn about generally available, beta, and experimentally supported languages.
+hide_title: true
+title: Supported languages
+tags:
+    - Semgrep Supply Chain 
+    - Semgrep OSS Engine
+    - Team & Enterprise Tier
+---
+
+import SupportedLanguagesTable from '/src/components/reference/_supported-languages-table.mdx'
+import SscIntro from "/src/components/concept/_ssc-intro.md"
+import MoreHelp from "/src/components/MoreHelp"
+import SemgrepProEngineIntroduction from "/src/components/concept/_semgrep-pro-engine-introduction.mdx"
+import AdmonitionSotCves from "/src/components/reference/_admonition-sot-cves.md"
+
+<ul id="tag__badge-list">
+{
+Object.entries(frontMatter).filter(
+    frontmatter => frontmatter[0] === 'tags')[0].pop().map(
+    (value) => <li class='tag__badge-item'>{value}</li> )
+}
+</ul>
+
+# Supported languages
+
+This document provides information about supported languages and language maturity definitions for the following products:
+
+* Semgrep Code
+* Semgrep Supply Chain
+
+## Semgrep Code 
+
+Secure your code quickly and continuously by scanning with Semgrep Code, our SAST (Static Application Security Testing) product, powered by Semgrep OSS Engine and Semgrep Pro Engine. The Semgrep OSS Engine is the foundation of Semgrep, it's our [open-source engine](https://github.com/semgrep/semgrep), designed for fast code analysis. The Semgrep Pro Engine is designed for advanced code analysis, designed to catch complex vulnerabilities and reduce false positives. Use Semgrep Code to quickly find and fix vulnerabilities in your code base. 
+
+### Language maturity
+Semgrep Code supports over 30 languages and counting! 🚀 
+
+<SupportedLanguagesTable />
+
+### Maturity levels
+
+#### Language maturity factors (Pro Engine)
+
+Semgrep Pro Engine has two maturity levels:
+* Generally available (GA) 
+* Beta
+
+**Generally Available**: Receives highest quality support from the Semgrep team. Reported issues are resolved promptly and timelines for fixes are communicated to customers within 2 weeks.
+
+**Beta**: Supported by the Semgrep team. Reported issues are tracked and prioritized to be fixed after GA languages.
+
+#### Language maturity factors (OSS Engine)
+
+Semgrep OSS Engine has three maturity levels:
+* Generally available (GA) 
+* Beta
+* Experimental 
+
+Their differences are outlined in the following table:
+
+| Feature  | GA | Beta | Experimental
+|----------|---------------|------------------| ----- |
+| Parse Rate  | 99%+ | 95%+ | 90%+ | 
+| Number of rules  | 10+ | 5+ | 0+. Query the [Registry](https://semgrep.dev/r) to see if any rules exist for your language. | 
+| Semgrep syntax | Regexp, equivalence, deep expression operators, types and typing. All features supported in Beta. | Complete metavariable support, metavariable equality. All features supported in Experimental. | Syntax, ellipsis operator, basic metavariable functionality.|
+| Support | Highest quality support by the Semgrep team. Reported issues are resolved promptly. | Supported by the Semgrep team. Reported issues are fixed after GA languages. | There are limitations to this language's functionality. Reported issues are tracked and prioritized with best effort.|
+
+
+### More information
+Visit the cheat sheet generation script and associated semgrep-core test files to learn more about each feature:
+* [Generation script](https://github.com/semgrep/semgrep/blob/develop/scripts/generate_cheatsheet.py)
+* [`semgrep-core` test files](https://github.com/semgrep/semgrep/tree/develop/tests)
+
+Visit the Semgrep public language dashboard to see the parse rates for each language
+* See [Parse rates by language](https://dashboard.semgrep.dev/).
+
+<!-- coupling: If you modify the features in the levels below, change also 
+     /semgrep/blob/develop/tests/Test.ml and its maturity level regression testing code.
+-->
+
+## Semgrep Supply Chain
+
+<SscIntro/>
+
+Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your codebase for reachable findings based on the lockfiles. Some languages, such as Java, have several lockfiles, depending on your repository's package manager. For some languages, such as JavaScript and Python, a manifest file is also parsed to determine [transitivity](/docs/semgrep-supply-chain/glossary/#transitive-or-indirect-dependency).
+
+<table>
+<thead><tr>
+    <th>Language</th>
+    <th>Supported package managers</th>
+    <th>Lockfile</th>
+    <th>Reachability support level‡</th>
+    <th>License detection support</th>
+    <th>Time period of reachability rule coverage for CVEs/GHSAs</th>
+</tr></thead>
+<tbody>
+<tr>
+   <td>C#</td>
+   <td>NuGet</td>
+   <td><code>packages.lock.json</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+   <td rowspan="12">Since May 2022</td>
+</tr>
+<tr>
+   <td>Go</td>
+   <td>Go modules (<code>go mod</code>)</td>
+   <td><code>go.mod</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+  </tr>
+<tr rowspan="2">
+   <td rowspan="2">Java</td>
+   <td>Gradle</td>
+   <td><code>gradle.lockfile</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+  </tr>
+  <tr>
+   <td>Maven</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+  </tr>
+  <tr>
+   <td rowspan="3">JavaScript or TypeScript</td>
+   <td>npm (Node.js)</td>
+   <td><code>package-lock.json</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+  </tr>
+  <tr>
+   <td>Yarn, Yarn 2, Yarn 3</td>
+   <td><code>yarn.lock</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>--</td>
+  </tr>
+  <tr>
+   <td>pnpm</td>
+   <td><code>pnpm-lock.yaml</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>--</td>
+  </tr>
+  <tr>
+   <td rowspan="4">Python</td>
+   <td>pip</td>
+   <td><code>requirements.txt</code>†† (generated by e.g. <code>pip freeze</code>)</td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td rowspan="4">✔️ (PyPI packages only)</td>
+  </tr>
+  <tr>
+   <td>pip-tools</td>
+   <td><code>requirements.txt</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+  </tr>
+  <tr>
+   <td>Pipenv</td>
+   <td><code>Pipfile.lock</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+  </tr>
+  <tr>
+   <td>Poetry</td>
+   <td><code>poetry.lock</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+  </tr>
+  <tr>
+   <td>Ruby</td>
+   <td>RubyGems</td>
+   <td><code>Gemfile.lock</code></td>
+   <td style={{"text-align": "center"}}>GA</td>
+   <td>✔️</td>
+  </tr>
+  <tr>
+   <td>Rust</td>
+   <td>Cargo</td>
+   <td><code>cargo.lock</code></td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>✔️</td>
+   <td rowspan="5">Not applicable due to reachability support level</td>
+</tr>
+<tr>
+   <td>Dart</td>
+   <td>Pub</td>
+   <td><code>pubspec.lock</code></td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>--</td>
+</tr>
+<tr>
+   <td>Kotlin</td>
+   <td>Maven</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>--</td>
+</tr>
+<tr>
+   <td>PHP</td>
+   <td>Composer</td>
+   <td><code>composer.lock</code></td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>--</td>
+</tr>
+<tr>
+   <td>Scala</td>
+   <td>Maven</td>
+   <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
+   <td style={{"text-align": "center"}}>Lockfile-only</td>
+   <td>--</td>
+</tr>
+  </tbody>
+</table>
+
+_*Semgrep Supply Chain scans transitive dependencies for **all supported languages** but does **not** perform reachability analysis on transitive dependencies._ <br />
+_**‡Reachability support level** refers to the level of support for reachability analysis for the language. At the minimum, Semgrep Supply Chain uses **lockfile-only** rules, which check a package's version against versions with known vulnerabilities._ <br />
+_**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a **lockfile**. This means that `requirements.txt` must be set to exact versions (pinned dependencies) and the file must be generated automatically._
+
+<AdmonitionSotCves />
+
+:::info Transitivity support
+For more information on transitivity, see [Transitive dependencies and reachability analysis](/docs/semgrep-supply-chain/overview/#transitive-dependencies-and-reachability-analysis).
+:::
+
+### Maturity levels
+
+Semgrep Supply Chain has two maturity levels:
+
+* General Availability (GA)
+* Beta
+
+Their differences are outlined in the following table:
+
+<table>
+  <tr>
+   <td><strong>Feature</strong>
+   </td>
+   <td><strong>GA</strong>
+   </td>
+   <td><strong>Beta</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>Number of reachability rules
+   </td>
+   <td>10+
+   </td>
+   <td>1+
+   </td>
+  </tr>
+  <tr>
+   <td>Semgrep, Inc. rule-writing support
+   </td>
+   <td>Quickly release new rules for all critical and high vulnerabilities based on the latest <a href="https://nvd.nist.gov/vuln">security advisories</a>.
+   </td>
+   <td>No commitment for new rules based on the latest security advisories.
+   </td>
+  </tr>
+  <tr>
+   <td>Semgrep OSS Engine <a href='/docs/supported-languages#semgrep-oss-engine'>language support</a>
+   </td>
+   <td>Semgrep OSS Engine support is GA.
+   </td>
+   <td>Semgrep OSS Engine support is at least Beta.
+   </td>
+  </tr>
+</table>
+
+:::info Feature and product maturity levels
+* The detailed specifications previously provided apply only to language support. Language maturity levels differ from feature and product maturity levels.
+* Semgrep features and products documented as experimental, beta, or GA generally follow the definitions in a [Software release life cycle](https://en.wikipedia.org/wiki/Software_release_life_cycle).
+:::
+
+## Known limitations of Semgrep Pro Engine
+
+### CommonJS
+
+Currently Semgrep Pro Engine does not handle specific cases of CommmonJS where you define a function and assign it to an export later, Semgrep Pro Engine does not track the code below:
+
+```js
+function get_user() {
+    return get_user_input("example")
+  }
+
+module.exports = get_user
+```
+
+### Regressions in Semgrep Pro
+
+For cross-file (interfile) analysis, Semgrep Pro Engine resolves names differently than Semgrep OSS. Consequently, rules with `interfile: true` may produce different results than Semgrep OSS Engine. Some instances could be regarded as regressions; if you encounter them, please file a bug report. When you need to report a bug in Semgrep Pro Engine, go through [Semgrep Support](/docs/support/). You can also contact us through [Semgrep Community Slack group](https://go.semgrep.dev/slack).
+
+<MoreHelp />

--- a/sidebars.js
+++ b/sidebars.js
@@ -447,8 +447,8 @@ module.exports = {
         collapsible: false,
         items: [
             'getting-started/quickstart-oss',
-            'prerequisites',
-            { type: 'ref', id: 'supported-languages' }
+            'prerequisites-oss',
+            'supported-languages-oss'
         ]
     },
     {
@@ -458,7 +458,7 @@ module.exports = {
         items: [
             'running-rules',
             'getting-started/cli-oss',
-            'ignoring-files-folders-code'
+            'ignore-oss'
         ]
     },
     {
@@ -466,7 +466,7 @@ module.exports = {
       label: 'References',
       collapsible: false,
       items: [
-        'cli-reference'
+        'cli-reference-oss'
       ]
     },
     {


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

See:
- https://linear.app/semgrep/issue/MKT-818/after-new-sidebars-clean-up
- https://semgrepinc.slack.com/archives/C02JT6YA5S7/p1708625378388649

I feel as though the correct answer here is to use partial mdx files and import them, so that there is a single source of truth that is then funneled / cascaded to the doc files but at the same time I feel we're hitting a level of complexity on keeping the docs readable and maintainable. This is, for now, a "quick fix".
