### PR TITLE
Add GitLab workflow example for semgrep publish

### DIFF
--- a/docs/writing-rules/private-rules.md
+++ b/docs/writing-rules/private-rules.md
@@ -98,6 +98,22 @@ This section provides an example of how to automatically publish your private ru
             SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     ```
 
+A similar example job for GitLab CI/CD:
+
+```yaml
+    semgrep-publish:
+      image: semgrep/semgrep
+      script: semgrep publish --visibility=org_private .
+
+    rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+    variables:
+      SEMGREP_APP_TOKEN: $SEMGREP_APP_TOKEN
+```
+
+As above, make sure that `SEMGREP_APP_TOKEN` is defined in your GitLab project's CI/CD variables.
+
 ## Deleting private rules
 
 <DeleteCustomRule />

--- a/docs/writing-rules/private-rules.md
+++ b/docs/writing-rules/private-rules.md
@@ -103,7 +103,7 @@ A similar example job for GitLab CI/CD:
 ```yaml
     semgrep-publish:
       image: semgrep/semgrep
-      script: semgrep publish --visibility=org_private .
+      script: semgrep publish --visibility=org_private ./private_rule_dir
 
     rules:
       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/docs/writing-rules/private-rules.md
+++ b/docs/writing-rules/private-rules.md
@@ -98,9 +98,9 @@ This section provides an example of how to automatically publish your private ru
             SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     ```
 
-A similar example job for GitLab CI/CD:
+    A sample job for GitLab CI/CD:
 
-```yaml
+    ```yaml
     semgrep-publish:
       image: semgrep/semgrep
       script: semgrep publish --visibility=org_private ./private_rule_dir
@@ -110,9 +110,9 @@ A similar example job for GitLab CI/CD:
 
     variables:
       SEMGREP_APP_TOKEN: $SEMGREP_APP_TOKEN
-```
+    ```
 
-As above, make sure that `SEMGREP_APP_TOKEN` is defined in your GitLab project's CI/CD variables.
+    Ensure that `SEMGREP_APP_TOKEN` is defined in your GitLab project's CI/CD variables.
 
 ## Deleting private rules
 


### PR DESCRIPTION
Adds a basic GitLab workflow file allowing publishing of private semgrep rules from GitLab.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
