### PR TITLE
Promote C and C++ to GA

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -60,6 +60,9 @@ Semgrep OSS Engine has three maturity levels:
 * Generally available (GA) 
 * Beta
 * Experimental 
+* Community Supported\*
+
+\*Community supported languages meet the parse rate and syntax requirements of Experimental languages, but ongoing development from Semgrep has stopped. Users can still access community rules or write their own rules.
 
 Their differences are outlined in the following table:
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -60,7 +60,7 @@ Semgrep OSS Engine has three maturity levels:
 * Generally available (GA) 
 * Beta
 * Experimental 
-* Community Supported\*
+* Community supported\*
 
 \*Community supported languages meet the parse rate and syntax requirements of Experimental languages, but ongoing development from Semgrep has stopped. Users can still access community rules or write their own rules.
 

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -3,7 +3,7 @@
 | Language | Semgrep OSS Engine | Semgrep Pro Engine (cross-function) | Semgrep Pro Engine (cross-file)
 |:---------- |:----------------------------|:---------------------------|:---------------------------|
 | C          | Community supported | GA | GA |     
-| C++        | Community Supported | GA | GA | 
+| C++        | Community supported | GA | GA | 
 | C#         | GA | GA | GA |
 | Go         | GA | GA | GA |                         
 | Java       | GA | GA | GA |                   

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -2,7 +2,7 @@
 
 | Language | Semgrep OSS Engine | Semgrep Pro Engine (cross-function) | Semgrep Pro Engine (cross-file)
 |:---------- |:----------------------------|:---------------------------|:---------------------------|
-| C          | Community Supported | GA | GA |     
+| C          | Community supported | GA | GA |     
 | C++        | Community Supported | GA | GA | 
 | C#         | GA | GA | GA |
 | Go         | GA | GA | GA |                         

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -2,6 +2,8 @@
 
 | Language | Semgrep OSS Engine | Semgrep Pro Engine (cross-function) | Semgrep Pro Engine (cross-file)
 |:---------- |:----------------------------|:---------------------------|:---------------------------|
+| C          | Community Supported | GA | GA |     
+| C++        | Community Supported | GA | GA | 
 | C#         | GA | GA | GA |
 | Go         | GA | GA | GA |                         
 | Java       | GA | GA | GA |                   
@@ -21,8 +23,6 @@
 | Generic    | GA | -- | -- |  
 | Swift      | Beta | -- | -- |     
 | Bash       | Experimental | -- | -- |  
-| C          | Experimental | -- | -- |     
-| C++        | Experimental | -- | -- |  
 | Cairo      | Experimental | -- | -- | 
 | Clojure    | Experimental | -- | -- |  
 | Dart       | Experimental | -- | -- |   


### PR DESCRIPTION
Promotes C and C++ to GA, and adds new community-supported definitions

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
