### PR TITLE
update with tip on viewing exit code

### DIFF
--- a/docs/cli-reference-oss.md
+++ b/docs/cli-reference-oss.md
@@ -89,6 +89,17 @@ Semgrep can finish with the following exit codes:
 - **13**: The API key is invalid.
 - **14**: Semgrep scan failed.
 
+:::tip
+To view the exit code when running `semgrep scan`, enter the following command immediately after the Semgrep scan has finished:
+```console
+echo $?
+```
+The output is a single exit code, such as:
+```console
+1
+```
+:::
+
 <!-- REMOVED STATUSES (NOT USED ANYMORE)
 - 4: Semgrep encountered an invalid pattern.
 - 6: Rule with `pattern-where-python` found but `--dangerously-allow-arbitrary-code-execution-from-rules` was not set. See `--dangerously-allow-arbitrary-code-execution-from-rules`. (Note: `pattern-where-python` is no longer supported in Semgrep, so this applies only to legacy Semgrep versions).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -90,7 +90,7 @@ Semgrep can finish with the following exit codes:
 - **14**: Semgrep scan failed.
 
 :::tip
-To view the exit code when running `semgrep scan`, enter the following command immediately after the Semgrep scan has finished:
+To view the exit code when running `semgrep scan`, enter the following command immediately after the Semgrep scan finishes:
 ```console
 echo $?
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -89,6 +89,16 @@ Semgrep can finish with the following exit codes:
 - **13**: The API key is invalid.
 - **14**: Semgrep scan failed.
 
+:::tip
+To view the exit code when running `semgrep scan`, enter the following command immediately after the Semgrep scan has finished:
+```console
+echo $?
+```
+The output is a single exit code, such as:
+```console
+1
+```
+:::
 <!-- REMOVED STATUSES (NOT USED ANYMORE)
 - 4: Semgrep encountered an invalid pattern.
 - 6: Rule with `pattern-where-python` found but `--dangerously-allow-arbitrary-code-execution-from-rules` was not set. See `--dangerously-allow-arbitrary-code-execution-from-rules`. (Note: `pattern-where-python` is no longer supported in Semgrep, so this applies only to legacy Semgrep versions).


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

Helpful tip, even for us internal folks.

WRT to duplication, I am avoiding componentizing our repeating sections until our migration is done. (I am crying inside.)
