### PR TITLE
Update label for Cheat sheets in sidebars.js

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -27,7 +27,7 @@ module.exports = {
       label: 'Knowledge base',
       href: '/kb/',
     },
-    { type: 'ref', id: 'cheat-sheets/java-code-injection', label: 'OWASP cheat sheets'},
+    { type: 'ref', id: 'cheat-sheets/java-code-injection', label: 'Cheat sheets'},
     { type: 'ref', id: 'release-notes/introduction', label: 'Release notes'},
     { type: 'link', href: 'https://semgrep.dev/api/v1/docs/', label: 'API'},
     { type: 'ref', id: 'faq', label: 'About Semgrep' },

--- a/sidebars.js
+++ b/sidebars.js
@@ -27,7 +27,7 @@ module.exports = {
       label: 'Knowledge base',
       href: '/kb/',
     },
-    { type: 'ref', id: 'cheat-sheets/java-code-injection', label: 'Cheat sheets'},
+    { type: 'ref', id: 'cheat-sheets/java-code-injection', label: 'Cheat sheets for security issues'},
     { type: 'ref', id: 'release-notes/introduction', label: 'Release notes'},
     { type: 'link', href: 'https://semgrep.dev/api/v1/docs/', label: 'API'},
     { type: 'ref', id: 'faq', label: 'About Semgrep' },


### PR DESCRIPTION
Why do we call our cheat sheets - "OWASP Cheat Sheets" ?
OWASP is a different orgainzation, those cheat sheets are not created by OWASP, they are created by us. Those are Semgrep Cheat sheets :smile:.
So I suggest renaming to "Cheat Sheets".
