### PR TITLE
deprecate extract mode

### DIFF
--- a/docs/writing-rules/experiments/extract-mode.md
+++ b/docs/writing-rules/experiments/extract-mode.md
@@ -9,7 +9,7 @@ import MoreHelp from "/src/components/MoreHelp"
 # Extract mode
 
 
-:::error
+:::danger Deprecation notice
 As of Semgrep 1.65.0, extract mode has been deprecated and removed from Semgrep. This feature may return in the future.
 :::
 

--- a/docs/writing-rules/experiments/extract-mode.md
+++ b/docs/writing-rules/experiments/extract-mode.md
@@ -8,13 +8,18 @@ import MoreHelp from "/src/components/MoreHelp"
 
 # Extract mode
 
-## Introduction
+
+:::error
+As of Semgrep 1.65.0, extract mode has been deprecated and removed from Semgrep. This feature may return in the future.
+:::
+
 
 Extract mode enables you to run existing rules on subsections of files where the rule language is different than the language of the file. For example, running a JavaScript rule on code contained inside of script tags in an HTML document.
 
+<!-- 
 :::info
 The extract mode feature is still in a very experimental stage and may not work as intended. The Semgrep team is planning to improve this feature in the future. Reach out for help and suggestions on the <a href="https://go.semgrep.dev/slack">Semgrep Community Slack</a>.
-:::
+::: -->
 
 ## Example of extract mode
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

In line with https://github.com/semgrep/semgrep/pull/9891