### PR TITLE
Fix invalid ipv6 address in network-broker.md

### DIFF
--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -75,7 +75,7 @@ Ensure that you are logged in to the server where you want to run Semgrep Networ
   ```yaml
   inbound:
     wireguard:
-      localAddress: fdf0:59dc:33cf:9be8:yyyy:0:1
+      localAddress: SEMGREP_LOCAL_ADDRESS
       privateKey: YOUR_PRIVATE_KEY
       ...
   ```


### PR DESCRIPTION
Corrected invalid ipv6 address by replacing it with a variable to keep consistent with the rest of the doc.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
