### PR TITLE
Update conflicting docs for default number of jobs

### DIFF
--- a/src/components/reference/_cli-help-scan-output.md
+++ b/src/components/reference/_cli-help-scan-output.md
@@ -163,7 +163,7 @@ OPTIONS
            have time limit. Defaults to 0 s for all CLI scans. For CI scans,
            it defaults to 3 hours.
 
-       -j VAL, --jobs=VAL (absent=4)
+       -j VAL, --jobs=VAL
            Number of subprocesses to use to run checks in parallel. Defaults
            to the number of cores detected on the system (1 if using --pro). 
 


### PR DESCRIPTION
This PR removes the `absent=<number-of-cores-deteced>` from the docs, since this value is variable and depends on the number of cores of the machine where `semgrep` is run. This leads to conflicting information in the docs, because the description of the `--jobs` parameter explains that it defaults to the number of cores detected on the system, whereas the `absent=4` value is hardcoded, which is confusing.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
