### PR TITLE
render the experimental langs as list

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -111,40 +111,40 @@ Community supported languages have varying levels of rule coverage - check the r
 
 <details><summary>Click to view <strong>Semgrep OSS</strong> languages.</summary>
 
-- Bash      
-- C         
-- C++       
-- C#        
-- Cairo     
-- Clojure   
-- Dart       
+- Bash
+- C
+- C++
+- C#
+- Cairo
+- Clojure
+- Dart
 - Dockerfile
-- Generic   
-- Go        
-- Hack       
-- HTML          
-- Java      
+- Generic
+- Go
+- Hack
+- HTML
+- Java
 - JavaScript
-- JSON      
-- Jsonnet   
-- Julia      
-- Lisp       
-- Lua        
-- Kotlin    
-- Ruby      
-- Rust      
-- JSX       
-- Ocaml      
-- PHP       
-- Python    
-- R          
-- Scala     
-- Scheme     
-- Solidity   
-- Swift     
+- JSON
+- Jsonnet
+- Julia
+- Lisp
+- Lua
+- Kotlin
+- Ruby
+- Rust
+- JSX
+- Ocaml
+- PHP
+- Python
+- R
+- Scala
+- Scheme
+- Solidity
+- Swift
 - TypeScript
-- YAML      
-- XML       
+- YAML
+- XML
 
 </details>
 

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -2,48 +2,50 @@
 
 | Language | Maturity level | Cross-function analysis | Cross-file analysis
 |:---------- |:----------------------------|:---------------------------|:---------------------------|
-| C          | GA | ✅ | ✅  |     
+| C          | GA | ✅ | ✅  |
 | C++        | GA | ✅ | ✅  | 
 | C#         | GA | ✅ | ✅  |
-| Go         | GA | ✅ | ✅  |                      
-| Java       | GA | ✅  | ✅  |                 
+| Go         | GA | ✅ | ✅  |
+| Java       | GA | ✅  | ✅  |
 | JavaScript | GA | ✅  | ✅  |
 | Kotlin     | GA | ✅  | ✅  | 
 | TypeScript | GA | ✅  | ✅  |
-| Ruby       | GA | ✅  | -- |  
+| Ruby       | GA | ✅  | -- |
 | Rust       | GA | ✅   | -- |
-| JSX        | GA | ✅   | -- |                       
-| PHP        | GA | ✅   | -- |                   
-| Python     | GA | ✅   | -- |                        
+| JSX        | GA | ✅   | -- |
+| PHP        | GA | ✅   | -- | 
+| Python     | GA | ✅   | -- | 
 | Scala      | GA | ✅   | -- | 
-| Generic    | GA | -- | -- |  
-| JSON       | GA | -- | -- |                    
-| Terraform  | GA | -- | -- |      
+| Generic    | GA | -- | -- |
+| JSON       | GA | -- | -- |
+| Terraform  | GA | -- | -- |
 | Apex       | Beta   | ✅  | -- |
 | Elixir     | Beta   |  ✅ | -- |
 | Swift      | Beta | -- | -- |
 
-<details><summary>Click to view <strong>Experimental</strong> languages.</summary>
+The following languages are **Experimental**:
 
-- Bash      
-- Cairo     
-- Clojure   
-- Dart       
+- Bash
+- Cairo
+- Clojure
+- Dart
 - Dockerfile
-- Hack       
-- HTML          
-- Jsonnet   
-- Julia      
-- Lisp       
-- Lua        
-- Ocaml      
-- R          
-- Scheme     
-- Solidity   
-- YAML      
-- XML       
+- Hack
+- HTML
+- Jsonnet
+- Julia
+- Lisp
+- Lua
+- Ocaml
+- R
+- Scheme
+- Solidity
+- YAML
+- XML
 
-</details>
+<!--
+<details><summary>Click to view <strong>Experimental</strong> languages.</summary>
+</details> -->
 
 If you'd like to request a language not shown here, please [create an issue on the Semgrep GitHub repo](https://github.com/semgrep/semgrep/issues). 
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A person likes this PR enough to approve it
- [x] This change has no security implications or else you have pinged the security team


### THIS PR:

- Removes lots of trailing whitespace ... probably from copypasta
- Renders the experimental langs as a list.
- 
![image](https://github.com/semgrep/semgrep-docs/assets/20766840/b99d30d1-683e-424f-9124-61bac3c13efb)

