### PR TITLE
fix(secrets): remove deleted CLI command

### DIFF
--- a/src/components/reference/_cli-help-scan-output.md
+++ b/src/components/reference/_cli-help-scan-output.md
@@ -44,11 +44,6 @@ OPTIONS
            run if not currently in a git directory, there are unstaged
            changes, or given baseline hash doesn't exist. 
 
-       --beta-testing-secrets-enabled
-           Please use --secrets instead of --beta-testing-secrets. Requires
-           Semgrep Secrets, contact support@semgrep.com for more information
-           on this.
-
        -d, --dump-command-for-core
            <internal, do not use>
 


### PR DESCRIPTION
The PR https://github.com/semgrep/semgrep/pull/9987 will remove the `--beta-testing-secrets-enabled` flag. We should update docs accordingly.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
