### PR TITLE
Update docs for SEMGREP_REPO_NAME and SEMGREP_REPO_DISPLAY_NAME

### DIFF
--- a/docs/semgrep-ci/ci-environment-variables.md
+++ b/docs/semgrep-ci/ci-environment-variables.md
@@ -205,7 +205,7 @@ pipelines:
 
 ### `SEMGREP_REPO_NAME`
 
-Set `SEMGREP_REPO_NAME` to create a repository name when scanning with a CI provider we don't provide support for. For hyperlinks and PR comments to work, this name should be the same as your repository name understood by your CI provider.
+Set `SEMGREP_REPO_NAME` to create a repository name when scanning with a [CI provider that Semgrep doesn't provide explicit support for](/deployment/add-semgrep-to-other-ci-providers/). For hyperlinks and PR comments to work, this name should be the same as your repository name understood by your CI provider.
 
 To avoid hardcoding this value, check your CI provider's documentation for available environment variables that can automatically detect the correct values for every CI job. 
 

--- a/docs/semgrep-ci/ci-environment-variables.md
+++ b/docs/semgrep-ci/ci-environment-variables.md
@@ -236,7 +236,7 @@ jobs:
 
 Set `SEMGREP_REPO_DISPLAY_NAME` to define the name used for the project associated with a given Semgrep scan. By default, `SEMGREP_REPO_DISPLAY_NAME` has the same value as `SEMGREP_REPO_NAME`. This allows you to use a different name for your project than the repository name or to scan a monorepo as multiple projects.
 
-#### Scanning a monorepo as multiple projects
+#### Scan a monorepo as multiple projects
 
 Create a semgrep scan for each folder you want to scan separately. For each scan, use a different value for `SEMGREP_REPO_DISPLAY_NAME`.
 

--- a/docs/semgrep-ci/ci-environment-variables.md
+++ b/docs/semgrep-ci/ci-environment-variables.md
@@ -209,6 +209,7 @@ Set `SEMGREP_REPO_NAME` to create a repository name when scanning with a [CI pro
 
 To avoid hardcoding this value, check your CI provider's documentation for available environment variables that can automatically detect the correct values for every CI job. 
 
+Semgrep automatically detects `SEMGREP_REPO_NAME` if your [provider is listed in Semgrep Cloud Platform](/deployment/add-semgrep-to-ci/#guided-setup-for-ci-providers-in-scp). In this case, there is no need to set the variable.
 Examples:
 
 Within a Bash environment:
@@ -234,7 +235,7 @@ jobs:
 
 ### `SEMGREP_REPO_DISPLAY_NAME`
 
-Set `SEMGREP_REPO_DISPLAY_NAME` to define the name used for the project associated with a given Semgrep scan. By default, `SEMGREP_REPO_DISPLAY_NAME` has the same value as `SEMGREP_REPO_NAME`. This allows you to use a different name for your project than the repository name or to scan a monorepo as multiple projects.
+Set `SEMGREP_REPO_DISPLAY_NAME` to define the name used for the project in Semgrep Cloud Platform. By default, `SEMGREP_REPO_DISPLAY_NAME` has the same value as `SEMGREP_REPO_NAME`. This allows you to use a different name for your project than the repository name or to scan a monorepo as multiple projects.
 
 #### Scan a monorepo as multiple projects
 


### PR DESCRIPTION
This updates with our new recommendation for how to use each environment and provides example guidance for using SEMGREP_REPO_DISPLAY_NAME to scan a monorepo as separate projects.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
