### PR TITLE
Give CircleCI lockfile gen article a proper title

### DIFF
--- a/docs/kb/semgrep-supply-chain/ssc-lockfiles-circleci.md
+++ b/docs/kb/semgrep-supply-chain/ssc-lockfiles-circleci.md
@@ -1,4 +1,5 @@
 ---
+title: Generate lockfiles for Semgrep Supply Chain in a Circle CI pipeline
 description: How to generate lockfiles for Semgrep Supply Chain in a Circle CI pipeline.
 tags:
   - Semgrep Supply Chain
@@ -6,7 +7,8 @@ tags:
   - Lockfiles
   - Workspaces
 ---
-## Generate lockfiles for Semgrep Supply Chain in a Circle CI pipeline
+
+# Generate lockfiles for Semgrep Supply Chain in a Circle CI pipeline
 
 Semgrep Supply Chain needs your project's lockfiles as input to scan your codebase successfully. If the [lockfiles that Supply Chain supports](/docs/supported-languages/#semgrep-supply-chain) are not under source control in your project, you can generate the lockfile as part of the CI job.
 


### PR DESCRIPTION
The title wasn't coming through, it was only showing the filename. It may not be necessary to both specify the title and change to an h1, but I wanted to be safe.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A technical writer reviews the content or PR (xs change)
