### PR TITLE
Pull one last change into BB configs, expand changes to OSS

### DIFF
--- a/src/components/code_snippets/_bitbucket-semgrep-app-sast.mdx
+++ b/src/components/code_snippets/_bitbucket-semgrep-app-sast.mdx
@@ -1,12 +1,11 @@
 ```yaml
-image: atlassian/default-image:latest
+image: semgrep/semgrep:latest
 
 pipelines:
   branches:
     # Change to your default branch if different from main
     main:
     - step:
-        image: semgrep/semgrep
         name: Semgrep scan on push
         script:
           - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
@@ -15,7 +14,6 @@ pipelines:
   pull-requests:
     '**': # This applies to pull requests for all branches
       - step:
-          image: semgrep/semgrep
           name: Semgrep scan on PR
           script:
             - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
@@ -29,7 +27,6 @@ pipelines:
   # Trigger job manually. For cron in Bitbucket, see: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-triggers/#On-schedule
     semgrep-manual:
       - step:
-          image: semgrep/semgrep
           name: Semgrep manual scan
           script:
             - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN

--- a/src/components/code_snippets/_bitbucket-semgrep-app-ssc.mdx
+++ b/src/components/code_snippets/_bitbucket-semgrep-app-ssc.mdx
@@ -1,32 +1,34 @@
 ```yaml
-image: atlassian/default-image:latest
+image: semgrep/semgrep:latest
 
 pipelines:
-  default:
-    - parallel:
+  branches:
+    # Change to your default branch if different from main
+    main:
+    - step:
+        name: Semgrep scan on push
+        script:
+          - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
+          - semgrep ci --supply-chain
+
+  pull-requests:
+    '**': # This applies to pull requests for all branches
       - step:
-          name: 'Run Semgrep scan with current branch'
-          deployment: dev # https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-monitor-deployments/
-          image: semgrep/semgrep
+          name: Semgrep scan on PR
           script:
-            # The following variables are required to set up a scan connected to Semgrep Cloud Platform:
             - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
+            - export BITBUCKET_TOKEN=$PAT # Necessary for PR comments
+            # Change to your default branch if different from main
+            - export SEMGREP_BASELINE_REF="origin/main"
+            - git fetch origin "+refs/heads/*:refs/remotes/origin/*"
+            - semgrep ci --supply-chain
 
-            # Uncomment the following line to scan changed 
-            # files in PRs or MRs (diff-aware scanning): 
-            # - export SEMGREP_BASELINE_REF = "origin/main"
-            # - git fetch origin "+refs/heads/*:refs/remotes/origin/*"
-
-            # Troubleshooting:
-
-            # Uncomment the following lines if Semgrep Cloud Platform > Findings Page does not create links
-            # to the code that generated a finding or if you are not receiving PR or MR comments.
-            # - export SEMGREP_JOB_URL="${SEMGREP_REPO_URL}/addon/pipelines/home#!/results/${BITBUCKET_PIPELINE_UUID}"
-            # - export SEMGREP_COMMIT=$BITBUCKET_COMMIT
-            # - export SEMGREP_PR_ID=$BITBUCKET_PR_ID
-            # - export SEMGREP_BRANCH=$BITBUCKET_BRANCH
-            # - export SEMGREP_REPO_URL=$BITBUCKET_GIT_HTTP_ORIGIN
-            # - export SEMGREP_REPO_NAME=$BITBUCKET_REPO_FULL_NAME
-
+  custom:
+  # Trigger job manually. For cron in Bitbucket, see: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-triggers/#On-schedule
+    semgrep-manual:
+      - step:
+          name: Semgrep manual scan
+          script:
+            - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
             - semgrep ci --supply-chain
 ```

--- a/src/components/code_snippets/_bitbucket-semgrep-app-standalone.mdx
+++ b/src/components/code_snippets/_bitbucket-semgrep-app-standalone.mdx
@@ -1,17 +1,34 @@
 ```yaml
-image: atlassian/default-image:latest
+image: semgrep/semgrep:latest
 
 pipelines:
-  default:
-    - parallel:
-      - step:
-          name: 'Run Semgrep scan with current branch'
-          deployment: dev
-          image: semgrep/semgrep
-          script:
-            # Uncomment the following line to scan changed 
-            # files in PRs or MRs (diff-aware scanning): 
-            # - export SEMGREP_BASELINE_REF = "main"
+  branches:
+    # Change to your default branch if different from main
+    main:
+    - step:
+        name: Semgrep scan on push
+        script:
+          - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
+          - semgrep ci --code
 
+  pull-requests:
+    '**': # This applies to pull requests for all branches
+      - step:
+          name: Semgrep scan on PR
+          script:
+            - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
+            - export BITBUCKET_TOKEN=$PAT # Necessary for PR comments
+            # Change to your default branch if different from main
+            - export SEMGREP_BASELINE_REF="origin/main"
+            - git fetch origin "+refs/heads/*:refs/remotes/origin/*"
+            - semgrep ci --code
+
+  custom:
+  # Trigger job manually. For cron in Bitbucket, see: https://support.atlassian.com/bitbucket-cloud/docs/pipeline-triggers/#On-schedule
+    semgrep-manual:
+      - step:
+          name: Semgrep manual scan
+          script:
+            - export SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN
             - semgrep ci --code
 ```

--- a/src/components/code_snippets/_bitbucket-semgrep-oss-sast.mdx
+++ b/src/components/code_snippets/_bitbucket-semgrep-oss-sast.mdx
@@ -1,5 +1,5 @@
 ```yaml
-image: atlassian/default-image:latest
+image: semgrep/semgrep
 
 pipelines:
   default:
@@ -7,7 +7,6 @@ pipelines:
       - step:
           name: 'Run Semgrep scan with current branch'
           deployment: dev # https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-monitor-deployments/
-          image: semgrep/semgrep
           script:
             - semgrep scan --config auto
 ```

--- a/src/components/code_snippets/_bitbucket-semgrep-oss-sast.mdx
+++ b/src/components/code_snippets/_bitbucket-semgrep-oss-sast.mdx
@@ -1,5 +1,5 @@
 ```yaml
-image: semgrep/semgrep
+image: semgrep/semgrep:latest
 
 pipelines:
   default:


### PR DESCRIPTION
When I was pulling the new configs from these docs (#1491) into the app I wanted to see if we could just list the image once, replacing the Atlassian default, and it worked fine, so I'm back-propagating that change into the docs again. 😂 

I know two of the three app snippets aren't in use, so the update on those is just consistency for the future.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
