### PR TITLE
Add tip admonition to clarify directory syntax in .semgrepignore

### DIFF
--- a/docs/ignore-oss.md
+++ b/docs/ignore-oss.md
@@ -84,6 +84,10 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 * Any line that begins with a colon, but not `:include`, raises an error.
 * `\:` is added to escape leading colons.
 
+:::tip
+To ignore an entire directory, make sure the `.semgrepignore` entry ends with a `/`, designating it as a directory and not a file.
+:::
+
 Unsupported patterns are silently removed from the pattern list (this is done so that `.gitignore` files may be included without raising errors). The removal is logged.
 
 For a description of `.gitignore` syntax, see [.gitignore documentation](https://git-scm.com/docs/gitignore).


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
