### PR TITLE
Move monorepo scanning to KB and update verbiage

### DIFF
--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -42,7 +42,7 @@ For the other modules, the commands look similar. For module B:
 
 You will then have the flexibility to trigger each one on appropriate events or frequencies.
 
-Now that you've successfully understood how to configure your monorepo to be scanned in parts, you also have to understand how to configure the findings from each part or module to show up as their own project in Semgrep AppSec Platform.
+Now that you understand how to configure your monorepo to be scanned in parts, you also have to understand how to configure the findings from each part or module to show up as their own project in Semgrep AppSec Platform.
 
 To assign findings from the module to their own project in Semgrep Appsec Platform, you must explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
 

--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -47,7 +47,7 @@ Now that you've successfully understood how to configure your monorepo to be sca
 To assign findings from the module to their own project in Semgrep Appsec Platform, you must explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
 
 :::info
-You will need to ensure that `SEMGREP_REPO_NAME` ([see reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) is still being properly set as with any Semgrep scan, to ensure that hyperlink and PR/MR comment functionality is retained.
+Ensure that `SEMGREP_REPO_NAME` ([see reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) is still properly set as with any Semgrep scan, to ensure that hyperlink and PR/MR comment functionality is retained.
 :::
 
 For example, if your monorepo is located at `https://github.com/semgrep/monorepo` the `SEMGREP_REPO_DISPLAY_NAME` would default to the value of `SEMGREP_REPO_NAME`, which in this case would be `semgrep/monorepo`. To split the monorepo into four projects corresponding to the logical modules, set `SEMGREP_REPO_NAME` as you normally would while setting `SEMGREP_REPO_DISPLAY_NAME` to something relevant before running Semgrep:

--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -44,13 +44,13 @@ You will then have the flexibility to trigger each one on appropriate events or 
 
 Now that you understand how to configure your monorepo to be scanned in parts, you also have to understand how to configure the findings from each part or module to show up as their own project in Semgrep AppSec Platform.
 
-To assign findings from the module to their own project in Semgrep Appsec Platform, you must explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
+To assign findings from the module to their own project in Semgrep AppSec Platform, you must explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable, which only works with Semgrep versions 1.61.1 and later ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
 
 :::info
-Ensure that `SEMGREP_REPO_NAME` is still properly set (either automatically if using a [supported SCM and CI provider](/docs/semgrep-ci/sample-ci-configs#feature-support) or [explicitly](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) as with any Semgrep scan, to ensure that hyperlink and PR/MR comment functionality is retained.
+Ensure that `SEMGREP_REPO_NAME` is still properly set (either automatically if using a [supported SCM and CI provider](/docs/semgrep-ci/sample-ci-configs#feature-support) or [explicitly](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) as with any Semgrep scan, in order to retain hyperlink and PR/MR comment functionality.
 :::
 
-For example, if your monorepo is located at `https://github.com/semgrep/monorepo` the `SEMGREP_REPO_DISPLAY_NAME` would default to the value of `SEMGREP_REPO_NAME`, which in this case would be `semgrep/monorepo`. To split the monorepo into four projects corresponding to the logical modules, set `SEMGREP_REPO_NAME` as you normally would while setting `SEMGREP_REPO_DISPLAY_NAME` to something relevant before running Semgrep:
+For example, if your monorepo is located at `https://github.com/semgrep/monorepo` the `SEMGREP_REPO_DISPLAY_NAME` would default to the value of `SEMGREP_REPO_NAME`, which in this case is `semgrep/monorepo`. To split the monorepo into four projects corresponding to the logical modules, set `SEMGREP_REPO_NAME` as you normally would while setting `SEMGREP_REPO_DISPLAY_NAME` to a relevant name before running Semgrep:
 
     export SEMGREP_REPO_DISPLAY_NAME="semgrep/monorepo/moduleA"
 

--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -19,7 +19,7 @@ As such, it can be helpful to scan a monorepo in parts for multiple reasons:
 
 When scanning a repo with Semgrep in CI, the base command is `semgrep ci`. To understand this default setup for your source code manager (SCM) and CI provider, see [Getting started with Semgrep in continuous integration (CI)](/deployment/add-semgrep-to-ci).
 
-To split up your monorepo, you need to make two changes. First, use the `--include` flag to determine *how* you want to logically split up the code. Second, update the `SEMGREP_REPO_NAME` environment variable to assign findings to separate projects in Semgrep AppSec Platform. 
+To split up your monorepo, you need to make two changes. First, use the `--include` flag to determine *how* you want to logically split up the code. Second, update the `SEMGREP_REPO_DISPLAY_NAME` environment variable to assign findings to separate projects in Semgrep AppSec Platform. 
 
 For example, if the monorepo has four main modules and their paths are:
 
@@ -42,19 +42,19 @@ For the other modules, the commands look similar. For module B:
 
 You will then have the flexibility to trigger each one on appropriate events or frequencies.
 
-Now that you've successfully configured your monorepo to be scanned in parts, you also have to configure the findings from each part or module to show up as their own project in Semgrep AppSec Platform.
+Now that you've successfully understood how to configure your monorepo to be scanned in parts, you also have to understand how to configure the findings from each part or module to show up as their own project in Semgrep AppSec Platform.
 
-To ensure findings from the module are assigned to their own project in Semgrep AppSec Platform, you will need to explicitly set the `SEMGREP_REPO_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables/#semgrep_repo_name)).
+To have findings from the module be assigned to their own project in Semgrep AppSec Platform, you will need to explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
 
 :::info
-Changing the `SEMGREP_REPO_NAME` value in a scan so that it does not match the repo's `<org>/<repo name>` structure on the SCM may cause issues with PR/MR comments and code hyperlinks in Semgrep AppSec Platform. This is a necessary tradeoff when splitting up a repo into multiple projects.
+You will need to ensure that `SEMGREP_REPO_NAME` ([see reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) is still being properly set as with any Semgrep scan, to ensure that hyperlink and PR/MR comment functionality is retained.
 :::
 
-For example, if your monorepo is located at `https://github.com/semgrep/monorepo` the `SEMGREP_REPO_NAME` would typically be set to `semgrep/monorepo`. To split the single project into four projects corresponding to the logical modules, set `SEMGREP_REPO_NAME` to match the module name before running Semgrep:
+For example, if your monorepo is located at `https://github.com/semgrep/monorepo` the `SEMGREP_REPO_DISPLAY_NAME` would default to the value of `SEMGREP_REPO_NAME`, which in this case would be `semgrep/monorepo`. To split the monorepo into four projects corresponding to the logical modules, set `SEMGREP_REPO_NAME` as you normally would while setting `SEMGREP_REPO_DISPLAY_NAME` to something relevant before running Semgrep:
 
-    export SEMGREP_REPO_NAME="semgrep/monorepo/moduleA"
+    export SEMGREP_REPO_DISPLAY_NAME="semgrep/monorepo/moduleA"
 
-And then running Semgrep as demonstrated above:
+And then run Semgrep as demonstrated earlier:
 
     semgrep ci --include=/src/moduleA/*
 

--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -44,7 +44,7 @@ You will then have the flexibility to trigger each one on appropriate events or 
 
 Now that you've successfully understood how to configure your monorepo to be scanned in parts, you also have to understand how to configure the findings from each part or module to show up as their own project in Semgrep AppSec Platform.
 
-To have findings from the module be assigned to their own project in Semgrep AppSec Platform, you will need to explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
+To assign findings from the module to their own project in Semgrep Appsec Platform, you must explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
 
 :::info
 You will need to ensure that `SEMGREP_REPO_NAME` ([see reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) is still being properly set as with any Semgrep scan, to ensure that hyperlink and PR/MR comment functionality is retained.

--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -47,7 +47,7 @@ Now that you understand how to configure your monorepo to be scanned in parts, y
 To assign findings from the module to their own project in Semgrep Appsec Platform, you must explicitly set the `SEMGREP_REPO_DISPLAY_NAME` environment variable ([see CI environment variables reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_display_name)).
 
 :::info
-Ensure that `SEMGREP_REPO_NAME` ([see reference](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) is still properly set as with any Semgrep scan, to ensure that hyperlink and PR/MR comment functionality is retained.
+Ensure that `SEMGREP_REPO_NAME` is still properly set (either automatically if using a [supported SCM and CI provider](/docs/semgrep-ci/sample-ci-configs#feature-support) or [explicitly](/docs/semgrep-ci/ci-environment-variables#semgrep_repo_name)) as with any Semgrep scan, to ensure that hyperlink and PR/MR comment functionality is retained.
 :::
 
 For example, if your monorepo is located at `https://github.com/semgrep/monorepo` the `SEMGREP_REPO_DISPLAY_NAME` would default to the value of `SEMGREP_REPO_NAME`, which in this case would be `semgrep/monorepo`. To split the monorepo into four projects corresponding to the logical modules, set `SEMGREP_REPO_NAME` as you normally would while setting `SEMGREP_REPO_DISPLAY_NAME` to something relevant before running Semgrep:

--- a/docs/semgrep-ci/ci-environment-variables.md
+++ b/docs/semgrep-ci/ci-environment-variables.md
@@ -235,56 +235,11 @@ jobs:
 
 ### `SEMGREP_REPO_DISPLAY_NAME`
 
-Set `SEMGREP_REPO_DISPLAY_NAME` to define the name used for the project in Semgrep AppSec Platform. By default, `SEMGREP_REPO_DISPLAY_NAME` has the same value as `SEMGREP_REPO_NAME`. This allows you to use a different name for your project than the repository name or to scan a monorepo as multiple projects.
+Set `SEMGREP_REPO_DISPLAY_NAME` to define the name displayed for the project in Semgrep AppSec Platform. By default, `SEMGREP_REPO_DISPLAY_NAME` has the same value as `SEMGREP_REPO_NAME`. This allows you to use a different name for your project than the repository name, while retaining hyperlink and PR/MR comment functionality. It can also be used when [scanning a monorepo in parts](/kb/semgrep-ci/scan-monorepo-in-parts) to display each part as a separate project in Semgrep AppSec Platform.
 
-#### Scan a monorepo as multiple projects
-
-Create a semgrep scan for each folder you want to scan separately. For each scan, use a different value for `SEMGREP_REPO_DISPLAY_NAME`.
-
-For example, consider a repository with the top level folders `proj1` and `proj2`. You can create separate Semgrep scans for the two folders.
-
-Within a Bash environment:
-
-```bash
-SEMGREP_REPO_DISPLAY_NAME="corporation/myrepo-proj1" semgrep ci --include proj1
-
-SEMGREP_REPO_DISPLAY_NAME="corporation/myrepo-proj2" semgrep ci --include proj2
-```
-
-Within a Github Actions environment:
-
-```yaml
-name: Semgrep
-jobs:
-  semgrep:
-    strategy:
-      matrix:
-        subdir:
-          - proj1
-          - proj2
-    name: semgrep/ci
-    runs-on: ubuntu-20.04
-    env:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-      SEMGREP_REPO_DISPLAY_NAME: corporation/myrepo-${{ matrix.subdir }}
-    container:
-      image: semgrep/semgrep
-    steps:
-    - uses: actions/checkout@v3
-    - run: semgrep ci --include=${{ matrix.subdir }}
-```
-
-You may want to scan a monorepo in parts to manage the projects separately or to improve performance.
-
-If your repository doesn't split cleanly into folders, one strategy is to use `--include` for the main folders and `--exclude` to capture everything else. Returning to the bash example, this would look like:
-
-```bash
-SEMGREP_REPO_DISPLAY_NAME="corporation/myrepo-proj1" semgrep ci --include proj1
-
-SEMGREP_REPO_DISPLAY_NAME="corporation/myrepo-proj2" semgrep ci --include proj2
-
-SEMGREP_REPO_DISPLAY_NAME="corporation/myrepo-proj2" semgrep ci --exclude proj1 --exclude proj2
-```
+:::info
+This environment variable is only works with Semgrep versions 1.61.1 and later.
+:::
 
 ### `SEMGREP_REPO_URL`
 

--- a/docs/semgrep-ci/ci-environment-variables.md
+++ b/docs/semgrep-ci/ci-environment-variables.md
@@ -238,7 +238,7 @@ jobs:
 Set `SEMGREP_REPO_DISPLAY_NAME` to define the name displayed for the project in Semgrep AppSec Platform. By default, `SEMGREP_REPO_DISPLAY_NAME` has the same value as `SEMGREP_REPO_NAME`. This allows you to use a different name for your project than the repository name, while retaining hyperlink and PR/MR comment functionality. It can also be used when [scanning a monorepo in parts](/kb/semgrep-ci/scan-monorepo-in-parts) to display each part as a separate project in Semgrep AppSec Platform.
 
 :::info
-This environment variable is only works with Semgrep versions 1.61.1 and later.
+This environment variable only works with Semgrep versions 1.61.1 and later.
 :::
 
 ### `SEMGREP_REPO_URL`


### PR DESCRIPTION
Moved the info on using display name to the relevant KB. Decided not to re-use the GitHub Actions example because it used matrices and that's a bit too advanced/confusing to use as a simple example. I think the KB does a good job of explaining how to use the new env var now. Also added a minimum version for the new env var in the variables reference page.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
