### PR TITLE
Update scan-monorepo-in-parts.md: including recommendations to split …

### DIFF
--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -19,7 +19,7 @@ As such, it can be helpful to scan a monorepo in parts for multiple reasons:
 
 When scanning a repo with Semgrep in CI, the base command is `semgrep ci`. To understand this default setup for your source code manager (SCM) and CI provider, see [Getting started with Semgrep in continuous integration (CI)](/deployment/add-semgrep-to-ci).
 
-To split up your monorepo, you need to make two changes. First, use the `--include` flag to determine *how* you want to logically split up the code. Second, update the `SEMGREP_REPO_DISPLAY_NAME` environment variable to assign findings to separate projects in Semgrep AppSec Platform. 
+To split up your monorepo, you need to make two changes. First, use the `--include` flag to determine *how* you want to logically split up the code. We recommend splitting it either by language or no more than 100,000 lines of code. Second, update the `SEMGREP_REPO_DISPLAY_NAME` environment variable to assign findings to separate projects in Semgrep AppSec Platform. 
 
 For example, if the monorepo has four main modules and their paths are:
 

--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -19,7 +19,7 @@ As such, it can be helpful to scan a monorepo in parts for multiple reasons:
 
 When scanning a repo with Semgrep in CI, the base command is `semgrep ci`. To understand this default setup for your source code manager (SCM) and CI provider, see [Getting started with Semgrep in continuous integration (CI)](/deployment/add-semgrep-to-ci).
 
-To split up your monorepo, you need to make two changes. First, use the `--include` flag to determine *how* you want to logically split up the code. We recommend splitting it either by language or no more than 100,000 lines of code. Second, update the `SEMGREP_REPO_DISPLAY_NAME` environment variable to assign findings to separate projects in Semgrep AppSec Platform. 
+To split up your monorepo, you need to make two changes. First, use the `--include` flag to determine *how* you want to logically split up the code. Second, update the `SEMGREP_REPO_DISPLAY_NAME` environment variable to assign findings to separate projects in Semgrep AppSec Platform. 
 
 For example, if the monorepo has four main modules and their paths are:
 
@@ -28,7 +28,7 @@ For example, if the monorepo has four main modules and their paths are:
     /src/moduleC
     /src/moduleD
 
-Then splitting its scans into four separate scans, one for each module, would provide a logical separation for findings.
+Then splitting its scans into four separate scans, one for each module, would provide a logical separation for findings. In general, we recommend modules to not exceed ~100,000 lines of code in order to keep optimal scan time and efficiency.
 
 After choosing a logical split, use the `--include` flag ([see CLI reference](/docs/cli-reference)) with the relevant path to only scan files in that module's code path:
 


### PR DESCRIPTION
Rippling needed size recommendations for splitting their monorepo because it's only one language. Engineering and product determined ~100,000 is a good estimate for the upper limit. This recommendation is great context for other customers who face similar issues.

https://linear.app/semgrep/issue/SAF-1026/size-recommendations-for-ripplings-monorepo