### PR TITLE
add footnote to SSC support languages about transitivity

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -254,7 +254,7 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
   </tr>
   <tr>
    <td>Rust</td>
-   <td>Cargo</td>
+   <td>Cargo§</td>
    <td><code>cargo.lock</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
    <td>✔️</td>
@@ -270,7 +270,7 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
 <tr>
    <td rowspan="2">Kotlin</td>
    <td>Gradle</td>
-   <td><code>gradle.lockfile</code></td>
+   <td><code>gradle.lockfile§</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
    <td>--</td>
 </tr>
@@ -307,6 +307,7 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
 _*Semgrep Supply Chain scans transitive dependencies for **all supported languages** but does **not** perform reachability analysis on transitive dependencies._ <br />
 _**‡Reachability support level** refers to the level of support for reachability analysis for the language. At the minimum, Semgrep Supply Chain uses **lockfile-only** rules, which check a package's version against versions with known vulnerabilities._ <br />
 _**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a **lockfile**. This means that `requirements.txt` must be set to exact versions (pinned dependencies) and the file must be generated automatically._
+_**§** We do not analyze the transitivity of packages for these language/lockfile combinations. All dependencies will be listed with "Unknown" transitivity 
 
 <AdmonitionSotCves />
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -306,8 +306,8 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
 
 _*Semgrep Supply Chain scans transitive dependencies for **all supported languages** but does **not** perform reachability analysis on transitive dependencies._ <br />
 _**‡Reachability support level** refers to the level of support for reachability analysis for the language. At the minimum, Semgrep Supply Chain uses **lockfile-only** rules, which check a package's version against versions with known vulnerabilities._ <br />
-_**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a **lockfile**. This means that `requirements.txt` must be set to exact versions (pinned dependencies) and the file must be generated automatically._
-_**§** We do not analyze the transitivity of packages for these language/lockfile combinations. All dependencies will be listed with "Unknown" transitivity 
+_**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a **lockfile**. This means that `requirements.txt` must be set to exact versions (pinned dependencies) and the file must be generated automatically._ <br />
+_**§** We do not analyze the transitivity of packages for these language/lockfile combinations. All dependencies will be listed with "Unknown" transitivity._
 
 <AdmonitionSotCves />
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -307,7 +307,7 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
 _*Semgrep Supply Chain scans transitive dependencies for **all supported languages** but does **not** perform reachability analysis on transitive dependencies._ <br />
 _**‡Reachability support level** refers to the level of support for reachability analysis for the language. At the minimum, Semgrep Supply Chain uses **lockfile-only** rules, which check a package's version against versions with known vulnerabilities._ <br />
 _**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a **lockfile**. This means that `requirements.txt` must be set to exact versions (pinned dependencies) and the file must be generated automatically._ <br />
-_**§** We do not analyze the transitivity of packages for these language/lockfile combinations. All dependencies will be listed with "Unknown" transitivity._
+_**§** Supply Chain does not analyze the transitivity of packages for these language or lockfile combinations. All dependencies are listed as **Unknown** transitivity._
 
 <AdmonitionSotCves />
 


### PR DESCRIPTION
Rust with `Cargo.lock` and Kotlin with `gradle.lockfile` do not support determining whether or not a dependency is transitive, all dependencies will have `Unknown` transitivity. I added this as a footnote.


### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
