### PR TITLE
Update historical-scanning.md

### DIFF
--- a/docs/semgrep-secrets/historical-scanning.md
+++ b/docs/semgrep-secrets/historical-scanning.md
@@ -107,7 +107,7 @@ Historical scan findings are not automatically marked as **Fixed**. To triage a 
 
 - Historical scanning can slow down scan times. Depending on the size of your repository history, scans can finish under 5 minutes to more than 60 minutes for extreme cases.
 - Within Semgrep AppSec Platform, historical scan findings are not automatically marked as **Fixed**. Findings can only exist in two states: `Open` or `Ignored`. Because Semgrep scans do not automatically detect historical findings as fixed, you must manually rotate and triage the secret as `Ignored`.
-- With historical scanning enabled, the CLI may display duplicate instances of the same secret finding if it occurs across various commits or branches. This is to ensure thorough analysis by presenting all occurrences. However, when utilizing the Semgrep AppSec Platform, findings from historical scans are deduplicated. Consequently, you'll encounter only one entry for each distinct secret, irrespective of its multiple appearances in your Git history..
+- With historical scanning enabled, the CLI output displays secrets still present in the current version of the code twice: once at the commit where they were initially added and once at the current commit from the standard Secrets scan. Semgrep AppSec Platform deduplicates the two findings and displays the secret as a current rather than a historical one.
 
 ### Size of commit history
 

--- a/docs/semgrep-secrets/historical-scanning.md
+++ b/docs/semgrep-secrets/historical-scanning.md
@@ -107,8 +107,7 @@ Historical scan findings are not automatically marked as **Fixed**. To triage a 
 
 - Historical scanning can slow down scan times. Depending on the size of your repository history, scans can finish under 5 minutes to more than 60 minutes for extreme cases.
 - Within Semgrep AppSec Platform, historical scan findings are not automatically marked as **Fixed**. Findings can only exist in two states: `Open` or `Ignored`. Because Semgrep scans do not automatically detect historical findings as fixed, you must manually rotate and triage the secret as `Ignored`.
-- A finding can show up twice in the CLI with historical scanning enabled: the HEAD commit in the regular Secrets scan and another commit in the historical scan.
-    - If findings are sent to Semgrep AppSec Platform, they are deduplicated and appear as a **regular finding**, not a historical finding.
+- With historical scanning enabled, the CLI may display duplicate instances of the same secret finding if it occurs across various commits or branches. This is to ensure thorough analysis by presenting all occurrences. However, when utilizing the Semgrep AppSec Platform, findings from historical scans are deduplicated. Consequently, you'll encounter only one entry for each distinct secret, irrespective of its multiple appearances in your Git history..
 
 ### Size of commit history
 


### PR DESCRIPTION
This documentation update PR clarifies how the CLI handles duplicate secret findings during historical scanning. It explains why duplicates may occur and highlights that the Semgrep AppSec Platform deduplicates findings, ensuring users see only unique instances. This enhances user understanding and streamlines the security analysis process.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
