### PR TITLE
Remove spurious ; that was messing with title

### DIFF
--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -4,8 +4,6 @@ slug: pattern-syntax
 description: "Learn Semgrep's pattern syntax to search code for a given code pattern. If you're just getting started writing Semgrep rules, check out the Semgrep Tutorial at https://semgrep.dev/learn"
 ---
 
-;
-
 # Pattern syntax
 
 :::tip


### PR DESCRIPTION
I noticed the title of this doc looked weird, and when I checked, there was a random ; at the top somehow. Hopefully removing that will get everything back to normal.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR (xs change)
