### PR TITLE
Add redirect for /semgrep-secrets/

### DIFF
--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -37,7 +37,7 @@ The [pre-commit framework](https://pre-commit.com/) can run `semgrep` at commit-
 ```yaml
 repos:
 - repo: https://github.com/semgrep/semgrep
-  rev: 'SEMGREP_VERSION_LATEST'
+  rev: 'v1.73.0'
   hooks:
     - id: semgrep
       # See https://semgrep.dev/explore to select a ruleset and copy its URL
@@ -49,7 +49,7 @@ The pre-commit can also run custom rules and rulesets from Semgrep Code, similar
 ```yaml
 repos:
 - repo: https://github.com/semgrep/semgrep
-  rev: 'SEMGREP_VERSION_LATEST'
+  rev: 'v1.73.0'
   hooks:
     - id:  semgrep-ci
 ```

--- a/docs/ignoring-files-folders-code.md
+++ b/docs/ignoring-files-folders-code.md
@@ -37,7 +37,29 @@ Without user customization, Semgrep refers to the following to define ignored fi
 In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repository's default template](https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore):
 
 ```
-DEFAULT_SEMGREPIGNORE_TEXT
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+.npm/
+.yarn/
+
+# Common test paths
+test/
+tests/
+*_test.go
+
+# Semgrep rules folder
+.semgrep
+
+# Semgrep-action log folder
+.semgrep_logs/
+
 
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -384,6 +384,7 @@ module.exports = {
           { from: "/semgrep-cloud-platform/webhooks/" , to: "/semgrep-appsec-platform/webhooks" } ,
           /* MAY 7, 2024 */
           { from: "/kb/semgrep-secrets/secrets_pr_comments" , to: "/semgrep-secrets/policies" } ,
+          { from: "/semgrep-secrets" , to: "/semgrep-secrets/conceptual-overview" },
         ]
       }
     ],


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
