### PR TITLE
update SBOM sidebar location

### DIFF
--- a/docs/semgrep-appsec-platform/dashboard.md
+++ b/docs/semgrep-appsec-platform/dashboard.md
@@ -98,6 +98,7 @@ Filters mentioned in previous sections [Filtering findings by time](#filtering-f
 
 ## See also
 
+* [Generate an SBOM](/semgrep-supply-chain/sbom)
 * [Semgrep Registry](https://semgrep.dev/explore)
 * [Findings](/semgrep-code/findings)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -244,9 +244,9 @@ module.exports = {
                 'semgrep-supply-chain/overview',
                 'semgrep-supply-chain/getting-started',
                 'semgrep-supply-chain/triage-remediation',
-                'semgrep-supply-chain/sbom',
                 'semgrep-supply-chain/ignoring-deps',
                 'semgrep-supply-chain/dependency-search',
+                'semgrep-supply-chain/sbom',
                 'semgrep-supply-chain/license-compliance'
             ]
         },

--- a/sidebars.js
+++ b/sidebars.js
@@ -155,8 +155,7 @@ module.exports = {
           collapsible: true,
           link: {type: 'doc', id: 'semgrep-appsec-platform/ticketing'},
           items: [
-            'semgrep-appsec-platform/dashboard',
-            'semgrep-supply-chain/sbom'
+            'semgrep-appsec-platform/dashboard'
           ]
         },
         {
@@ -245,6 +244,7 @@ module.exports = {
                 'semgrep-supply-chain/overview',
                 'semgrep-supply-chain/getting-started',
                 'semgrep-supply-chain/triage-remediation',
+                'semgrep-supply-chain/sbom',
                 'semgrep-supply-chain/ignoring-deps',
                 'semgrep-supply-chain/dependency-search',
                 'semgrep-supply-chain/license-compliance'

--- a/sidebars.js
+++ b/sidebars.js
@@ -153,7 +153,7 @@ module.exports = {
           type: 'category',
           label: 'Reports',
           collapsible: true,
-          link: {type: 'doc', id: 'semgrep-appsec-platform/ticketing'},
+          link: {type: 'doc', id: 'semgrep-appsec-platform/dashboard'},
           items: [
             'semgrep-appsec-platform/dashboard'
           ]


### PR DESCRIPTION
- Moves SBOM out of Reporting and into SCA (Supply Chain) in the sidebar. 
- Adds a link on the Dashboard reports page to SBOM doc.