### PR TITLE
Add a note for Dependency Search that only reflects 

### DIFF
--- a/docs/semgrep-supply-chain/dependency-search.md
+++ b/docs/semgrep-supply-chain/dependency-search.md
@@ -82,4 +82,4 @@ To ensure that your dependencies appear, check the following:
 * Ensure that Semgrep Supply Chain can parse your lockfile. Refer to [Supported languages](/supported-languages) for a list of supported languages and lockfiles.
 * Make sure you've scanned the repository at least once.
 * If you are using filters, ensure that your filters and search syntax is correct.
-* Make sure the the scan you are not referring to is a diff scan. Only dependencies scanned off of full scans are shown within the Dependencies page. 
+* Ensure that the scan you're referring to isn't a diff-aware scan. Only dependencies scanned off of full scans are shown on the **Dependencies** page. 

--- a/docs/semgrep-supply-chain/dependency-search.md
+++ b/docs/semgrep-supply-chain/dependency-search.md
@@ -82,3 +82,4 @@ To ensure that your dependencies appear, check the following:
 * Ensure that Semgrep Supply Chain can parse your lockfile. Refer to [Supported languages](/supported-languages) for a list of supported languages and lockfiles.
 * Make sure you've scanned the repository at least once.
 * If you are using filters, ensure that your filters and search syntax is correct.
+* Make sure the the scan you are not referring to is a diff scan. Only dependencies scanned off of full scans are shown within the Dependencies page. 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

For the Dependencies page, we don't actually show dependencies unless they were found off a full scan. This will add an extra note to tell users of the above circumstance. 

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
