### PR TITLE
Quick interim note on Secrets ignores

### DIFF
--- a/docs/semgrep-secrets/getting-started.md
+++ b/docs/semgrep-secrets/getting-started.md
@@ -8,8 +8,6 @@ tags:
   - Semgrep Secrets
 ---
 
-
-
 # Scan for secrets
 
 Semgrep Secrets allows you to detect and triage leaked secrets and credentials
@@ -21,7 +19,6 @@ This document guides you through:
 
 1. Enabling Semgrep Secrets
 2. Viewing your results and triaging your findings
-3. Setting up PR comments and notifications
 
 ## Language and environment support
 
@@ -37,7 +34,7 @@ You have completed a [Semgrep core deployment](/deployment/core-deployment).
 2. Click **<i class="fa-solid fa-gear"></i> Settings**.
 3. On the **Deployment** tab, click the **<i class="fa-solid fa-toggle-large-on"></i> Secrets** toggle to enable.
 
-Once you've enabled Secrets for your organization, all Semgrep scans include secret scanning. There are no additional steps to take.
+Once you've enabled Secrets for your organization, all Semgrep scans include secret scanning.
 
 ## Scan your repository
 
@@ -47,6 +44,15 @@ After you've enabled Semgrep Secrets, you can:
 * Start a scan from the CLI (Semgrep recommends that you run CLI scans only on feature branches, not main branches)
 * Wait for your scheduled Semgrep full scan
 * Open a pull request or merge request and wait for Semgrep to scan the branch automatically
+
+## Configure files to ignore
+
+Semgrep Secrets will scan files even if they are specified in a local `.semgrepignore`, since secrets can often be found in files that are not relevant for code scanning. To specify files to ignore in Semgrep Secrets as well:
+
+1. Sign in to Semgrep AppSec Platform.
+2. Go to **Projects** and select the gear icon <i class="fa-solid fa-gear"></i> to access the settings for the related project.
+3. Add entries to the **Path ignores** box to ignore them for Semgrep Secrets as well as other Semgrep products.
+4. Click **Save changes**.
 
 ## Upgrade your rules
 

--- a/docs/semgrep-secrets/getting-started.md
+++ b/docs/semgrep-secrets/getting-started.md
@@ -47,16 +47,16 @@ After you've enabled Semgrep Secrets, you can:
 
 ## Configure files to ignore
 
-Semgrep Secrets will scan files even if they are specified in a local `.semgrepignore`, since secrets can often be found in files that are not relevant for code scanning. To specify files to ignore in Semgrep Secrets as well:
+Semgrep Secrets scans all files, even those specified in a local `.semgrepignore` file, since secrets can often be found in files that are not relevant for code scanning. To specify files that Semgrep Secrets should ignore:
 
 1. Sign in to Semgrep AppSec Platform.
 2. Go to **Projects** and find your project. Select the gear icon <i class="fa-solid fa-gear"></i> to access the settings for the related project.
-3. Add entries to the **Path ignores** box to ignore them for Semgrep Secrets as well as other Semgrep products.
+3. Add the file paths to the **Path ignores** box. Semgrep ignores all file paths listed, including for Semgrep Secrets.
 4. Click **Save changes**.
 
 ## Upgrade your rules
 
-If you're using Semgrep Code rules to identify leaked credentials, you'll see prompts in Semgrep AppSec Platform indicating that there's an improved version that utilizes Semgrep Secrets' feature set, primarily its validators, which can validate whether the detected credential is active, and improvements in detecting and hiding false positives.
+If you're using Semgrep Code rules to identify leaked credentials, you'll see prompts in Semgrep AppSec Platform indicating that there's an improved version that uses Semgrep Secrets' feature set, primarily its validators, which can validate whether the detected credential is active, and improvements in detecting and hiding false positives.
 
 You can see individual findings for which there is a Semgrep Secrets rule upgrade in Semgrep AppSec Platform's **Findings** page. The findings are tagged with a label that says `Secrets version available! Click to see rule(s)`.
 

--- a/docs/semgrep-secrets/getting-started.md
+++ b/docs/semgrep-secrets/getting-started.md
@@ -50,7 +50,7 @@ After you've enabled Semgrep Secrets, you can:
 Semgrep Secrets will scan files even if they are specified in a local `.semgrepignore`, since secrets can often be found in files that are not relevant for code scanning. To specify files to ignore in Semgrep Secrets as well:
 
 1. Sign in to Semgrep AppSec Platform.
-2. Go to **Projects** and select the gear icon <i class="fa-solid fa-gear"></i> to access the settings for the related project.
+2. Go to **Projects** and find your project. Select the gear icon <i class="fa-solid fa-gear"></i> to access the settings for the related project.
 3. Add entries to the **Path ignores** box to ignore them for Semgrep Secrets as well as other Semgrep products.
 4. Click **Save changes**.
 


### PR DESCRIPTION
We'll have more on this in future, but in the meantime, this should help with some confusion we've seen about Secrets with `.semgrepignore`.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
