### PR TITLE
Fix broken links (missing docs path)

### DIFF
--- a/docs/deployment/core-deployment.md
+++ b/docs/deployment/core-deployment.md
@@ -54,7 +54,7 @@ These are the absolute minimum Semgrep features for any deployment.
         <tr>
             <td>SAST scanning</td>
             <td>Check that Semgrep:
-            <ul><li>Can scan your language and that the language's maturity matches your security needs. See <a href="/supported-languages"><i class="fa-regular fa-file-lines" /> Supported languages</a>.</li>
+            <ul><li>Can scan your language and that the language's maturity matches your security needs. See <a href="/docs/supported-languages"><i class="fa-regular fa-file-lines" /> Supported languages</a>.</li>
             <li>Provides rulesets that you can use out-of-the-box. See <a href="https://semgrep.dev/r/"><i class="fas fa-external-link fa-xs" /> Semgrep Registry</a>.</li></ul></td>
         </tr>
         <tr>
@@ -62,8 +62,8 @@ These are the absolute minimum Semgrep features for any deployment.
             <td>Check that Semgrep supports your lockfile or package manager.</td>
         </tr>
         <tr>
-            <td>Secrets scanning (beta)</td>
-            <td>Check that your services, such as Slack or Twilio, can be validated by Semgrep. Semgrep Secrets is in beta, so you must <a href="https://get.semgrep.dev/Book-a-demo.html"><i class="fas fa-external-link fa-xs"/> Book a demo.</a></td>
+            <td>Secrets scanning</td>
+            <td>Check that your services, such as Slack or Twilio, can be validated by Semgrep. Semgrep Secrets is available through Semgrep Sales, so you must <a href="https://get.semgrep.dev/Book-a-demo.html"><i class="fas fa-external-link fa-xs"/> Book a demo.</a></td>
         </tr>
         <tr>
             <td>SSO</td>
@@ -77,11 +77,11 @@ These are the absolute minimum Semgrep features for any deployment.
         </tr>
         <tr>
             <td>Scanning remote repositories through CI</td>
-            <td>Semgrep fully supports many popular CI providers. See <a href="/deployment/add-semgrep-to-ci"><i class="fa-regular fa-file-lines"></i> Add Semgrep to CI</a>.</td>
+            <td>Semgrep fully supports many popular CI providers. See <a href="/docs/deployment/add-semgrep-to-ci"><i class="fa-regular fa-file-lines"></i> Add Semgrep to CI</a>.</td>
         </tr>
         <tr>
             <td>Managed scanning (beta): scanning remote repositories in bulk without CI changes</td>
-            <td>An alternative method of scanning many repositories with Semgrep that doesn't require integration with your CI. Requires read access to user-selected repositories. See <a href="/deployment/managed-scanning"><i class="fa-regular fa-file-lines"></i> Add repositories to Semgrep in bulk (beta)</a>.</td>
+            <td>An alternative method of scanning many repositories with Semgrep that doesn't require integration with your CI. Requires read access to user-selected repositories. See <a href="/docs/deployment/managed-scanning"><i class="fa-regular fa-file-lines"></i> Add repositories to Semgrep in bulk (beta)</a>.</td>
         </tr>
         <tr>
             <td>PR or MR comments</td>
@@ -129,7 +129,7 @@ Useful features that you can add based on your tech stack. You can integrate the
     </tbody>
 </table>
 
-<!-- - Integrate Semgrep with Jira, Linear, and Asana (Private beta). -->
+<!-- - Integrate Semgrep with Jira (Private beta). -->
 
 ## Core deployment process
 


### PR DESCRIPTION
Mostly this just fixes some broken links that didn't have the proper docs path. I also made a few other tiny adjustments (Secrets not officially beta any longer, etc)

### Please ensure

- [ ] A technical writer reviews the content or PR (small PR)
- [x] This change has no security implications or else you have pinged the security team
