### PR TITLE
Reflect change of toggle name for SCA blocking

### DIFF
--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -111,7 +111,7 @@ Semgrep Supply Chain supports the scanning of monorepos. As outlined in [Project
 
 ## Block pull or merge requests
 
-Semgrep Supply Chain versions **v0.122.0** and earlier automatically blocked pull/merge request scans if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to block on scans that detect reachable findings in direct dependencies with high or critical severity.
+Semgrep Supply Chain versions **v0.122.0** and earlier automatically blocked pull/merge request scans if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to block on scans that detect reachable findings in direct dependencies with high or critical severity. Findings only block when there is an upgrade available, to prevent blocking when there is no resolution for the vulnerability.
 
 1. Log in to Semgrep AppSec Platform.
 2. Go to **Settings > Deployment** and navigate to the **Supply Chain (SCA)** section.

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -111,11 +111,11 @@ Semgrep Supply Chain supports the scanning of monorepos. As outlined in [Project
 
 ## Block pull or merge requests
 
-Semgrep Supply Chain versions **v0.122.0** and earlier automatically blocked pull/merge requests if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to block on pull request scans that detect reachable findings in direct dependencies with high or critical severity.
+Semgrep Supply Chain versions **v0.122.0** and earlier automatically blocked pull/merge request scans if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to block on scans that detect reachable findings in direct dependencies with high or critical severity.
 
 1. Log in to Semgrep AppSec Platform.
 2. Go to **Settings > Deployment** and navigate to the **Supply Chain (SCA)** section.
-3. Click **<i class="fa-solid fa-toggle-large-on"></i> PR/MR Blocking**.
+3. Click **<i class="fa-solid fa-toggle-large-on"></i> Scan Blocking**.
 
 Alternatively, you can configure your version control system to prevent merging if Semgrep Supply Chain identifies reachable findings.
 


### PR DESCRIPTION
We updated the name of the blocking toggle since it also causes full scans to exit with code 1. I changed the name and lightly modified the verbiage - since we still generally focus on PR/MRs for blocking, I didn't remove that aspect of the content.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
