### PR TITLE
clarify how blocking works

### DIFF
--- a/docs/semgrep-ci/configuring-blocking-and-errors-in-ci.md
+++ b/docs/semgrep-ci/configuring-blocking-and-errors-in-ci.md
@@ -16,7 +16,7 @@ This article documents how Semgrep pipelines handle blocking findings and errors
 
 ## Default configuration of blocking findings and error suppression
 
-Semgrep blocks the pull requests (PRs) or merge requests (MRs) in its default configuration only when it matches a blocking finding.
+Semgrep can help block pull requests (PRs) or merge requests (MRs). Semgrep returns exit code `1`, and you can use this result to set up additional checks to enforce a block on a PR or MR when it matches a blocking finding. This action applies to both full scans and [diff-aware scans](/semgrep-code/glossary#diff-aware-scan).
 
 Blocking findings can be defined as:
 

--- a/docs/semgrep-ci/configuring-blocking-and-errors-in-ci.md
+++ b/docs/semgrep-ci/configuring-blocking-and-errors-in-ci.md
@@ -25,6 +25,10 @@ Blocking findings can be defined as:
 
 By default, Semgrep does not block your pipeline when it encounters an internal error. Semgrep suppresses all errors and does not surface them to the CI provider. In case of an internal error, Semgrep sends an anonymous crash report to a crash-reporting server and does not block your CI pipeline. To change the default configuration, see the sections below.
 
+:::tip
+How to enforce a block on a PR or MR after Semgrep exits with error code `1` is dependent on your CI provider. Review your CI provider's documentation for further information.
+:::
+
 ## Configuration options for blocking findings and errors
 
 Configure, change or revert to the default setup of blocking findings and errors in your CI pipeline using the following options in CI configuration file:

--- a/docs/semgrep-ci/configuring-blocking-and-errors-in-ci.md
+++ b/docs/semgrep-ci/configuring-blocking-and-errors-in-ci.md
@@ -23,7 +23,7 @@ Blocking findings can be defined as:
 - Findings defined in the [Policies page](https://semgrep.dev/orgs/-/policies) of Semgrep AppSec Platform. Avoid blocking findings by removing rules from the **Block** rule mode of the [Policies page](https://semgrep.dev/orgs/-/policies).
 - If you do **not** use Semgrep AppSec Platform with Semgrep in CI (that is, you are using a **stand-alone setup**), blocking findings encompass all Semgrep findings. Any finding in this setup blocks your PRs or MRs.
 
-By default, Semgrep does not block your pipeline when it encounters an internal error. Semgrep suppresses all errors and does not surface them to the CI provider. In case of an internal error, Semgrep sends an anonymous crash report to a crash-reporting server and does not block your CI pipeline. To change the default configuration, see the sections below.
+By default, Semgrep does not block your pipeline when it encounters an internal error. In case of an internal error, Semgrep sends an anonymous crash report to a crash-reporting server and does not block your CI pipeline. To change the default configuration, see the sections below.
 
 :::tip
 How to enforce a block on a PR or MR after Semgrep exits with error code `1` is dependent on your CI provider. Review your CI provider's documentation for further information.

--- a/docs/semgrep-code/policies.md
+++ b/docs/semgrep-code/policies.md
@@ -56,7 +56,7 @@ The Policies page consists of a header and three main panes:
 
 Semgrep enables you to set a **workflow action** based on the presence of a finding. Workflow actions include:
 
-* Failing a CI job. Semgrep returns exit code `1`, and you can use this result to set up additional checks to enforce a block on a PR or MR.
+* Failing a CI job. Semgrep returns exit code `1`, and you can use this result to set up additional checks to enforce a block on a PR or MR. This action applies to both full scans and [diff-aware scans](/semgrep-code/glossary#diff-aware-scan).
 * Leaving a PR or MR comment.
 * Notifying select channels, such as private Slack channels or webhooks.
 

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -110,11 +110,12 @@ Semgrep Supply Chain supports the scanning of monorepos. As outlined in [Project
 
 ## Block pull or merge requests
 
-Semgrep can help block pull requests (PRs) or merge requests (MRs). Semgrep returns exit code `1`, and you can use this result to set up additional checks to enforce a block on a PR or MR when it matches a blocking finding. This feature works with both full scans and diff-aware scans, which are scans that show only the findings that have been caused by changes in files starting from a specific Git baseline. These are typically performed on feature branches when a pull or merge request is opened.
+Semgrep can be used to block pull requests (PRs) or merge requests (MRs) when it matches a blocking finding. When one or more findings is blocking, Semgrep returns exit code `1`, and you can use this result to set up additional checks to enforce a block in your CI/CD pipeline, such as not allowing merge of the PR/MR. This action applies to both full scans and [diff-aware scans](/semgrep-code/glossary#diff-aware-scan).
 
-Semgrep Supply Chain versions **v0.122.0** and earlier automatically aided in blocking pull/merge requests if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to help block whenever:
+Semgrep Supply Chain versions **v0.122.0** and earlier automatically aided in blocking pull/merge requests if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to help block scans whenever all of the following conditions are met:
 
-* It detects reachable findings in direct dependencies with high or critical severity
+* It detects reachable findings in direct dependencies
+* The reachable findings are of critical or high severity
 * There is an upgrade available for the affected dependency; this is to prevent blocking when there is no resolution for the vulnerability
 
 To enable **Scan Blocking**:

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -112,7 +112,7 @@ Semgrep Supply Chain supports the scanning of monorepos. As outlined in [Project
 
 Semgrep can help block pull requests (PRs) or merge requests (MRs). Semgrep returns exit code `1`, and you can use this result to set up additional checks to enforce a block on a PR or MR when it matches a blocking finding. This feature works with both full scans and diff-aware scans, which are scans that show only the findings that have been caused by changes in files starting from a specific Git baseline. These are typically performed on feature branches when a pull or merge request is opened.
 
-Semgrep Supply Chain versions **v0.122.0** and earlier automatically blocked pull/merge request if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to block whenever:
+Semgrep Supply Chain versions **v0.122.0** and earlier automatically aided in blocking pull/merge requests if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to help block whenever:
 
 * It detects reachable findings in direct dependencies with high or critical severity
 * There is an upgrade available for the affected dependency; this is to prevent blocking when there is no resolution for the vulnerability

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -110,7 +110,14 @@ Semgrep Supply Chain supports the scanning of monorepos. As outlined in [Project
 
 ## Block pull or merge requests
 
-Semgrep Supply Chain versions **v0.122.0** and earlier automatically blocked pull/merge request scans if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to block on scans that detect reachable findings in direct dependencies with high or critical severity. Findings only block when there is an upgrade available, to prevent blocking when there is no resolution for the vulnerability.
+Semgrep can help block pull requests (PRs) or merge requests (MRs). Semgrep returns exit code `1`, and you can use this result to set up additional checks to enforce a block on a PR or MR when it matches a blocking finding. This feature works with both full scans and diff-aware scans, which are scans that show only the findings that have been caused by changes in files starting from a specific Git baseline. These are typically performed on feature branches when a pull or merge request is opened.
+
+Semgrep Supply Chain versions **v0.122.0** and earlier automatically blocked pull/merge request if it discovered reachable findings in the code, but later versions do not do this. You can, however, configure Semgrep Supply Chain to block whenever:
+
+* It detects reachable findings in direct dependencies with high or critical severity
+* There is an upgrade available for the affected dependency; this is to prevent blocking when there is no resolution for the vulnerability
+
+To enable **Scan Blocking**:
 
 1. Log in to Semgrep AppSec Platform.
 2. Go to **Settings > Deployment** and navigate to the **Supply Chain (SCA)** section.


### PR DESCRIPTION
This is a follow-up to work done in https://github.com/semgrep/semgrep-docs/pull/1589 and is for [this Linear ticket](https://linear.app/semgrep/issue/TEC-64/clarify-blocking-as-it-relates-to-prmr-scans-and-full-scans).

One thing that always gives me pause is that "blocking" isn't strictly "blocking" -- it's Semgrep failing with exit code 1 and then the user has to handle that exit. So, I added that note wherever I thought would be helpful. I also added mentions that blocking works for both full and diff-aware scans, while retaining the PR/MR blocking language that we currently have. Let me know if this is actually muddying the waters and I can revisit how we explain this (do we need a KB-esque guide explaining blocking with all the definitions, including diff-aware vs full scans?)

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
