### PR TITLE
Typo fix in CI environment variables page

### DIFF
--- a/docs/semgrep-ci/ci-environment-variables.md
+++ b/docs/semgrep-ci/ci-environment-variables.md
@@ -51,7 +51,7 @@ Example:
 export SEMGREP_BASELINE_REF="main"
 ```
 :::info
-`SEMGREP_BASELINE_REF` is superceded by `SEMGREP_BASELINE_COMMIT`.
+`SEMGREP_BASELINE_REF` is superseded by `SEMGREP_BASELINE_COMMIT`.
 :::
 
 ### `SEMGREP_BASELINE_COMMIT`

--- a/docs/semgrep-ci/ci-environment-variables.md
+++ b/docs/semgrep-ci/ci-environment-variables.md
@@ -59,7 +59,7 @@ export SEMGREP_BASELINE_REF="main"
 Set `SEMGREP_BASELINE_COMMIT` to a commit hash to only show results that are **not** found in that hash. This environment variable doesn't work if you are not currently in a Git directory, there are unstaged changes, or given baseline hash doesn't exist.
 
 :::info
-The value of `SEMGREP_BASELINE_COMMIT` is superceded when the option `--baseline-commit` is set as part of the scan command.
+The value of `SEMGREP_BASELINE_COMMIT` is superseded when the option `--baseline-commit` is set as part of the scan command.
 :::
 
 ### `SEMGREP_ENABLE_VERSION_CHECK`


### PR DESCRIPTION
I always spell this wrong too, so I'm sensitive to seeing it lol

### Please ensure

- [x] A technical writer reviews the content or PR (xs PR)
