### PR TITLE
Including fork in "new rule based on existing rule" section title

### DIFF
--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -139,7 +139,7 @@ Advanced mode is a YAML editor that allows you to write rules using [Semgrep syn
 :::info Rules syntax
 Refer to [Rule syntax](/writing-rules/rule-syntax) for all possible fields and values to create a rule.
 
-To quickly learn Semgrep patterns and syntax, explore the Editor’s library of rules from the **public [Rule Registry](https://semgrep.dev/explore)**. Rules from the Registry can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. Semgrep Editor enables you to **adapt these rules** for your own organization’s use by [forking](#write-a-new-rule-based-on-an-existing-rule) them.
+To quickly learn Semgrep patterns and syntax, explore the Editor’s library of rules from the **public [Rule Registry](https://semgrep.dev/explore)**. Rules from the Registry can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. Semgrep Editor enables you to **adapt these rules** for your own organization’s use by [forking](#write-a-new-rule-by-forking-an-existing-rule) them.
 :::
 
 To write a rule in advanced mode:
@@ -248,7 +248,7 @@ If successful, you'll see a pop-up window indicating that your rule has been add
 
 [Semgrep Registry](https://semgrep.dev/explore/) is an open-source, community-driven repository of rules. These rules can detect OWASP vulnerabilities, best practice violations, and security issues for various languages and frameworks. You can fork an existing rule to use as a starting point for writing your own.
 
-### Write a new rule based on an existing rule
+### Write a new rule by forking an existing rule
 
 One way to create new rules is to fork an existing rule in Semgrep Registry and modify it to meet your software and business requirements.
 

--- a/docs/semgrep-code/overview.md
+++ b/docs/semgrep-code/overview.md
@@ -65,7 +65,7 @@ semgrep ci --oss-only
 ## Next steps
 
 - [View your findings](/semgrep-code/findings).
-- Customize how Semgrep Code scans your repository by modifying the [default rules set](https://semgrep.dev/p/default) or [writing your own rules](/semgrep-code/editor/#write-a-new-rule-based-on-an-existing-rule).
+- Customize how Semgrep Code scans your repository by modifying the [default rules set](https://semgrep.dev/p/default) or [writing your own rules](/semgrep-code/editor/#write-a-new-rule-by-forking-an-existing-rule).
 - Enable [autofix](/writing-rules/autofix) so that Semgrep can push code suggestions to GitHub or GitLab to help your developers resolve findings.
 - Enable [cross-file scanning](/semgrep-code/semgrep-pro-engine-intro/).
 


### PR DESCRIPTION
The term "fork" which the editor uses was not in the section title, and so this section wasn't showing up when searching for "fork rule". Hopefully this will help without being too specific/not clear to new users.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
