### PR TITLE
Make title of Secrets Path ignores KB more specific

### DIFF
--- a/docs/kb/semgrep-secrets/per-product-ignore-not-working.md
+++ b/docs/kb/semgrep-secrets/per-product-ignore-not-working.md
@@ -4,8 +4,8 @@ tags:
     - Semgrep Secrets
 ---
 
-# Why didn't Semgrep Secrets ignore the files and folders I specified?
+# Why didn't Semgrep ignore the files and folders in the Secrets Path ignores for this project?
 
-The Semgrep AppSec Platform allows you to [define ignore patterns](https://semgrep.dev/docs/ignoring-files-folders-code#define-ignored-files-and-folders-in-semgrep-appsec-platform) for specific Semgrep products for each project. However, product-specific ignores for Semgrep Secrets require Semgrep version `1.71.0` or later in your CLI or CI environment.
+The Semgrep AppSec Platform allows you to [define ignore patterns](https://semgrep.dev/docs/ignoring-files-folders-code#define-ignored-files-and-folders-in-semgrep-appsec-platform) for different Semgrep products for each project. Product-specific ignores for Semgrep Secrets require Semgrep version `1.71.0` or later in your CLI or CI environment.
 
 If you use an older version of Semgrep, the path ignores for Semgrep Secrets that are set in Semgrep AppSec Platform are not applied. Instead, the system applies the path ignores from SAST and SCA to your Secrets scan as well.


### PR DESCRIPTION
There are other reasons Semgrep might not have ignores files or folders in a Secrets scan, so let's specify exactly which ones are relevant for this guidance.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
