### PR TITLE
make quickstart the next link on the homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ hide_title: true
 id: Docs home
 displayed_sidebar: topLevelSidebar
 toc_max_heading_level: 2
-pagination_next: null
+pagination_next: getting-started/quickstart
 description: >-
   Read the documentation and get started with Semgrep.
   A fast, open-source, static analysis engine


### PR DESCRIPTION
Small change:

<img width="1199" alt="image" src="https://github.com/semgrep/semgrep-docs/assets/16521651/1a39e2c3-750d-4f7b-bc44-da8c91b4b9ae">
