### PR TITLE
Show how to reference ellipsis metavariables

### DIFF
--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -509,6 +509,12 @@ match:
 foo(1,2,3,1,2)
 ```
 
+When referencing an ellipsis metavariable in a rule message or [metavariable-pattern](/writing-rules/rule-syntax#metavariable-pattern), include the ellipsis:
+
+```yaml
+- message: Call to foo($...ARGS)
+```
+
 ### Displaying matched metavariables in rule messages
 
 Display values of matched metavariables in rule messages. Add a metavariable to the rule message (for example `Found $X`) and Semgrep replaces it with the value of the detected metavariable.


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

### Context

This confused both me and a customer (who tried to just use `$ARGS` as we would anywhere else). [Playground test](https://semgrep.dev/playground/r/gxU3RYR/relsqui.ellipsis-metavariable-message) to verify I'm right about how it works:

![image](https://github.com/semgrep/semgrep-docs/assets/1859500/8426bac8-2aeb-4629-b365-0553108d579d)