### PR TITLE
Network Broker: Add detail on where to find the org ID

### DIFF
--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -103,16 +103,16 @@ Ensure that you are logged in to the server where you want to run Semgrep Networ
     baseUrl: <https://github.exampleCo.com/api/v3>
   ```
 
-1. Convert your deployment ID to hexadecimal for use in creating your deployment's local address `SEMGREP_LOCAL_ADDRESS`. You can use a tool such as [Decimal to Hexadecimal converter](https://www.rapidtables.com/convert/number/decimal-to-hex.html) if needed.
+1. Convert your organization ID to hexadecimal for use in creating your `SEMGREP_LOCAL_ADDRESS`. The organization ID is found in the **Identifiers** section of the main [Settings page](https://semgrep.dev/orgs/-/settings) in the Semgrep AppSec platform. (You may also hear this called a deployment ID.) You can use a tool such as [Decimal to Hexadecimal converter](https://www.rapidtables.com/convert/number/decimal-to-hex.html) to perform the conversion if needed.
 
-  <pre class="language-console"><code>fdf0:59dc:33cf:9be8:0:<span className="placeholder">DEPLOYMENT_ID</span>:0:1</code></pre>
+  <pre class="language-console"><code>fdf0:59dc:33cf:9be8:0:<span className="placeholder">ORGANIZATION_ID</span>:0:1</code></pre>
 
   Update the `localAddress` field of `config.yaml`;
 
   ```yaml
   inbound:
     wireguard:
-      localAddress: fdf0:59dc:33cf:9be8:0:DEPLOYMENT_ID:0:1
+      localAddress: fdf0:59dc:33cf:9be8:0:ORGANIZATION_ID:0:1
   ```
 
 1. Run the following command to start Semgrep Network Broker with your updated configuration file:

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -103,7 +103,7 @@ Ensure that you are logged in to the server where you want to run Semgrep Networ
     baseUrl: <https://github.exampleCo.com/api/v3>
   ```
 
-1. Convert your organization ID to hexadecimal for use in creating your `SEMGREP_LOCAL_ADDRESS`. The organization ID is found in the **Identifiers** section of the main [Settings page](https://semgrep.dev/orgs/-/settings) in the Semgrep AppSec platform. (You may also hear this called a deployment ID.) You can use a tool such as [Decimal to Hexadecimal converter](https://www.rapidtables.com/convert/number/decimal-to-hex.html) to perform the conversion if needed.
+1. Convert your organization ID to hexadecimal for use in creating your `SEMGREP_LOCAL_ADDRESS`. The organization ID is found in the **Identifiers** section of the [Settings' **Deployment** page](https://semgrep.dev/orgs/-/settings) in Semgrep AppSec Platform. You may also hear this called a deployment ID. You can use a tool such as [Decimal to Hexadecimal converter](https://www.rapidtables.com/convert/number/decimal-to-hex.html) to perform the conversion if needed.
 
   <pre class="language-console"><code>fdf0:59dc:33cf:9be8:0:<span className="placeholder">ORGANIZATION_ID</span>:0:1</code></pre>
 


### PR DESCRIPTION
And prefer organization to deployment based on UI labeling, but note that it's also called deployment ID.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
