### PR TITLE
Add ruleset as a glossary term

### DIFF
--- a/docs/semgrep-code/glossary.md
+++ b/docs/semgrep-code/glossary.md
@@ -41,7 +41,11 @@ Not to be confused with **policy-as-code**.
 
 A [<i class="fas fa-external-link fa-xs"></i> collection of publicly available SAST rules](https://semgrep.dev/r) that you can download. Rules can be filtered by language, OWASP bug class, severity, and so on. Many of these rules are open source, and you can view the license of the rule you are using. Contributions are welcome.
 
-Rules are frequently organized by rulesets, enabling you to find related rules by framework and language.
+Rules are frequently organized by [rulesets](#ruleset), enabling you to find related rules by framework and language.
+
+## Ruleset
+
+Rulesets are rules related through a programming language, OWASP category, or framework. Rulesets are curated by the team at Semgrep and updated as new rules are added to the Semgrep Registry.
 
 ## Scan target
 


### PR DESCRIPTION
The CS AI (and some newer folks) were unclear that "ruleset" is a specific item, so at least define it in the glossary as a start.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
