### PR TITLE
Be more clear that SSC scans must use the supported lockfile names

### DIFF
--- a/docs/kb/semgrep-supply-chain/ssc-python-lockfiles.md
+++ b/docs/kb/semgrep-supply-chain/ssc-python-lockfiles.md
@@ -17,7 +17,7 @@ To correctly scan all dependencies in a project, Semgrep Supply Chain requires a
 * `Pipfile.lock`
 * `Poetry.lock`
 
-You can use any of these three lockfiles to get a successful Semgrep Supply Chain scan.
+You can use any of these three lockfiles to get a successful Semgrep Supply Chain scan. Your lockfiles must have one of these three names in order to be scanned.
 
 ## Generating `requirements.txt`
 
@@ -298,26 +298,10 @@ The generated `Poetry.lock` file contains all transitive and direct dependencies
 
 While there may already be a lockfile in the repository, such as a `Pipfile.lock`, you may want to generate a new one, for example a `requirements.txt`, to be sure it has the latest dependencies.
 
-In Semgrep, you can use the flag `--include` to specify only one lockfile:
+When scanning with Semgrep Supply Chain, you can use the flag `--include` to specify that only a single lockfile should be scanned. The lockfile must still have one of the supported names.
 
 ```
-semgrep --supply-chain --include=requirements.txt
-```
-
-Alternatively, your repository may already have a `requirements.txt` file, but you want to generate a fresh and updated version.
-
-However, generating a new `requirements.txt` file and running the previous command may result in the following error:
-
-```
-[ERROR] Found pending changes in tracked files. Baseline scans runs require a clean git state.
-```
-
-This is due to git conflicts between the previously committed `requirements.txt` file and the newly generated `requirements.txt` file.
-
-A solution to this issue can be to generate the new `requirements.txt` file in a different folder and then specifically include it in the Semgrep scan:
-
-```
-semgrep --supply-chain --include=ssc/requirements.txt
+semgrep ci --supply-chain --include=requirements.txt
 ```
 
 ## Conclusions

--- a/docs/kb/semgrep-supply-chain/why-no-findings.md
+++ b/docs/kb/semgrep-supply-chain/why-no-findings.md
@@ -17,7 +17,8 @@ Check the [Supported Languages table](/supported-languages#semgrep-supply-chain)
 
 Semgrep Supply Chain searches the parent directories of any code files for the nearest relevant lockfile. Monolithic repositories (monorepos) have their findings grouped based on the lockfiles present in subdirectories.
 
-Semgrep Supply Chain only recognizes the lockfile names indicated in the [Supported Languages table](/supported-languages#maturity-levels).
+Semgrep Supply Chain only recognizes the lockfile names indicated in the [Supported Languages table](/supported-languages#semgrep-supply-chain).
+If you do not use the standard lockfile name for your ecosystem, renaming the lockfile to the standard name before scanning with Semgrep in CI is recommended.
 
 [Reach out for help](#if-youre-still-having-trouble) if you run into trouble with lockfile location or naming.
 

--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -28,7 +28,9 @@ This article walks you through the Semgrep Supply Chain configuration and custom
 
 ## Project directory structure
 
-Semgrep Supply Chain requires a [lockfile](/semgrep-supply-chain/glossary/#lockfile). Code files that use the dependencies in the lockfile must be nested in the same directory as the lockfile. Semgrep Supply Chain can correctly parse code files in subfolders as well.
+Semgrep Supply Chain requires a [lockfile](/semgrep-supply-chain/glossary/#lockfile). Your code must use [supported lockfile ecosystems and filenames](/docs/supported-languages#semgrep-supply-chain). 
+
+Semgrep Supply Chain can correctly parse code files and lockfiles in subfolders as well. Code files that use the dependencies in the lockfile must be nested in the same directory as the lockfile. Lockfiles must all use the supported lockfile names.
 
 In the following example, Semgrep Supply Chain assumes that all code files using the dependencies in `my-project/running/lockfile.json` are nested in `my-project/running/` or deeper directories.
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -157,7 +157,9 @@ Visit the Semgrep public language dashboard to see the parse rates for each lang
 
 <SscIntro/>
 
-Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your codebase for reachable findings based on the lockfiles. Some languages, such as Java, have several lockfiles, depending on your repository's package manager. For some languages, such as JavaScript and Python, a manifest file is also parsed to determine [transitivity](/docs/semgrep-supply-chain/glossary/#transitive-or-indirect-dependency).
+Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your codebase for reachable findings based on the lockfiles. Some languages, such as Java, have several supported lockfiles, depending on your repository's package manager. For a lockfile to be scanned by Semgrep Supply Chain, it must have one of the supported lockfile names.
+
+For some languages, such as JavaScript and Python, a manifest file is also parsed to determine [transitivity](/docs/semgrep-supply-chain/glossary/#transitive-or-indirect-dependency).
 
 <table>
 <thead><tr>


### PR DESCRIPTION
Our docs didn't consistently mention / explain that you can literally only use the supported lockfile names - this change attempts to make that clear in multiple places.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
