### PR TITLE
Remove vim extension link

### DIFF
--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -18,10 +18,6 @@ Several third-party tools include Semgrep extensions.
 - IntelliJ Ultimate Idea (and most other IntelliJ products) [`semgrep-intellij`](https://plugins.jetbrains.com/plugin/22622-semgrep)
 - Emacs: [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode)
 
-### Community-contributed IDE extensions
-
-- Vim: [`semgrep.vim`](https://github.com/semgrep/semgrep.vim)
-
 ### The LSP Command
 
 All of our official extensions use the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) to communicate


### PR DESCRIPTION
This is rad, but sadly it hasn't been updated in three years and was archived by the owner a couple of months ago.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
