### PR TITLE
Add link to helpful KB, clarify language a bit

### DIFF
--- a/docs/semgrep-supply-chain/dependency-search.md
+++ b/docs/semgrep-supply-chain/dependency-search.md
@@ -67,6 +67,6 @@ This section describes possible issues and how to resolve them.
 To ensure that your dependencies appear, check the following:
 
 * Ensure that Semgrep Supply Chain can parse your lockfile. Refer to [Supported languages](/supported-languages) for a list of supported languages and lockfiles.
-* Make sure you've scanned the repository at least once.
+* Make sure you've scanned the repository at least once. If you're having trouble seeing dependencies after a scan, check out [Why aren't Supply Chain findings showng?](https://semgrep.dev/docs/kb/semgrep-supply-chain/why-no-findings) for additional troubleshooting tips.
 * If you are using filters, ensure that your filters and search syntax is correct.
-* Ensure that the scan you're referring to isn't a diff-aware scan. Only dependencies scanned off of full scans are shown on the **Dependencies** page. 
+* Ensure that the scan you're referring to isn't a diff-aware scan. Only dependencies scanned from full scans are shown on the **Dependencies** page. 

--- a/docs/semgrep-supply-chain/dependency-search.md
+++ b/docs/semgrep-supply-chain/dependency-search.md
@@ -67,6 +67,6 @@ This section describes possible issues and how to resolve them.
 To ensure that your dependencies appear, check the following:
 
 * Ensure that Semgrep Supply Chain can parse your lockfile. Refer to [Supported languages](/supported-languages) for a list of supported languages and lockfiles.
-* Make sure you've scanned the repository at least once. If you're having trouble seeing dependencies after a scan, check out [Why aren't Supply Chain findings showng?](https://semgrep.dev/docs/kb/semgrep-supply-chain/why-no-findings) for additional troubleshooting tips.
+* Make sure you've scanned the repository at least once. If you're having trouble seeing dependencies after a scan, see [Why aren't Supply Chain findings showng?](https://semgrep.dev/docs/kb/semgrep-supply-chain/why-no-findings) for additional troubleshooting tips.
 * If you are using filters, ensure that your filters and search syntax is correct.
 * Ensure that the scan you're referring to isn't a diff-aware scan. Only dependencies scanned from full scans are shown on the **Dependencies** page. 

--- a/docs/semgrep-supply-chain/dependency-search.md
+++ b/docs/semgrep-supply-chain/dependency-search.md
@@ -69,4 +69,4 @@ To ensure that your dependencies appear, check the following:
 * Ensure that Semgrep Supply Chain can parse your lockfile. Refer to [Supported languages](/supported-languages) for a list of supported languages and lockfiles.
 * Make sure you've scanned the repository at least once. If you're having trouble seeing dependencies after a scan, see [Why aren't Supply Chain findings showng?](https://semgrep.dev/docs/kb/semgrep-supply-chain/why-no-findings) for additional troubleshooting tips.
 * If you are using filters, ensure that your filters and search syntax is correct.
-* Ensure that the scan you're referring to isn't a diff-aware scan. Only dependencies scanned from full scans are shown on the **Dependencies** page. 
+* Ensure that the scan you're referring to isn't a diff-aware scan. Only dependencies detected during full scans are shown on the **Dependencies** page. 


### PR DESCRIPTION
There's a KB about not seeing SSC findings, so refer folks to that if they don't see any dependencies also. I made a small wording change because "off of" seemed weird to me, but maybe "in" is better?

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
