### PR TITLE
Update the slack notifications hyperlink to correctly redirect

### DIFF
--- a/docs/semgrep-appsec-platform/slack.md
+++ b/docs/semgrep-appsec-platform/slack.md
@@ -127,7 +127,7 @@ To check that your notifications are set up, receive a test message from Semgrep
 
 ### Check your filters
 
-If you have set up any filter, such as filtering for a specific policy or project, all conditions of that filter must be present for the notification to be sent. Review your filters by following the steps in [Changing Slack notification settings](#changing-slack-notification-settings).
+If you have set up any filter, such as filtering for a specific policy or project, all conditions of that filter must be present for the notification to be sent. Review your filters by following the steps in [Changing Slack notification settings](#change-slack-notification-settings).
 
 ### Permissions not up-to-date
 


### PR DESCRIPTION
Correcting the hyperlink under "Check your Filters" Section from https://semgrep.dev/docs/semgrep-appsec-platform/slack-notifications#changing-slack-notification-settings to https://semgrep.dev/docs/semgrep-appsec-platform/slack-notifications#change-slack-notification-settings.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
