### PR TITLE
Update CLI reference to use tabs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -9,6 +9,8 @@ hide_title: true
 title: CLI reference
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import CLIHelpOutput from '/src/components/reference/_cli-help-output.md'
 import CLIHelpScanOutput from '/src/components/reference/_cli-help-scan-output.md'
 import CLIHelpCiOutput from '/src/components/reference/_cli-help-ci-output.md'
@@ -35,33 +37,18 @@ Command output:
 
 <CLIHelpOutput />
 
-## Semgrep scan command options
+## `semgrep scan` and `semgrep ci` command options
 
-To list all available `semgrep scan` options, run the following command:
+To list all available `semgrep scan` or `semgrep ci` options, run one of the following commands:
 
-```bash
-semgrep scan --help
-```
-
-Command output:
-
-<CLIHelpScanOutput />
-
-<!-- vale off -->
-
-## Semgrep ci command options
-
-To list all available `semgrep ci` options, run the following command:
-
-```bash
-semgrep ci --help
-```
-
-Command output:
-
-<CLIHelpCiOutput />
-
-<!-- vale on -->
+<Tabs>
+  <TabItem value="semgrep scan --help" label="semgrep scan --help">
+    <CLIHelpScanOutput />
+  </TabItem>
+  <TabItem value="semgrep ci --help" label="semgrep ci --help" default>
+    <CLIHelpCiOutput />
+  </TabItem>
+</Tabs>
 
 ## Ignore files
 


### PR DESCRIPTION
Using tabs for the `scan` vs `ci` output makes a lot more sense to me and looks pretty clear. I know there was discussion around why we didn't use tabs to begin with, but I'm hoping to spark that up again here now that we can also see what it looks like with tabs vs one long scrolling page.

Additionally, CTRL/CMD+F on the webpage is better when using tabs, so you don't get duplicate results.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
