### PR TITLE
Update GHA sample workflow to only do full scan when workflow file changes or on a cron schedule

### DIFF
--- a/src/components/code_snippets/_gha-semgrep-app-sast.mdx
+++ b/src/components/code_snippets/_gha-semgrep-app-sast.mdx
@@ -13,9 +13,13 @@ on:
   pull_request: {}
   # Scan on-demand through GitHub Actions interface:
   workflow_dispatch: {}
-  # Scan mainline branches and report all findings:
+  # Scan mainline branches if there are changes to .github/workflows/semgrep.yml:
   push:
-    branches: ["master", "main"]
+    branches:
+      - main
+      - master
+    paths:
+      - .github/workflows/semgrep.yml
   # Schedule the CI job (this method uses cron syntax):
   schedule:
     - cron: '20 17 * * *' # Sets Semgrep to scan every day at 17:20 UTC.


### PR DESCRIPTION
Changing the sample GHA workflow to better match the workflow used in semgrep.dev, as scanning on every push to main is unnecessary.

See slack convo:

https://semgrepinc.slack.com/archives/C02PV1VVAUR/p1715284784859239

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
