### PR TITLE
Add a caution about using literal metavariables with metavariable-pattern

### DIFF
--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -364,6 +364,25 @@ You can also use `/$X/` and `:$X` to respectively match
 any regular expressions or atoms (in languages that support
 those constructs, e.g., Ruby).
 
+:::caution
+Because literal metavariables bind to strings that may not be valid code, if you want to match them in more detail with a [`metavariable-pattern`](/writing-rules/rule-syntax/#metavariable-pattern), you'll need to [specify `generic` language](/writing-rules/rule-syntax#metavariable-pattern-with-nested-language) inside the `metavariable-pattern`. For example:
+
+```
+rules:
+  - id: match-literal-string
+    languages:
+      - python
+    severity: INFO
+    message: Found "$STRING"
+    patterns:
+      - pattern: '"$STRING"'
+      - metavariable-pattern:
+          language: generic
+          metavariable: $STRING
+          pattern: "literal string contents"
+```
+:::
+
 ### Typed metavariables
 
 #### Syntax

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -364,7 +364,7 @@ You can also use `/$X/` and `:$X` to respectively match
 any regular expressions or atoms (in languages that support
 those constructs, e.g., Ruby).
 
-:::caution
+:::info
 Because literal metavariables bind to strings that may not be valid code, if you want to match them in more detail with a [`metavariable-pattern`](/writing-rules/rule-syntax/#metavariable-pattern), you'll need to [specify `generic` language](/writing-rules/rule-syntax#metavariable-pattern-with-nested-language) inside the `metavariable-pattern`. For example:
 
 ```

--- a/docs/writing-rules/pattern-syntax.mdx
+++ b/docs/writing-rules/pattern-syntax.mdx
@@ -365,7 +365,7 @@ any regular expressions or atoms (in languages that support
 those constructs, e.g., Ruby).
 
 :::info
-Because literal metavariables bind to strings that may not be valid code, if you want to match them in more detail with a [`metavariable-pattern`](/writing-rules/rule-syntax/#metavariable-pattern), you'll need to [specify `generic` language](/writing-rules/rule-syntax#metavariable-pattern-with-nested-language) inside the `metavariable-pattern`. For example:
+Because literal metavariables bind to strings that may not be valid code, if you want to match them in more detail with a [`metavariable-pattern`](/writing-rules/rule-syntax/#metavariable-pattern), you must [specify `generic` language](/writing-rules/rule-syntax#metavariable-pattern-with-nested-language) inside the `metavariable-pattern`. For example:
 
 ```
 rules:


### PR DESCRIPTION
This [came up in the community slack](https://semgrep.slack.com/archives/CK86BJ5DW/p1722930455768219) and it took a little digging to figure out [why my first attempt wasn't working](https://github.com/semgrep/semgrep/issues/6299#issuecomment-1287082436).

It might also be worth clarifying why the pattern here has two sets of quotes (the outer one gets stripped when the yaml file is interpreted -- it's only really necessary because the literal metavariable is the entire pattern) but I wasn't sure how to do that succinctly or if this is where it belonged, so I left it for a future update.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications ~or else you have pinged the security team~
- [ ] ~Redirects are added if the PR changes page URLs~
- [ ] ~If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link~
