### PR TITLE
Point out `-j` in the Bitbucket memory tip

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -291,7 +291,7 @@ You can customize the scan by entering custom rules or other rulesets to scan wi
 </Tabs>
 
 :::tip
-If the pipeline's default runner runs out of memory, you can [add the `size` directive](https://support.atlassian.com/bitbucket-cloud/docs/global-options/#Size) to the Semgrep step to increase the memory available:
+If the pipeline's default runner runs out of memory, you can limit the number of subprocesses Semgrep uses with the [`-j`](/cli-reference) switch, or [add the `size` directive](https://support.atlassian.com/bitbucket-cloud/docs/global-options/#Size) to the Semgrep step to increase the memory available:
 
 ```yaml
 pipelines:

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -291,7 +291,7 @@ You can customize the scan by entering custom rules or other rulesets to scan wi
 </Tabs>
 
 :::tip
-If the pipeline's default runner runs out of memory, you can limit the number of subprocesses Semgrep uses with the [`-j` switch](/cli-reference), or [add the `size` directive](https://support.atlassian.com/bitbucket-cloud/docs/global-options/#Size) to the Semgrep step to increase the memory available:
+If the pipeline's default runner runs out of memory, you can limit the number of subprocesses Semgrep uses with the [`-j` flag](/cli-reference), or [add the `size` directive](https://support.atlassian.com/bitbucket-cloud/docs/global-options/#Size) to the Semgrep step to increase the memory available:
 
 ```yaml
 pipelines:

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -291,7 +291,7 @@ You can customize the scan by entering custom rules or other rulesets to scan wi
 </Tabs>
 
 :::tip
-If the pipeline's default runner runs out of memory, you can limit the number of subprocesses Semgrep uses with the [`-j`](/cli-reference) switch, or [add the `size` directive](https://support.atlassian.com/bitbucket-cloud/docs/global-options/#Size) to the Semgrep step to increase the memory available:
+If the pipeline's default runner runs out of memory, you can limit the number of subprocesses Semgrep uses with the [`-j` switch](/cli-reference), or [add the `size` directive](https://support.atlassian.com/bitbucket-cloud/docs/global-options/#Size) to the Semgrep step to increase the memory available:
 
 ```yaml
 pipelines:


### PR DESCRIPTION
This came from a followup with the same user who suggested the original tip -- it turned out both were necessary in their case. I don't want to make a specific suggestion here because it would require tracking Bitbucket's infrastructure settings, so instead I'm pointing out both tuning tools.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications ~or else you have pinged the security team~
- [ ] ~Redirects are added if the PR changes page URLs~
- [ ] ~If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link~
