### PR TITLE
Add next step hints after forking a rule

### DIFF
--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -269,7 +269,7 @@ The following example shows how [the original rule, identifying uses of `SHA-1` 
 
 <iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=RDxN" width="100%" height="432px" frameBorder="0"></iframe>
 
-When you fork a rule, the copy is independent from the original. To add your new rule to your scans, [add it to your Policies](#add-a-rule-to-the-policies-page). If you want your copy to replace the rule you forked, disable the original on the Policies page.
+When you fork a rule, the copy is independent from the original. To run your new rule in your scans, [add it to a policy](#add-a-rule-to-the-policies-page). If you want your copy to replace the rule you forked, disable the original on the Policies page.
 
 ## Contribute to the open-source Semgrep Registry
 

--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -269,7 +269,7 @@ The following example shows how [the original rule, identifying uses of `SHA-1` 
 
 <iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=RDxN" width="100%" height="432px" frameBorder="0"></iframe>
 
-When you fork a rule, the copy is independent from the original. To run your new rule in your scans, [add it to a policy](#add-a-rule-to-the-policies-page). If you want your copy to replace the rule you forked, disable the original on the Policies page.
+When you fork a rule, the copy is independent from the original. To run your new rule in your scans, [add it to a policy](#add-a-rule-to-the-policies-page). If you want your copy to replace the rule you forked, add it to a policy, then disable the original on the Policies page.
 
 ## Contribute to the open-source Semgrep Registry
 

--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -269,6 +269,8 @@ The following example shows how [the original rule, identifying uses of `SHA-1` 
 
 <iframe title="Prevent use of MD2" src="https://semgrep.dev/embed/editor?snippet=RDxN" width="100%" height="432px" frameBorder="0"></iframe>
 
+When you fork a rule, the copy is independent from the original. To add your new rule to your scans, [add it to your Policies](#add-a-rule-to-the-policies-page). If you want your copy to replace the rule you forked, disable the original on the Policies page.
+
 ## Contribute to the open-source Semgrep Registry
 
 :::info


### PR DESCRIPTION
Another one that came up in customer chat, clarifying how forked rules relate to the originals (not at all) and what you need to do next to use one after creating one.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] ~Redirects are added if the PR changes page URLs~
- [ ] ~If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link~
