### PR TITLE
fix broken link, attempt 2

### DIFF
--- a/docs/semgrep-supply-chain/getting-started.md
+++ b/docs/semgrep-supply-chain/getting-started.md
@@ -80,7 +80,7 @@ Depending on how your CI/CD system is configured, you can trigger a Semgrep Supp
   </tr>
   <tr>
    <td>Pull or merge request</td>
-   <td><a href="/deployment/customize-ci-jobs#set-up-diff-aware-scans">Diff-aware scan</a></td>
+   <td><a href="/docs/deployment/customize-ci-jobs#set-up-diff-aware-scans">Diff-aware scan</a></td>
    <td>All dependency rules</td>
   </tr>
   <tr>


### PR DESCRIPTION
This being an HTML link instead of a markdown link meant that `/docs` wasn't automatically prepended to the link provided.

[Working preview](https://deploy-preview-1704--semgrep-docs-prod.netlify.app/docs/semgrep-supply-chain/getting-started#event-triggered-scans)