### PR TITLE
remove semgrep pro engine, replace with semgrep

### DIFF
--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -71,7 +71,7 @@ The JavaScript and TypeScript ecosystems contain various ways for importing and 
 
 ##### ES6
 
-Semgrep can track data through the definition of exports for es6:
+Semgrep can track data through the definition of exports for ES6:
 
 ```js
 export function readUser() {

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -231,7 +231,7 @@ semgrep --config pro.yaml . --pro
 
 ### Propagating values
 
-In the previous example, it only mattered cared whether the string was constant or not, so the example used `”...”`, but constant propagation also propagates the constant value. To illustrate the use of Semgrep with constant propagation, the rule from the previous section is changed to search for calls to `dangerous("Employees");`.
+In the previous example, it only mattered whether the string was constant or not, so the example used `”...”`, but constant propagation also propagates the constant value. To illustrate the use of Semgrep with constant propagation, the rule from the previous section is changed to search for calls to `dangerous("Employees");`.
 
 #### Java
 

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -144,8 +144,7 @@ class BadRequest extends ExampleException {
 
 Where `ExampleException` is thrown, it is also good to find `BadRequest`, because `BadRequest` is a child of `ExampleException`. Unlike Semgrep OSS, Semgrep can find `BadRequest`. Since Semgrep uses information from all the files in the directory it scans, it detects `BadRequest` and finds both thrown exceptions.
 
-:::tip Try it out
-If you are following in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), in the `docs/class_inheritance` directory, try the following commands to test the difference:
+If you are following along with the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), in the `docs/class_inheritance` directory, try the following commands to test the difference:
 
 1. Run Semgrep OSS:
     ```sh
@@ -155,7 +154,6 @@ If you are following in the cloned [Semgrep testing repository](https://github.c
     ```sh
     semgrep --config pro.yaml . --pro
     ```
-:::
 
 ### Using class inheritance with typed metavariables
 
@@ -169,13 +167,11 @@ The rule searches for any variable of type `ExampleException` being logged. Semg
 For a more realistic example where typed metavariables are used, see the following [rule written by the Semgrep community](https://semgrep.dev/playground/s/o9l6) to find code vulnerable to the log4j vulnerability.
 :::
 
-:::tip Try it out
-Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/class_inheritance_with_typed_metavariables` and run the following command:
+To test this example in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), run Semgrep by going to `docs/class_inheritance_with_typed_metavariables` and entering the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
 ```
-:::
 
 ## Constant propagation
 
@@ -204,13 +200,11 @@ public final class Constants {
 
 Semgrep matches the first call without any change to the rule.
 
-:::tip Try it out
-Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_dangerous_calls` and run the following command:
+To test this through the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), go to `docs/constant_propagation_dangerous_calls` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
 ```
-:::
 
 #### JavaScript and TypeScript
 
@@ -229,7 +223,7 @@ export const EMPLOYEE_TABLE_NAME = "Employees";
 
 Semgrep matches the first call without any change to the rule.
 
-Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_dangerous_calls` and run the following command:
+To test this in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests),go to `docs/constant_propagation_dangerous_calls` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
@@ -245,7 +239,7 @@ In the previous example, it only mattered cared whether the string was constant 
 
 With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
 
-Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_propagating_values` and run the following command:
+To test this in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), go to `docs/constant_propagation_propagating_values` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
@@ -257,7 +251,7 @@ semgrep --config pro.yaml . --pro
 
 With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
 
-Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_propagating_values` and run the following command:
+To test this in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), go to `docs/constant_propagation_propagating_values` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -223,7 +223,7 @@ export const EMPLOYEE_TABLE_NAME = "Employees";
 
 Semgrep matches the first call without any change to the rule.
 
-To test this in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests),go to `docs/constant_propagation_dangerous_calls` and run the following command:
+To test this in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), go to `docs/constant_propagation_dangerous_calls` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -7,49 +7,48 @@ toc_max_heading_level: 5
 
 # Cross-file analysis examples
 
-This document provides an overview of Semgrep cross-file (interfile) analysis features through specific examples, such as its use in type inferences, class inheritance, constant propagation, and taint analysis. Several examples provide a comparison between the results of Semgrep Pro Engine and Semgrep OSS Engine.
+This document provides an overview of Semgrep's proprietary cross-file (interfile) and cross-function (intrafile) taint analysis features through specific examples, such as its use in type inferences, class inheritance, constant propagation, and taint analysis.
+
+Differences between Semgrep and Semgrep OSS can be observed by viewing the examples in a separate Playground tab. See the following section for more information.
+
+Note that Semgrep cross-file analysis implies cross-function analysis as well.
 
 ## Tips and tricks for an interactive experience
 
-The following resources can help you to test the code in the sections below. As you work through the examples in this document, try the following:
+The following resources can help you test the code in the sections below. As you work through the examples in this document, try the following:
 
-- Ensure that the <i class="fa-solid fa-toggle-large-on"></i> **Cross-file analysis** toggle is enabled on the [Playground](https://semgrep.dev/playground/new) page.
-    - Rules you use in Semgrep Pro Engine require `interfile: true` key included in the `options` key. See the following [example](https://semgrep.dev/playground/s/lkPE).
-- The [Semgrep cross-file analysis testing repository](https://github.com/semgrep/semgrep-pro-tests)
-    - Clone the repository:
-        ```sh
-        git clone https://github.com/semgrep/semgrep-pro-tests
-        ```
-    - Follow the instructions in the sections of this document. Generally:
-        - To run Semgrep Pro Engine with cross-file (interfile) analysis, run:
-            ```sh
-            semgrep --pro --config=pro.yaml .
-            ```
-        - To run Semgrep Pro Engine with cross-function (interprocedural) analysis, run:
-            ```sh
-            semgrep --pro-intrafile --config=pro.yaml .
-            ```
+- Ensure that the **<i class="fa-solid fa-gem"></i> Pro** toggle is enabled on the [Playground](https://semgrep.dev/playground/new) page.
+  - Rules that make use of interfile analysis require the `interfile: true` key included under the `options` key.
+  - On the Playground, true positives that are detected by Semgrep's cross-file analysis are marked with a **purple star: <span style={{color: '#b968ff'}}><i class="fa-solid fa-star"></i></span>**.
+- Clone the [Semgrep cross-file analysis testing repository](https://github.com/semgrep/semgrep-pro-tests):
+  ```sh
+  git clone https://github.com/semgrep/semgrep-pro-tests
+   ```
+  - Follow the instructions in the sections of this document. To run Semgrep in the cloned testing repository with cross-file (interfile) analysis, enter:
+    ```sh
+    semgrep --pro --config=pro.yaml .
+    ```
 
 ## Taint tracking
 
 Semgrep OSS allows you to search for the flow of any potentially exploitable input into an important sink using taint mode. For more information, see the [taint mode](/writing-rules/data-flow/taint-mode) documentation.
 
-In the examples below, see a comparison of Semgrep OSS and Semgrep Pro Engine while searching for dangerous calls using data obtained `get_user_input` call. The rule does this by specifying the source of taint as `get_user_input(...)` and the sink as `dangerous(...);`.
+In the examples below, see a comparison of Semgrep and Semgrep OSS  while searching for dangerous calls using data obtained `get_user_input` call. The rule does this by specifying the source of taint as `get_user_input(...)` and the sink as `dangerous(...);`.
 
 ### Java
 
-Semgrep matches `dangerous(“Select * from “ + user_input)`, because `user_input` is obtained by calling `get_user_input`. However, it does not match the similar call using `still_user_input`, because its analysis does not cross function boundaries to know that `still_user_input` is a wrapper function for `user_input`.
+Semgrep matches `dangerous(“Select * from “ + user_input)`, because `user_input` is obtained by calling `get_user_input`. However, on Semgrep OSS, it does not match the similar call using `still_user_input`, because its analysis does not cross function boundaries to know that `still_user_input` is a wrapper function for `user_input`.
 
 <iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=Ab0Zp" width="100%" height="432" frameborder="0"></iframe>
 
-Semgrep Pro Engine matches both dangerous calls because it does cross function boundaries. In fact, with Semgrep Pro Engine, the taint rule can track calls to `get_user_input` over multiple jumps in multiple files.
+Semgrep matches both dangerous calls because it does cross function boundaries. In fact, the taint rule can track calls to `get_user_input` over multiple jumps in multiple files.
 
 :::tip Try it out
-Ensure that the **Pro Engine beta** <i class="fa-solid fa-toggle-large-on"></i> toggle is enabled in the following link to an [example of dangerous taint](https://semgrep.dev/playground/s/J0dQ) rule. To run Semgrep Pro Engine in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/taint_tracking/java` and run the following command:
-
-```sh
-semgrep --config pro.yaml . --pro
-```
+- Turn on the **<i class="fa-solid fa-gem"></i> Pro** toggle in the following link to an [example of dangerous taint](https://semgrep.dev/playground/s/J0dQ) rule.
+- To run Semgrep in the cloned [testing repository](https://github.com/semgrep/semgrep-pro-tests), go to `docs/taint_tracking/java` and run the following command:
+  ```sh
+  semgrep --config pro.yaml . --pro
+  ```
 :::
 
 ### JavaScript and TypeScript
@@ -58,23 +57,21 @@ Here, Semgrep OSS matches `dangerous(“Select * from “ + user_input)`, becaus
 
 <iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=kO41" width="100%" height="432" frameborder="0"></iframe>
 
-Semgrep Pro matches both dangerous calls because it does cross function boundaries. In fact, with Semgrep Pro, the taint rule can track calls to `get_user_input` over multiple jumps in multiple files.
+Semgrep matches both dangerous calls because it does cross function boundaries. In fact, with Semgrep Pro, the taint rule can track calls to `get_user_input` over multiple jumps in multiple files.
 
-:::tip Try it out
-Enable the **Semgrep Pro Engine beta** <i class="fa-solid fa-toggle-large-on"></i> toggle in the following link to an [example of dangerous taint](https://semgrep.dev/s/Po9p). To run Semgrep Pro Engine in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/taint_tracking/javascript` and run the following command:
+You can run JavaScript examples in your cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests) by going to `docs/taint_tracking/javascript` and running the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
 ```
-:::
 
 #### ES6 and CommonJS
 
-The JavaScript and TypeScript ecosystems contain various ways for importing and exporting code, Semgrep Pro Engine can track dataflow through ES6 imports or exports and some CommonJS export paths (See [Known limitations of Semgrep Pro Engine](/semgrep-code/semgrep-pro-engine-intro#known-limitations-of-cross-file-analysis).
+The JavaScript and TypeScript ecosystems contain various ways for importing and exporting code, Semgrep can track dataflow through ES6 imports or exports and some CommonJS export paths (See [Known limitations of cross file analysis](/semgrep-code/semgrep-pro-engine-intro#known-limitations-of-cross-file-analysis).
 
 ##### ES6
 
-Semgrep Pro Engine can track data through the definition of exports for es6:
+Semgrep can track data through the definition of exports for es6:
 
 ```js
 export function readUser() {
@@ -82,7 +79,7 @@ export function readUser() {
 }
 ```
 
-Semgrep Pro Engine can follow the dataflow when it is imported into another location:
+Semgrep can follow the dataflow when it is imported into another location:
 
 ```js
 import { readUser } from "./es6/es6";
@@ -92,7 +89,7 @@ readUser()
 
 ##### CommonJS
 
-Semgrep Pro Engine can track data through the definition of exports for CommonJS when the function is defined inline:
+Semgrep can track data through the definition of exports for CommonJS when the function is defined inline:
 
 ```js
 module.exports = function get_user() {
@@ -106,19 +103,16 @@ const readUser = require("./commonjs/common")
 readUser()
 ```
 
-:::tip Try it out
-To run Semgrep Pro in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/taint_tracking/imports` and run the following command:
-
+You can run examples in your cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests) by going to `docs/taint_tracking/imports` and running the following command:
 ```sh
 semgrep --config pro.yaml . --pro
 ```
-:::
 
 ## Type inference and class inheritance
 
 ### Class inheritance
 
-This section compares the possible findings of a scan across multiple files using Semgrep OSS and Semgrep Pro. The file `app.java` includes two check functions that throw exceptions. This example looks for methods that throw a particular exception, `ExampleException`.
+This section compares the possible findings of a scan across multiple files using Semgrep OSS and Semgrep. The file `app.java` includes two check functions that throw exceptions. This example looks for methods that throw a particular exception, `ExampleException`.
 
 <iframe title="Semgrep example no prints"src="https://semgrep.dev/embed/editor?snippet=yOYk" width="100%" height="432" frameborder="0"></iframe>
 
@@ -148,16 +142,16 @@ class BadRequest extends ExampleException {
 }
 ```
 
-Where `ExampleException` is thrown, we also want to find `BadRequest`, because `BadRequest` is a child of `ExampleException`. Unlike Semgrep OSS, Semgrep Pro Engine can find `BadRequest`. Since Semgrep Pro Engine uses information from all the files in the directory it scans, it detects `BadRequest` and finds both thrown exceptions.
+Where `ExampleException` is thrown, it is also good to find `BadRequest`, because `BadRequest` is a child of `ExampleException`. Unlike Semgrep OSS, Semgrep can find `BadRequest`. Since Semgrep uses information from all the files in the directory it scans, it detects `BadRequest` and finds both thrown exceptions.
 
 :::tip Try it out
-If you are following in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests), in the `docs/class_inheritance` directory, try the following commands to test the difference:
+If you are following in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), in the `docs/class_inheritance` directory, try the following commands to test the difference:
 
 1. Run Semgrep OSS:
     ```sh
     semgrep --config pro.yaml .
     ```
-2. Run Semgrep Pro Engine:
+2. Run Semgrep:
     ```sh
     semgrep --config pro.yaml . --pro
     ```
@@ -165,18 +159,18 @@ If you are following in the cloned [Semgrep Pro Engine testing repository](https
 
 ### Using class inheritance with typed metavariables
 
-Semgrep Pro Engine uses cross-file (interfile) class inheritance information when matching [typed metavariables](/writing-rules/pattern-syntax/#typed-metavariables). Continuing the example from the previous section, see the following example file, which has defined some exceptions and includes their logging:
+Semgrep uses cross-file class inheritance information when matching [typed metavariables](/writing-rules/pattern-syntax/#typed-metavariables). Continuing the example from the previous section, see the following example file, which has defined some exceptions and includes their logging:
 
 <iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=14bk" width="100%" height="432" frameborder="0"></iframe>
 
-The rule searches for any variable of type `ExampleException` being logged. Semgrep is **not** able to find instances of `BadRequest` being logged, unlike Semgrep Pro Engine. Allowing typed metavariables to access information from the entire program enables users to query any variable for its type and use that information in conjunction with the rest of the code resulting in more accurate findings.
+The rule searches for any variable of type `ExampleException` being logged. Semgrep OSS is **not** able to find instances of `BadRequest` being logged, unlike Semgrep. Allowing typed metavariables to access information from the entire program enables users to query any variable for its type and use that information in conjunction with the rest of the code resulting in more accurate findings.
 
 :::note
 For a more realistic example where typed metavariables are used, see the following [rule written by the Semgrep community](https://semgrep.dev/playground/s/o9l6) to find code vulnerable to the log4j vulnerability.
 :::
 
 :::tip Try it out
-Run Semgrep Pro Engine in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/class_inheritance_with_typed_metavariables` and run the following command:
+Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/class_inheritance_with_typed_metavariables` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
@@ -195,7 +189,7 @@ semgrep --config pro.yaml . --pro
 
 Semgrep OSS matches the first and second calls as it cannot find a constant value for either `user_input` or `EMPLOYEE_TABLE_NAME`.
 
-Now consider an example a bit more complicated to illustrate what Semgrep Pro Engine can do. If the `EMPLOYEE_TABLE_NAME` is imported from a global constants file with the following content:
+Now consider an example a bit more complicated to illustrate what Semgrep can do. If the `EMPLOYEE_TABLE_NAME` is imported from a global constants file with the following content:
 
 Global constants file:
 ```java
@@ -208,10 +202,10 @@ public final class Constants {
 }
 ```
 
-Semgrep Pro Engine matches the first call without any change to the rule.
+Semgrep matches the first call without any change to the rule.
 
 :::tip Try it out
-Run Semgrep Pro Engine in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_dangerous_calls` and run the following command:
+Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_dangerous_calls` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
@@ -224,7 +218,7 @@ semgrep --config pro.yaml . --pro
 
 Semgrep matches the first and second calls because Semgrep cannot find a constant value for either `user_input` or `EMPLOYEE_TABLE_NAME`.
 
-Now consider an example a bit more complicated to illustrate what Semgrep Pro Engine can do. If the `EMPLOYEE_TABLE_NAME` is imported from a global constants file with the following content:
+Now consider an example a bit more complicated to illustrate what Semgrep can do. If the `EMPLOYEE_TABLE_NAME` is imported from a global constants file with the following content:
 
 Global constants file:
 ```js
@@ -233,44 +227,38 @@ export const PLANCK_CONSTANT = 6.62606896e-34;
 export const EMPLOYEE_TABLE_NAME = "Employees";
 ```
 
-Semgrep Pro Engine matches the first call without any change to the rule.
+Semgrep matches the first call without any change to the rule.
 
-:::tip Try it out
-Run Semgrep Pro Engine in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_dangerous_calls` and run the following command:
+Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_dangerous_calls` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
 ```
-:::
 
 ### Propagating values
 
-In the previous example, we only cared whether the string was constant or not, so we used `”...”`, but constant propagation also propagates the constant value. To illustrate the use of Semgrep Pro Engine with constant propagation, the rule from the previous section is changed to search for calls to `dangerous("Employees");`.
+In the previous example, it only mattered cared whether the string was constant or not, so the example used `”...”`, but constant propagation also propagates the constant value. To illustrate the use of Semgrep with constant propagation, the rule from the previous section is changed to search for calls to `dangerous("Employees");`.
 
 #### Java
 
 <iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=YqyD" width="100%" height="432" frameborder="0"></iframe>
 
-With Semgrep Pro Engine, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
+With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
 
-:::tip Try it out
-Run Semgrep Pro Engine in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_propagating_values` and run the following command:
+Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_propagating_values` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
 ```
-:::
 
 #### JavaScript and TypeScript
 
 <iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=pORk" width="100%" height="432" frameborder="0"></iframe>
 
-With Semgrep Pro Engine, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
+With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
 
-:::tip Try it out
-Run Semgrep Pro Engine in the cloned [Semgrep Pro Engine testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_propagating_values` and run the following command:
+Run Semgrep in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests). Go to `docs/constant_propagation_propagating_values` and run the following command:
 
 ```sh
 semgrep --config pro.yaml . --pro
 ```
-:::

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -9,7 +9,7 @@ toc_max_heading_level: 5
 
 This document provides an overview of Semgrep's proprietary cross-file (interfile) and cross-function (intrafile) taint analysis features through specific examples, such as its use in type inferences, class inheritance, constant propagation, and taint analysis.
 
-Differences between Semgrep and Semgrep OSS can be observed by viewing the examples in a separate Playground tab. See the following section for more information.
+Differences between Semgrep and Semgrep OSS can be observed by viewing the examples in separate Playground tabs. See the following section for more information.
 
 Note that Semgrep cross-file analysis implies cross-function analysis as well.
 

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -237,7 +237,7 @@ In the previous example, it only mattered cared whether the string was constant 
 
 <iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=YqyD" width="100%" height="432" frameborder="0"></iframe>
 
-With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
+With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently.
 
 To test this in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), go to `docs/constant_propagation_propagating_values` and run the following command:
 

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -24,7 +24,7 @@ The following resources can help you test the code in the sections below. As you
   ```sh
   git clone https://github.com/semgrep/semgrep-pro-tests
    ```
-  - Follow the instructions in the sections of this document. To run Semgrep in the cloned testing repository with cross-file (interfile) analysis, enter:
+  - Follow the instructions in the subsequent sections of this document using this testing repository. To run Semgrep in the cloned testing repository with cross-file (interfile) analysis, enter:
     ```sh
     semgrep --pro --config=pro.yaml .
     ```

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -249,7 +249,7 @@ semgrep --config pro.yaml . --pro
 
 <iframe title="Semgrep example no prints" src="https://semgrep.dev/embed/editor?snippet=pORk" width="100%" height="432" frameborder="0"></iframe>
 
-With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently:
+With Semgrep, this rule matches the last three calls to `dangerous`, since these calls are selected from the `Employees` table, though each one obtains the table name differently.
 
 To test this in the cloned [Semgrep testing repository](https://github.com/semgrep/semgrep-pro-tests), go to `docs/constant_propagation_propagating_values` and run the following command:
 

--- a/docs/semgrep-code/semgrep-pro-engine-examples.md
+++ b/docs/semgrep-code/semgrep-pro-engine-examples.md
@@ -67,7 +67,7 @@ semgrep --config pro.yaml . --pro
 
 #### ES6 and CommonJS
 
-The JavaScript and TypeScript ecosystems contain various ways for importing and exporting code, Semgrep can track dataflow through ES6 imports or exports and some CommonJS export paths (See [Known limitations of cross file analysis](/semgrep-code/semgrep-pro-engine-intro#known-limitations-of-cross-file-analysis).
+The JavaScript and TypeScript ecosystems contain various ways for importing and exporting code. Semgrep can track dataflow through ES6 imports or exports and some CommonJS export paths. See [Known limitations of cross file analysis](/semgrep-code/semgrep-pro-engine-intro#known-limitations-of-cross-file-analysis).
 
 ##### ES6
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -204,6 +204,7 @@ module.exports = {
                 'semgrep-code/triage-remediation',
                 'ignoring-files-folders-code',
                 'semgrep-code/semgrep-pro-engine-intro',
+                'semgrep-code/semgrep-pro-engine-examples',
                 'semgrep-code/remove-duplicates',
                 'semgrep-code/editor',
                 'semgrep-code/pro-rules',


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link


### What
- Adds back Semgrep Pro Engine examples to the sidebars.
- Simplifies explanation of proprietary semgrep (**both** cross-file and cross-function taint analysis).
- Removes excessive callouts.