### PR TITLE
add warning about needing to be signed in to use semgrep ci

### DIFF
--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -20,13 +20,6 @@ Learn how to set up Semgrep, scan your project for security issues using Semgrep
 
 Before proceeding, see [Prerequisites](/prerequisites) to ensure that your machine meets Semgrep's requirements.
 
-## Recommended setup
-
-For scans using `semgrep ci`:
-
-* Ensure that you have and are logged in to your [Semgrep Account](https://semgrep.dev/login).
-* Ensure that you've enabled the **Cross-file analysis** <i class="fa-solid fa-toggle-large-on"></i> toggle on Semgrep AppSec Platform's [Settings](https://semgrep.dev/orgs/-/settings) page.
-
 ## Set up Semgrep
 
 <Install />
@@ -35,6 +28,17 @@ For scans using `semgrep ci`:
 
 <Login />
 
+:::warning
+Semgrep scans triggered using `semgrep ci` fail if you aren't signed in to your Semgrep account.
+:::
+
+## Enable cross-file analysis
+
+To enable [cross-file analysis](/semgrep-code/semgrep-pro-engine-intro), which allows you to detect vulnerabilities across files and folders:
+
+1. [Sign in to Semgrep AppSec Platform](https://semgrep.dev/login) if you haven't already.
+2. Navigate to [Settings > Deployment](https://semgrep.dev/orgs/-/settings).
+3. Click the **Cross-file analysis** <i class="fa-solid fa-toggle-large-on"></i> toggle to enable cross-file analysis.
 
 ## Scan your project
 

--- a/src/components/procedure/_login-activate.mdx
+++ b/src/components/procedure/_login-activate.mdx
@@ -1,7 +1,7 @@
 1. Log in to your Semgrep account. Running this command launches a browser window, but you can also use the link that's returned in the CLI to proceed:
 
-  ```console
-  semgrep login
-  ```
+    ```console
+    semgrep login
+    ```
 
 2. In the **Semgrep CLI login**, click **Activate** to proceed.


### PR DESCRIPTION
The quickstart explicitly tells users to sign in, so I opted not to add any admonitions; let me know if you think we should have them anyway