### PR TITLE
update pnpm yarn

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -16,8 +16,6 @@ import SscIntro from "/src/components/concept/_ssc-intro.md"
 import SemgrepProEngineIntroduction from "/src/components/concept/_semgrep-pro-engine-introduction.mdx"
 import AdmonitionSotCves from "/src/components/reference/_admonition-sot-cves.md"
 
-
-
 # Supported languages
 
 This document provides information about supported languages and language maturity definitions for the following products:
@@ -210,13 +208,13 @@ For some languages, such as JavaScript and Python, a manifest file is also parse
    <td>Yarn, Yarn 2, Yarn 3</td>
    <td><code>yarn.lock</code></td>
    <td style={{"text-align": "center"}}>GA</td>
-   <td>--</td>
+   <td>✅</td>
   </tr>
   <tr>
    <td>pnpm</td>
    <td><code>pnpm-lock.yaml</code></td>
    <td style={{"text-align": "center"}}>GA</td>
-   <td>--</td>
+   <td>✅</td>
   </tr>
   <tr>
    <td rowspan="4">Python</td>
@@ -312,6 +310,7 @@ _**††**Semgrep Supply Chain supports `requirements.txt` when it is used as a
 _**§** Supply Chain does not analyze the transitivity of packages for these language or lockfile combinations. All dependencies are listed as **Unknown** transitivity._
 
 <AdmonitionSotCves />
+
 
 :::info Transitivity support
 For more information on transitivity, see [Transitive dependencies and reachability analysis](/docs/semgrep-supply-chain/overview/#transitive-dependencies-and-reachability-analysis).


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

**We now support license detection for pnpm and yarn 2 & 3**

Here is a preview:

![image](https://github.com/user-attachments/assets/0f83351c-9992-4f91-8f3d-c412de897bf7)

Additionally, I am aware we are working on backfilling till may 2017 so just let us know when to update the date, as well.