### PR TITLE
Refer to new pre-commit repo

### DIFF
--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -32,7 +32,7 @@ The [pre-commit framework](https://pre-commit.com/) can run `semgrep` at commit-
 
 ```yaml
 repos:
-- repo: https://github.com/semgrep/semgrep
+- repo: https://github.com/semgrep/pre-commit
   rev: 'SEMGREP_VERSION_LATEST'
   hooks:
     - id: semgrep
@@ -44,7 +44,7 @@ The pre-commit can also run custom rules and rulesets from Semgrep Code, similar
 
 ```yaml
 repos:
-- repo: https://github.com/semgrep/semgrep
+- repo: https://github.com/semgrep/pre-commit
   rev: 'SEMGREP_VERSION_LATEST'
   hooks:
     - id:  semgrep-ci


### PR DESCRIPTION
Asking users to clone all of semgrep to use pre-commit was a lot, so we made a separate pre-commit repo that is now automatically updated on each Semgrep release.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team