### PR TITLE
remove extra character

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -7,7 +7,7 @@
 | C#         | GA | ✅ | ✅  |
 | Go         | GA | ✅ | ✅  |
 | Java       | GA | ✅  | ✅  |
-| JavaScript | GA | ✅ s | ✅  |
+| JavaScript | GA | ✅  | ✅  |
 | Kotlin     | GA | ✅  | ✅  | 
 | [Python](/docs/semgrep-code/supported-languages-python)     | GA | ✅  | ✅  | 
 | TypeScript | GA | ✅  | ✅  |


### PR DESCRIPTION
there was a stray character in the supported languages table.