### PR TITLE
No support for Entra with OpenID currently

### DIFF
--- a/docs/deployment/sso.md
+++ b/docs/deployment/sso.md
@@ -21,6 +21,10 @@ This article walks you through single-sign on (SSO) configuration. Semgrep suppo
 
 ## OpenID Connect / OAuth 2.0
 
+:::warning
+Semgrep AppSec Platform does not support using OpenID with Microsoft Entra ID. Follow the instructions for [setting up SAML SSO with Microsoft Entra ID](#set-up-saml-sso-with-microsoft-entra-id) instead.
+:::
+
 To set up SSO in Semgrep AppSec Platform:
 
 1. Sign in to Semgrep AppSec Platform.


### PR DESCRIPTION
Our app doesn't support Microsoft Entra with OpenID; add a warning and redirect users to setting up with SAML.

Authentication is security-related, but this aspect of it is logistical (which type of SSO to use) so I've checked the box below that the change has no security implications.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
