### PR TITLE
Be clear that removing the workflow file is typical but optional

### DIFF
--- a/docs/deployment/managed-scanning.md
+++ b/docs/deployment/managed-scanning.md
@@ -109,7 +109,9 @@ Repositories must be accessible to both the public Semgrep GitHub app and the pr
 You can immediately add any existing project to Managed Scans.
 
 1. Follow the steps in [Add a repository](#add-a-repository-to-semgrep-managed-scans).
-1. Delete the `/.github/workflows/semgrep.yml` file in your GitHub repository.
+1. Delete the `/.github/workflows/semgrep.yml` file in your GitHub repository if appropriate.
+
+If you plan to continue running some scans in GitHub Actions (for example, using Managed Scans to run weekly full scans but GitHub Actions for diff-aware scans) you can leave the workflow file in place, and edit it to reflect your desired configuration.
 
 :::tip
 Semgrep preserves your findings, scans, and triage history.


### PR DESCRIPTION
Some folks are not converting fully to Managed Scans for every repo they migrate, so this explains that you can retain the workflow file if it's appropriate.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
