### PR TITLE
Correct API URLs for GH/GL

### DIFF
--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -98,14 +98,14 @@ Update the `config.yaml` by replacing the SCM information containing `YOUR_BASE_
 For GitLab: 
 <pre class="language-console"><code>
 gitlab:
-&nbsp;&nbsp;baseURL: https://<span className="placeholder">GITLAB_BASE_URL</span>/rest/api/latest
+&nbsp;&nbsp;baseURL: https://<span className="placeholder">GITLAB_BASE_URL</span>/api/v4
 &nbsp;&nbsp;token: <span className="placeholder">GITLAB_PAT</span>
 </code></pre>
 
 For GitHub:
 <pre class="language-console"><code>
 github:
-&nbsp;&nbsp;baseURL: https://<span className="placeholder">GITHUB_BASE_URL</span>/rest/api/latest
+&nbsp;&nbsp;baseURL: https://<span className="placeholder">GITHUB_BASE_URL</span>/api/v3
 &nbsp;&nbsp;token: <span className="placeholder">GITHUB_PAT</span>
 </code></pre>
 


### PR DESCRIPTION
When the formatting for these URLs was redone, they were also all set to the same path value after the base URL, but that's not right - the API path for each SCM is different and needs to be correct or the customer's config won't work.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
