### PR TITLE
Add check runs whitelist for NB with SMS

### DIFF
--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -180,7 +180,9 @@ inbound:
 
 ## Use Semgrep Network Broker with Managed Scans
 
-Semgrep Managed Scans uses Semgrep Network Broker to connect to your internal source code management instance. To clone repositories for scanning from any organization or group, the URL allowlist must include the base URL of your instance. For example, if your source code manager is at `https://git.example.com/`, the following allowlist will permit cloning repositories:
+Semgrep Managed Scans uses Semgrep Network Broker to connect to your internal source code management instance. 
+
+To clone repositories for scanning from any organization or group, the URL allowlist must include the base URL of your instance. For example, if your source code manager is at `https://git.example.com/`, the following allowlist will permit cloning repositories:
 
 ```yaml
 inbound:
@@ -189,6 +191,17 @@ inbound:
     - url: https://git.example.com/*
       methods: [GET, POST]
 ```
+
+Semgrep also creates and updates [GitHub Checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#checks) when performing Managed Scans on pull requests. To ensure checks can be both created and updated, add the `PATCH` method to the preceding allowlist example, or add a separate entry to allowlist check updates:
+
+```
+inbound:
+  allowlist:
+    # allow PATCH requests to update checks
+    - url: https://git.example.com/api/v3/repos/:owner/:repo/check-runs/:id
+      methods: [GET, POST, PATCH]
+```
+
 ## Run multiple instances of the Semgrep Network Broker
 
 You can run multiple instances of the Semgrep Network Broker to manage availability. Semgrep handles multiple requests accordingly, preventing issues like duplicate PR or MR comments. However, you may see some noise in your logs since the Broker hasn't been architected yet for this specific configuration.


### PR DESCRIPTION
Check run updates specifically require a PATCH, which we didn't have in the allowlist we suggest for SMS. This adds it.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team

I don't think this change has security implications, inasmuch as we're already advising whitelisting the whole instance for GET/POST, but feel free to request security review if you disagree!