### PR TITLE
correct misspelling of 'default'

### DIFF
--- a/src/components/reference/_cli-help-ci-output.md
+++ b/src/components/reference/_cli-help-ci-output.md
@@ -99,7 +99,7 @@ OPTIONS
 
        --exclude-minified-files
            Skip minified files. These are files that are > 7% whitespace, or
-           who have a large number of bytes per line. By defualt minified
+           who have a large number of bytes per line. By default minified
            files are scanned 
 
        --exclude-rule=VAL

--- a/src/components/reference/_cli-help-scan-output.md
+++ b/src/components/reference/_cli-help-scan-output.md
@@ -120,7 +120,7 @@ OPTIONS
 
        --exclude-minified-files
            Skip minified files. These are files that are > 7% whitespace, or
-           who have a large number of bytes per line. By defualt minified
+           who have a large number of bytes per line. By default minified
            files are scanned 
 
        --exclude-rule=VAL


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

closes #1798