### PR TITLE
follow up clean up

### DIFF
--- a/docs/usage-and-billing.mdx
+++ b/docs/usage-and-billing.mdx
@@ -28,7 +28,7 @@ A **contributor** is someone who has made at least **one** commit to a Semgrep-s
 
 Any type of Semgrep AppSec Platform scan counts towards the contributor total. This includes:
 
-- Scanning with Code or Supply Chain.
+- Scanning with Semgrep Code or Supply Chain.
 - Full scans on a repository or partial scans on a pull or merge request.
 
 ### Multiple Semgrep organization accounts

--- a/docs/usage-and-billing.mdx
+++ b/docs/usage-and-billing.mdx
@@ -71,7 +71,7 @@ Public projects have no limits on contributors.
 ### Semgrep CLI commands subject to usage limits
 
 - The `semgrep scan` command is subject to the usage limit only if the scan is by a logged-in contributor.
-- Semgrep computes contributor counts for any logged-in scan command (for example, `semgrep ci` and `semgrep scan`.
+- Semgrep computes contributor counts for any logged-in scan command such as `semgrep ci` and `semgrep scan`.
 
 ## Determine your plan needs
 
@@ -87,7 +87,7 @@ All members of the organization, regardless of contributor (license) status, hav
 
 ### Single-product purchases
 
-You can choose to purchase a single product. Products can also be disabled from the [Settings page](https://semgrep.dev/orgs/-/settings).
+You can choose to purchase a single product. Products can also be turned off from the [Settings page](https://semgrep.dev/orgs/-/settings).
 
 ### Number of licenses per product
 
@@ -120,11 +120,11 @@ To upgrade to the **Team tier** using a credit card:
 
 ![Payment menu](/img/billing-and-pricing-payment.png)<br />
 
-To purchase licenses for Semgrep Secrets, or to upgrade to the **Enterprise tier**, please [contact us](https://semgrep.dev/contact-us).
+To purchase licenses for Semgrep Secrets, or to upgrade to the **Enterprise tier**, please [contact Semgrep](https://semgrep.dev/contact-us).
 
 ### Billing
 
-Team tier users who pay through a credit card are charged monthly. Enterprise tier users are charged at an agreed-upon billing cycle. For any concerns such as custom payment methods and billing cycles, send an email to [billing@semgrep.com](mailto:billing@semgrep.com) to get in touch with our sales team.
+Team tier users who pay through a credit card are charged monthly. Enterprise tier users are charged at an agreed-upon billing cycle. For any concerns such as custom payment methods and billing cycles, send an email to the Semgrep sales team at [billing@semgrep.com](mailto:billing@semgrep.com).
 
 ## Modify or cancel your plan
 
@@ -139,8 +139,7 @@ Pay through the following methods:
   <dd>The payment will be processed through Stripe. If you need to change the credit card on file, please reach out to <a href="mailto:billing@semgrep.com">billing@semgrep.com</a>, and Semgrep will contact you for your updated credit card information.</dd>
   <dt>Pay through a purchase order or invoice.</dt>
   <dd>
-    Send an email to <a href="mailto:billing@semgrep.com">billing@semgrep.com</a> to get in touch
-    with our sales team.
+    Send an email to <a href="mailto:billing@semgrep.com">billing@semgrep.com</a>.
   </dd>
 </dl>
 

--- a/docs/usage-and-billing.mdx
+++ b/docs/usage-and-billing.mdx
@@ -11,9 +11,6 @@ hide_title: true
 
 # Usage and billing
 
-
-<!-- tk change all mentions of semgrep pro to semgrep appsec platform -->
-
 Learn about usage computation and other aspects of your Semgrep licenses.
 
 :::note
@@ -22,9 +19,8 @@ Learn about usage computation and other aspects of your Semgrep licenses.
 
 ## Usage
 
-All Semgrep Pro products are free under the **Team** tier for **10 monthly contributors**. These products include:
+Several Semgrep AppSec Platform products are free under the **Team** tier for **10 monthly contributors**. These products include:
 
-- Semgrep AppSec Platform
 - Semgrep Code
 - Semgrep Supply Chain
 
@@ -32,7 +28,7 @@ A **contributor** is someone who has made at least **one** commit to a Semgrep-s
 
 Any type of Semgrep AppSec Platform scan counts towards the contributor total. This includes:
 
-- Scanning with any Semgrep AppSec Platform product (Code, Supply Chain, and so on).
+- Scanning with Code or Supply Chain.
 - Full scans on a repository or partial scans on a pull or merge request.
 
 ### Multiple Semgrep organization accounts
@@ -74,7 +70,8 @@ Public projects have no limits on contributors.
 
 ### Semgrep CLI commands subject to usage limits
 
-The `semgrep scan` command is subject to the usage limit only if the scan is by a logged-in contributor. Semgrep computes contributor counts for any logged-in scan command (for example, `semgrep ci`, `semgrep scan`, and so on) when the Pro Engine, Supply Chain, or Pro rules are used.
+- The `semgrep scan` command is subject to the usage limit only if the scan is by a logged-in contributor.
+- Semgrep computes contributor counts for any logged-in scan command (for example, `semgrep ci` and `semgrep scan`.
 
 ## Determine your plan needs
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR


Updates to remove Semgrep Pro from the doc and position Semgrep AppSec Platform (Semgrep) as the totality of our paid offering. Also simplifies wording around logged-in scans counting towards contributor count