### PR TITLE
update valign to top

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -107,6 +107,8 @@ Semgrep Supply Chain parses **lockfiles** for dependencies, then scans your code
 
 For some languages, such as JavaScript and Python, a manifest file is also parsed to determine [transitivity](/docs/semgrep-supply-chain/glossary/#transitive-or-indirect-dependency). For more information on transitivity, see [Transitive dependencies and reachability analysis](/docs/semgrep-supply-chain/overview/#transitive-dependencies-and-reachability-analysis).
 
+<div class="language-support-table">
+
 <table>
 <thead><tr>
     <th>Language</th>
@@ -211,7 +213,7 @@ For some languages, such as JavaScript and Python, a manifest file is also parse
    <td><code>cargo.lock</code></td>
    <td style={{"text-align": "center"}}>Lockfile-only</td>
    <td>✅</td>
-   <td rowspan="8">Not applicable due to reachability support level</td>
+   <td rowspan="6">Not applicable due to reachability support level</td>
 </tr>
 <tr>
    <td>Dart</td>
@@ -250,7 +252,7 @@ For some languages, such as JavaScript and Python, a manifest file is also parse
 </tr>
   </tbody>
 </table>
-
+</div>
 _**§** Supply Chain does not analyze the transitivity of packages for these language and lockfile combinations. All dependencies are listed as **No Reachability Analysis.**_
 
 ### Maturity levels

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -1,4 +1,4 @@
-<div id="language-support-table">
+<div class="language-support-table">
 
 <table>
     <thead><tr>

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -838,3 +838,6 @@ a[class*=cardContainer_][class~=card]  {
     }
 }
 
+.language-support-table table td {
+    vertical-align: top;
+}


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

Milan pointed out that on long tables (multiple rowspans) the cell may appear empty at the top of the fold or a typical 900px macbook viewport, because the valign is at the middle of the rowspan, which is not (yet) visible.

Fix: valign to top.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
