### PR TITLE
Readability improvements in mobile

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ The code is kept here for easy maintenance.
     <div class="card__copy">
         <CardHeader>Get started</CardHeader>
         <CardBody>
-          Run your first Semgrep scan. 
+          Run your first Semgrep scan.<br />
         </CardBody>
     </div>
   </Card>

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ The code is kept here for easy maintenance.
   <h1>Semgrep <span style={{color: "#624DEF"}}>docs</span></h1>
 </div>
 
-<h5 class='home' style={{margin: '0px 0px 8px 0px'}}>Find bugs and reachable dependency vulnerabilities in code.<br />Enforce your code standards on every commit.</h5>
+<h5 class='home' style={{margin: '0px 0px 8px 0px'}}>Find bugs and reachable dependency vulnerabilities in code.<br />Enforce your code standards on every&nbsp;commit.</h5>
 
 <h3>Scan with Semgrep AppSec Platform</h3>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,17 +21,17 @@ Substitute the "dark:" logo path in case a new dark logo is made.
 The code is kept here for easy maintenance.
 -->
 
-<div style={{display: 'inline-flex', paddingTop: '32px'}}>
-<a href="https://semgrep.dev">
-  <ThemedImage
-    alt="Semgrep themed logo"
-    height="48px"
-    sources={{
-      light: ('img/semgrep.svg#no-shadow'),
-      dark: ('img/semgrep.svg#no-shadow'),
-    }} />
-</a>
-<h1>&nbsp;Semgrep <span style={{color: "#624DEF"}}>docs</span></h1>
+<div class='logo-index'>
+  <a href="https://semgrep.dev">
+    <ThemedImage
+      alt="Semgrep themed logo"
+      height="48px"
+      sources={{
+        light: ('img/semgrep.svg#no-shadow'),
+        dark: ('img/semgrep.svg#no-shadow'),
+      }} />
+  </a>
+  <h1>Semgrep <span style={{color: "#624DEF"}}>docs</span></h1>
 </div>
 
 <h5 class='home' style={{margin: '0px 0px 8px 0px'}}>Find bugs and reachable dependency vulnerabilities in code.<br />Enforce your code standards on every commit.</h5>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,8 +39,8 @@ module.exports = {
     navbar: {
       logo: {
         alt: 'Semgrep logo',
-        src: 'img/semgrep.svg',
-        srcDark: 'img/semgrep.svg',
+        src: 'img/semgrep-icon-text-horizontal.svg',
+        srcDark: 'img/semgrep-icon-text-horizontal-dark.svg',
         href: 'https://semgrep.dev',
         target: '_self'
       },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,8 +39,8 @@ module.exports = {
     navbar: {
       logo: {
         alt: 'Semgrep logo',
-        src: 'img/semgrep-icon-text-horizontal.svg',
-        srcDark: 'img/semgrep-icon-text-horizontal-dark.svg',
+        src: 'img/semgrep.svg',
+        srcDark: 'img/semgrep.svg',
         href: 'https://semgrep.dev',
         target: '_self'
       },

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -910,7 +910,7 @@ input#search_input_react {
 } 
 .navbar__search-input {
   @media (min-width: calc(380px + 1px)) {
-    width: 10rem;
+    width: 10rem !important;
   }
 }
 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -174,18 +174,11 @@ html[data-theme="light"] {
   img {
       box-shadow: var(--semgrep-docs-box-shadow);
       border-radius: var(--ifm-code-border-radius);
-      margin-bottom: 4px;
       border: var(--semgrep-docs-border);
   }
 
   .home {
       color: var(--semgrep-secondary-blue03);
-  }
-
-  h5.home {
-      @media screen and (max-width: 450px) {
-        font-size: 18px;
-      }
   }
 
   .card__copy > h6 {
@@ -436,29 +429,44 @@ h1 {
     font-size: 45px;
     line-height: 1.1;
     letter-spacing: -0.03em;
+    @media screen and (max-width: 450px) {
+      font-size: 36px;
+    }
 }
 
 h2 {
     font-size: 36px;
     line-height: 1.2;
     letter-spacing: -0.02em;
+    @media screen and (max-width: 450px) {
+      font-size: 30px;
+    }
 }
 
 h3 {
     font-size: 30px;
     line-height: 1.2;
     letter-spacing: -0.02em;
+    @media screen and (max-width: 450px) {
+      font-size: 24px;
+    }
 }
 
 h4 {
     font-size: 24px;
     line-height: 1.3;
     letter-spacing: -0.01em;
+    @media screen and (max-width: 450px) {
+      font-size: 20px;
+    }
 }
 
 h5 {
     font-size: 20px;
     line-height: 1.4;
+    @media screen and (max-width: 450px) {
+      font-size: 17px;
+    }
 }
 
 h6 {
@@ -787,13 +795,19 @@ a.card:hover {
     @media screen and (max-width: 1480px) {
       font-size: 16px;
     }
-    @media screen and (max-width: 1366px - 1px) {
-      min-height: 48px;
-    }
     @media screen and (max-width: 450px) {
+      font-size: 14px;
+    }
+    @media screen and (max-width: 410px) {
       font-size: 12px;
     }
   }
+}
+
+.card-50 > .card__copy > .card__body {
+    @media screen and (max-width: 1366px - 1px) {
+      min-height: 64px;
+    }
 }
 
 .card__image {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -904,9 +904,12 @@ Index
 
 
 input#search_input_react {
-  width: 100%;
+  @media (max-width: 380px) {
+    width: 100%;
+  }
 }
-
-navbarSearchContainer_node_modules-@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module {
-  width: 33%; 
+.navbarSearchContainer_node_modules-\@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module {
+  @media (max-width: 380px) {
+    width: 33%;
+  }
 }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -901,3 +901,12 @@ Index
       padding-top: 8px;
   }
 }
+
+
+input#search_input_react {
+  width: 100%;
+}
+
+navbarSearchContainer_node_modules-@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module {
+  width: 33%; 
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -182,6 +182,12 @@ html[data-theme="light"] {
       color: var(--semgrep-secondary-blue03);
   }
 
+  h5.home {
+      @media screen and (max-width: 450px) {
+        font-size: 18px;
+      }
+  }
+
   .card__copy > h6 {
     color: var(--semgrep-secondary-purple01);
   }
@@ -817,7 +823,9 @@ a[class*=cardContainer_][class~=card]  {
  *                                                                            *
  *****************************************************************************/
 
-/* columns */
+/* ----------------------------------------------------------------------------
+Semgrep vs Semgrep OSS
+---------------------------------------------------------------------------- */
 .col-3-grid > * {
     border-right: 1px solid var(--semgrep-grey-300);
 }
@@ -856,6 +864,10 @@ a[class*=cardContainer_][class~=card]  {
  *                                                                            *
  *****************************************************************************/
 
+
+/* ----------------------------------------------------------------------------
+Index
+---------------------------------------------------------------------------- */
 .language-support-table table td {
     vertical-align: top;
 }
@@ -864,7 +876,6 @@ a[class*=cardContainer_][class~=card]  {
   display: flex;
   padding-top: 32px;
   column-gap: 16px;
-  align-items: 'center';
   @media (max-width:475px) {
       flex-direction: column;
   }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -473,7 +473,7 @@ h6 {
   font-size: 17px;
 }
 
-p {
+p, ul, li, ol {
   @media screen and (max-width: 450px) {
     font-size: 14px;
   }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -439,7 +439,7 @@ h2 {
     line-height: 1.2;
     letter-spacing: -0.02em;
     @media screen and (max-width: 450px) {
-      font-size: 30px;
+      font-size: 26px;
     }
 }
 
@@ -471,6 +471,12 @@ h5 {
 
 h6 {
   font-size: 17px;
+}
+
+p {
+  @media screen and (max-width: 450px) {
+    font-size: 14px;
+  }
 }
 
 dt {

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -908,8 +908,9 @@ input#search_input_react {
     width: 100%;
   }
 }
-.navbarSearchContainer_node_modules-\@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module {
+
+.navbar__items--right>:last-child {
   @media (max-width: 380px) {
     width: 33%;
   }
-}
+} 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -473,7 +473,7 @@ h6 {
   font-size: 17px;
 }
 
-p, ul, li, ol, tr, td {
+p, ul, li, ol, tr, td, summary {
   @media screen and (max-width: 450px) {
     font-size: 14px;
   }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -473,7 +473,7 @@ h6 {
   font-size: 17px;
 }
 
-p, ul, li, ol, tr, td, summary {
+p, ul, li, ol, tr, td, summary, dl, dd {
   @media screen and (max-width: 450px) {
     font-size: 14px;
   }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -779,10 +779,13 @@ a.card:hover {
   width: 100%;
   p {
     @media screen and (max-width: 1480px) {
-      font-size: 14px;
+      font-size: 16px;
     }
     @media screen and (max-width: 1366px - 1px) {
-      font-size: 16px;
+      min-height: 48px;
+    }
+    @media screen and (max-width: 450px) {
+      font-size: 12px;
     }
   }
 }
@@ -793,10 +796,14 @@ a.card:hover {
   border-radius: unset;
   height: 100%;
   object-fit: cover;
-  width: 25%;
+  /* width: 25%; */
+    @media screen and (max-width: 450px) {
+      width: 30%;
+    }
+  /*
   @media screen and (max-width: 1366px - 1px) {
     width: 15%;
-  }
+  } */
 }
 
 a[class*=cardContainer_][class~=card]  {
@@ -858,9 +865,7 @@ a[class*=cardContainer_][class~=card]  {
   padding-top: 32px;
   column-gap: 16px;
   align-items: 'center';
-}
-@media (max-width:475px) {
-  .logo-index {
+  @media (max-width:475px) {
       flex-direction: column;
   }
 }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -907,10 +907,16 @@ input#search_input_react {
   @media (max-width: 380px) {
     width: 100%;
   }
+} 
+.navbar__search-input {
+  @media (min-width: calc(380px + 1px)) {
+    width: 10rem;
+  }
 }
 
 .navbar__items--right>:last-child {
   @media (max-width: 380px) {
     width: 33%;
   }
-} 
+}
+

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -473,7 +473,7 @@ h6 {
   font-size: 17px;
 }
 
-p, ul, li, ol {
+p, ul, li, ol, tr, td {
   @media screen and (max-width: 450px) {
     font-size: 14px;
   }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -896,7 +896,8 @@ Index
   display: flex;
   padding-top: 32px;
   column-gap: 16px;
-  @media (max-width:475px) {
+  @media (max-width: 475px) {
       flex-direction: column;
+      padding-top: 8px;
   }
 }

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -310,6 +310,7 @@ html[data-theme="dark"] {
 details.alert {
     background: unset;
 }
+
 /******************************************************************************
  *                                                                            *
  * SIDEBAR                                                                    *
@@ -524,7 +525,11 @@ li > img {
   padding-top: 4px;
 }
 
-/* navbar */
+/******************************************************************************
+ *                                                                            *
+ * NAVBAR                                                                     *
+ *                                                                            *
+ *****************************************************************************/
 
 /* announcement banner */
 .announcementBar_node_modules-\@docusaurus-theme-classic-lib-next-theme-AnnouncementBar-styles-module {
@@ -716,6 +721,7 @@ article > a[class*="cardContainer_"][class~="card"] {
  *                                                                            *
  * CARDS                                                                      *
  * 3-col layouts, flex, fixed, etc.                                           *
+ * index.md                                                                   *
  *****************************************************************************/
 
 .col-2-fixed, .col-3-fixed {
@@ -798,7 +804,6 @@ a[class*=cardContainer_][class~=card]  {
   border: var(--semgrep-docs-border);
 }
 
-
 /******************************************************************************
  *                                                                            *
  * GRID COLUMNS                                                               *
@@ -838,6 +843,24 @@ a[class*=cardContainer_][class~=card]  {
     }
 }
 
+/******************************************************************************
+ *                                                                            *
+ * PAGE-SPECIFIC CUSTOM CLASSES                                               *
+ *                                                                            *
+ *****************************************************************************/
+
 .language-support-table table td {
     vertical-align: top;
+}
+
+.logo-index {
+  display: flex;
+  padding-top: 32px;
+  column-gap: 16px;
+  align-items: 'center';
+}
+@media (max-width:475px) {
+  .logo-index {
+      flex-direction: column;
+  }
 }


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR

Was not easy to resize previews in this GH PR comment, so please check this doc: [Screenshot of fixes.](https://docs.google.com/document/d/1fHO9ukjByAprkES2zbWjb37Tqha8LthMDkTckp48xDs/edit?tab=t.0)

Fixes
- Header - controversial - remove "Semgrep" text (look at screenshot, Semgrep goes under the search bar on 380px)
  - For some reason, docusaurus sets this in the config file, where it seems I can't swap out a longer asset for a shorter one based on breakpoints a la `content` as I would in CSS.
- Reduce padding between breadcrumbs and logo in article (see arrow)
- Fix Semgrep logo and Semgrep docs by changing arrangement from horizontal to vertical (see arrow)
- Made text a little smaller, in line with reduced size on phones (this still respects if the user overrides the setting)
- Fixed the gradient icon squares

Please also check ON YOUR PHONES some docs as I adjusted everything - the p, the ol, the ul, the h1-h5s.

 https://deploy-preview-1816--semgrep-docs-prod.netlify.app/docs/