### PR TITLE
Clarify difference between code links

### DIFF
--- a/docs/semgrep-code/findings.md
+++ b/docs/semgrep-code/findings.md
@@ -34,7 +34,9 @@ The **Code** page consists of:
 - The **filter panel**, which you can use to group and filter for specific findings
 - Information about findings identified by Semgrep Code. Each finding in the list includes:
   - The name and description of the rule used to generate the finding
-  - The name of the project, as well as links to the Git branch and source code, where Semgrep Code identified the finding
+  - The name of the project
+  - A link to the commit where the finding was first identified
+  - A link to the line of code where the finding was most recently seen
 
 ### Group findings
 

--- a/docs/semgrep-code/findings.md
+++ b/docs/semgrep-code/findings.md
@@ -36,7 +36,7 @@ The **Code** page consists of:
   - The name and description of the rule used to generate the finding
   - The name of the project
   - A link to the commit where the finding was first identified
-  - A link to the line of code where the finding was most recently seen
+  - A link to the lines of code where the finding was most recently seen
 
 ### Group findings
 

--- a/docs/semgrep-secrets/getting-started.md
+++ b/docs/semgrep-secrets/getting-started.md
@@ -69,6 +69,8 @@ The **Secrets** page consists of:
   - Whether it has been validated by a Semgrep validator
   - Whether it is a [historical finding](/semgrep-secrets/historical-scanning)
   - For users of the Semgrep Jira integration: whether there is a Jira ticket that accompanies that finding
+  - A link to the commit where the finding was first identified
+  - A link to the lines of code where the finding was most recently seen
 
 ### Group findings
 


### PR DESCRIPTION
The git hash and line of code link in findings details go to different places. This adds a couple of bullet points about what those places are.

AFAIK the same thing is true for Secrets and SSC but I didn't see a parallel page for either of them where we could make this same change.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
