### PR TITLE
Add a reference for Semgrepignore v2 (and v1 at the same time)

### DIFF
--- a/docs/cheat-sheets/rails-xss.mdx
+++ b/docs/cheat-sheets/rails-xss.mdx
@@ -385,7 +385,7 @@ Example:
 
 #### Mitigation
 
-Ban template variables in `&lt;script&gt;` blocks. Alternatively, If necessary, use the the `escape_javascript` function or its alias, `j`. Review each usage carefully and exempt with `# nosem`.
+Ban template variables in `&lt;script&gt;` blocks. Alternatively, If necessary, use the `escape_javascript` function or its alias, `j`. Review each usage carefully and exempt with `# nosem`.
 
 #### Semgrep rule
 

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -45,7 +45,7 @@ The pre-commit can also run custom rules and rulesets from Semgrep Code, similar
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.101.0'
+  rev: 'SEMGREP_VERSION_LATEST'
   hooks:
     - id:  semgrep-ci
 ```

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -33,7 +33,7 @@ The [pre-commit framework](https://pre-commit.com/) can run `semgrep` at commit-
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'SEMGREP_VERSION_LATEST'
+  rev: 'v1.101.0'
   hooks:
     - id: semgrep
       # See https://semgrep.dev/explore to select a ruleset and copy its URL
@@ -45,7 +45,7 @@ The pre-commit can also run custom rules and rulesets from Semgrep Code, similar
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'SEMGREP_VERSION_LATEST'
+  rev: 'v1.101.0'
   hooks:
     - id:  semgrep-ci
 ```

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -33,7 +33,7 @@ The [pre-commit framework](https://pre-commit.com/) can run `semgrep` at commit-
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.101.0'
+  rev: 'SEMGREP_VERSION_LATEST'
   hooks:
     - id: semgrep
       # See https://semgrep.dev/explore to select a ruleset and copy its URL

--- a/docs/ignoring-files-folders-code.md
+++ b/docs/ignoring-files-folders-code.md
@@ -36,7 +36,30 @@ Without user customization, Semgrep refers to the following to define ignored fi
 In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repository's default template](https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore):
 
 ```
-DEFAULT_SEMGREPIGNORE_TEXT
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+.npm/
+.yarn/
+
+# Common test paths
+test/
+tests/
+testsuite/
+*_test.go
+
+# Semgrep rules folder
+.semgrep
+
+# Semgrep-action log folder
+.semgrep_logs/
+
 ```
 
 :::caution
@@ -87,6 +110,12 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 Unsupported patterns are silently removed from the pattern list (this is done so that `.gitignore` files may be included without raising errors). The removal is logged.
 
 For a description of `.gitignore` syntax, see [.gitignore documentation](https://git-scm.com/docs/gitignore).
+
+:::caution
+[Semgrepignore is being revised](/semgrepignore-v2-reference) to
+support multiple `.semgrepignore` files and match the Gitignore
+specification more closely.
+:::
 
 ## Define ignored files and folders in Semgrep AppSec Platform
 

--- a/docs/ignoring-files-folders-code.md
+++ b/docs/ignoring-files-folders-code.md
@@ -36,30 +36,7 @@ Without user customization, Semgrep refers to the following to define ignored fi
 In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repository's default template](https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore):
 
 ```
-# Common large paths
-node_modules/
-build/
-dist/
-vendor/
-.env/
-.venv/
-.tox/
-*.min.js
-.npm/
-.yarn/
-
-# Common test paths
-test/
-tests/
-testsuite/
-*_test.go
-
-# Semgrep rules folder
-.semgrep
-
-# Semgrep-action log folder
-.semgrep_logs/
-
+DEFAULT_SEMGREPIGNORE_TEXT
 ```
 
 :::caution

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 This document covers the Semgrepignore target filtering system that is
 currently available with the `--experimental` option of the `semgrep`
-command ("v2"). It differs slightly from the legacy implementation which is
+command. It differs from the legacy **v1** implementation.
 referred to as "v1".
 
 ## The target filtering process

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -52,7 +52,7 @@ looked up in the current folder.
      soon as we have finer-grained replacements.
 -->
 
-As an experimental debugging aid, Semgrep provides the the `--x-ls` option
+As an experimental debugging aid, Semgrep provides the `--x-ls` option
 to list the target files. `--x-ls-long` additionally prints excluded
 files and a brief justification. Beware that these two options are
 likely to be renamed or change their behavior in the

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -4,7 +4,7 @@ append_help_link: true
 description: |
   Reference of the semgrepignore file fitering mechanism for Semgrep
 hide_title: true
-title: Semgrepignore reference (v2)
+title: Semgrepignore v2 reference
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -91,14 +91,28 @@ Supported sources of Semgrepignore patterns are:
 * default Semgrepignore patterns.
 
 These sources of filters are grouped into precedence levels.
-At the end of a level,
-only the selected paths will be considered for the next level. For
-example, `*.c` in the first level will exclude `hello.c` even if
-the next level de-excludes it with `!hello.c`. The levels are:
+Within a precedence level, a path can be deselected and reselected
+any number of times. After applying all the filters within a
+precedence level, only the selected paths make it to the next
+level. There are two precedence levels:
 
 1. command-line `--exclude` and `--include` filters;
 2. default Semgrepignore patterns, `.gitignore` files,
    `.semgrepignore` files.
+
+For example, consider this `.semgrepignore` file:
+```
+*.c
+!hello.c
+```
+In the absence of `--exclude` or `--include` filters,
+`hello.c` will be first deselected by `*.c` and then
+reselected by the negated pattern `!hello.c`.
+
+However, if we move the `*.c` exclusion pattern to the command line by
+invoking `semgrep --exclude *.c`,
+the file `hello.c` is deselected and ignored even if
+the `.semgrepignore` file contains `!hello.c`.
 
 In a Git project under Semgrepignore v2, `.gitignore` and
 `.semgrepignore` files are consulted in the same order as in the

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -82,7 +82,7 @@ A Semgrepignore pattern is a glob pattern that is matched by Semgrep
 against file paths to determine whether these paths should be allowed or
 disallowed as target files.
 
-Supported sources of Semgrepignore patterns are:
+Semgrep looks up Semgrepignore patterns in the following places:
 
 * command-line `--exclude` and `--include` filters;
 * the `.semgrepignore` file in the current folder (v1 only);

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -10,7 +10,7 @@ title: Semgrepignore v2 reference
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Semgrepignore reference (v2)
+# Semgrepignore v2 reference
 
 This document covers the Semgrepignore **v2** target filtering system that is
 currently available with the `--experimental` option of the `semgrep`

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -90,8 +90,9 @@ Supported sources of Semgrepignore patterns are:
 * all the `.gitignore` files in the project in Git projects (v2 only);
 * default Semgrepignore patterns.
 
-These sources of filters are grouped into levels. At the end of a level,
-only selected paths will be considered for the next level. For
+These sources of filters are grouped into precedence levels.
+At the end of a level,
+only the selected paths will be considered for the next level. For
 example, `*.c` in the first level will exclude `hello.c` even if
 the next level de-excludes it with `!hello.c`. The levels are:
 

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -38,11 +38,20 @@ The list of files obtained by expanding the scanning roots are called
 **target files**. To obtain target files, Semgrep follows a
 number of fixed rules and some configurable filters.
 
-for each scanning root, Semgrep infers a **project root** (v2 only). The
+For each scanning root, Semgrep infers a **project root** (v2 only). The
 project root determines the location of applicable `.semgrepignore`
 files as well as `.gitignore` files in Git projects. In v1 where is no
 notion of a project root, the `.semgrepignore` file is unique and
 looked up in the current folder.
+
+Semgrep determines the project root for each scanning root by first
+obtaining the real path (physical path) to the scanning root. Then,
+Semgrep searches up the file hierarchy for a `.git` folder or
+similar used by one of the popular file version control systems
+(Git, Mercurial, etc.) indicating a project root.
+If no project root is found this way, it
+defaults to the scanning root itself if it is a folder or to its containing
+folder if it is a regular file.
 
 <!-- TODO: explain project detection.
      Go over options to disable listing files using `git ls-files`
@@ -52,12 +61,12 @@ looked up in the current folder.
      soon as we have finer-grained replacements.
 -->
 
+:::caution
 As an experimental debugging aid, Semgrep provides the `--x-ls` option
 to list the target files. `--x-ls-long` additionally prints excluded
 files and a brief justification. Beware that these two options are
 likely to be renamed or change their behavior in the
 future. Meanwhile, its typical usage is:
-
 ```
 semgrep --x-ls
 ```
@@ -65,7 +74,7 @@ or
 ```
 semgrep --x-ls --experimental
 ```
-
+:::
 
 ## Sources of Semgrepignore patterns
 

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -52,7 +52,7 @@ looked up in the current folder.
      soon as we have finer-grained replacements.
 -->
 
-As an experimental debugging aid, we provide the the `--x-ls` option
+As an experimental debugging aid, Semgrep provides the the `--x-ls` option
 to list the target files. `--x-ls-long` additionally prints excluded
 files and a brief justification. Beware that these two options are
 likely to be renamed or change their behavior in the

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -35,7 +35,7 @@ the following exceptions:
   upcoming section.
 
 The list of files obtained by expanding the scanning roots are called
-"target files". To obtain target files, Semgrep follows a
+**target files**. To obtain target files, Semgrep follows a
 number of fixed rules and some configurable filters.
 
 For each scanning root, Semgrep infers a project root (v2 only). The

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 # Semgrepignore reference (v2)
 
-This document covers the Semgrepignore target filtering system that is
+This document covers the Semgrepignore **v2** target filtering system that is
 currently available with the `--experimental` option of the `semgrep`
 command. It differs from the legacy **v1** implementation.
 referred to as "v1".

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -56,7 +56,7 @@ As an experimental debugging aid, Semgrep provides the the `--x-ls` option
 to list the target files. `--x-ls-long` additionally prints excluded
 files and a brief justification. Beware that these two options are
 likely to be renamed or change their behavior in the
-future. Meanwhile, typical usage is:
+future. Meanwhile, its typical usage is:
 
 ```
 semgrep --x-ls

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -1,0 +1,155 @@
+---
+slug: semgrepignore-v2-reference
+append_help_link: true
+description: |
+  Reference of the semgrepignore file fitering mechanism for Semgrep
+hide_title: true
+title: Semgrepignore reference (v2)
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Semgrepignore reference (v2)
+
+This document covers the Semgrepignore target filtering system that is
+currently available with the `--experimental` option of the `semgrep`
+command ("v2"). It differs slightly from the legacy implementation which is
+referred to as "v1".
+
+## The target filtering process
+
+A `semgrep scan` command takes one or more scanning roots as
+arguments. The default scanning root is the current folder, `.`.
+Scanning roots are folders, individual files, or named pipes that should be
+expanded into a list of regular files to be analyzed. Symbolic links are
+allowed as scanning roots.
+
+Expanding a folder consists in listing its contents recursively with
+the following exceptions:
+
+* Symbolic links other than the original scanning roots are ignored.
+* In Git projects, Git submodules are ignored.
+* Paths excluded via Semgrepignore patterns are ignored. Semgrepignore
+  patterns can be of different sources which are detailed in the
+  upcoming section.
+
+The list of files obtained by expanding the scanning roots are called
+"target files". To obtain target files, Semgrep follows a
+number of fixed rules and some configurable filters.
+
+For each scanning root, Semgrep infers a project root (v2 only). The
+project root determines the location of applicable `.semgrepignore`
+files as well as `.gitignore` files in Git projects. In v1 where is no
+notion of a project root, the `.semgrepignore` file is unique and
+looked up in the current folder.
+
+<!-- TODO: explain project detection.
+     Go over options to disable listing files using `git ls-files`
+     while possibly still consulting the `.gitignore` files -- when we
+     have an option for it. Right now we have only `--no-git-ignore`
+     which is confusing and too coarse. I'd like to deprecate it as
+     soon as we have finer-grained replacements.
+-->
+
+As an experimental debugging aid, we provide the the `--x-ls` option
+to list the target files. `--x-ls-long` additionally prints excluded
+files and a brief justification. Beware that these two options are
+likely to be renamed or change their behavior in the
+future. Meanwhile, typical usage is:
+
+```
+semgrep --x-ls
+```
+or
+```
+semgrep --x-ls --experimental
+```
+
+
+## Sources of Semgrepignore patterns
+
+A Semgrepignore pattern is a glob pattern that is matched by Semgrep
+against file paths to determine whether these paths should be allowed or
+disallowed as target files.
+
+Supported sources of Semgrepignore patterns are:
+
+* command-line `--exclude` and `--include` filters;
+* the `.semgrepignore` file in the current folder (v1 only);
+* all the `.semgrepignore` files in the project (v2 only);
+* all the `.gitignore` files in the project in Git projects (v2 only);
+* default Semgrepignore patterns.
+
+These sources of filters are grouped into levels. At the end of a level,
+only selected paths will be considered for the next level. For
+example, `*.c` in the first level will exclude `hello.c` even if
+the next level de-excludes it with `!hello.c`. The levels are:
+
+1. command-line `--exclude` and `--include` filters;
+2. default Semgrepignore patterns, `.gitignore` files,
+   `.semgrepignore` files.
+
+In a Git project under Semgrepignore v2, `.gitignore` and
+`.semgrepignore` files are consulted in the same order as in the
+Gitignore specification. In a folder containing both a `.gitignore`
+and a `.semgrepignore` file, the `.gitignore` file is read before the
+`.semgrepignore` file.
+
+Default Semgrepignore patterns apply in projects that lack a main
+`.semgrepignore` file. In v1, the main `.semgrepignore` file is
+expected in the current folder. In v2, it is expected at the project
+root. These default patterns are:
+
+```
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+.npm/
+.yarn/
+
+# Common test paths
+test/
+tests/
+testsuite/
+*_test.go
+
+# Semgrep rules folder
+.semgrep
+
+# Semgrep-action log folder
+.semgrep_logs/
+```
+
+## Semgrepignore pattern syntax
+
+In Semgrepignore v2, the pattern syntax conforms strictly to the
+[Gitignore pattern syntax](https://git-scm.com/docs/gitignore#_pattern_format).
+They are glob patterns which support `*` and `**` with their usual
+meanings. For example, pattern `**/tmp/*.js` matches paths `tmp/foo.js` and
+`src/tmp/bar.js`.
+Note that the Gitignore specification contains subtleties associated
+with determining whether a pattern is anchored (relative to the folder
+containing the pattern) or floating (relative to the folder containing
+the pattern or any of its subfolders). For
+example, `/a` and `a/b` are anchored patterns but not `a/`. Please
+consult the Gitignore documentation for details.
+
+In Semgrepignore v1, the following exceptions to the Gitignore
+specification apply:
+
+* unsupported: pattern negation with `!`
+* unsupported: character ranges such as `[a-z]`
+* extension:
+  `:include` followed by an unquoted file path relative to the path of
+  folder of the source `.semgrepignore` file (the current folder in v1)
+  will insert patterns read from that file. A common use case was
+  `:include .gitignore` but it has become unnecessary in v2 where
+  `.gitignore` files are consulted automatically.
+  Include directives are deprecated in v2.

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -38,7 +38,7 @@ The list of files obtained by expanding the scanning roots are called
 **target files**. To obtain target files, Semgrep follows a
 number of fixed rules and some configurable filters.
 
-For each scanning root, Semgrep infers a project root (v2 only). The
+for each scanning root, Semgrep infers a **project root** (v2 only). The
 project root determines the location of applicable `.semgrepignore`
 files as well as `.gitignore` files in Git projects. In v1 where is no
 notion of a project root, the `.semgrepignore` file is unique and

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -25,7 +25,7 @@ Scanning roots are folders, individual files, or named pipes that should be
 expanded into a list of regular files to be analyzed. Symbolic links are
 allowed as scanning roots.
 
-Expanding a folder consists in listing its contents recursively with
+Expanding a folder consists of listing its contents recursively with
 the following exceptions:
 
 * Symbolic links other than the original scanning roots are ignored.

--- a/sidebars.js
+++ b/sidebars.js
@@ -308,7 +308,8 @@ module.exports = {
             ]
         },
         'cli-reference',
-        `semgrep-appsec-platform/json-and-sarif`,
+        'semgrep-appsec-platform/json-and-sarif',
+        'semgrepignore-v2-reference',
       ]
     }
   ],


### PR DESCRIPTION
This a reference for the new (v2) Semgrepignore mechanism. I wrote it such that it's complete and also covers the legacy v1. This is currently available with `--experimental` which includes other things than file targeting but we'll soon provide a flag to use just this new feature (we'll also make some users use it by default). For now, having this document out there is useful for CSEs and other stakeholders who need to manage a smooth transition to v2.

Preview:
* https://deploy-preview-1861--semgrep-docs-prod.netlify.app/docs/ignoring-files-folders-code#define-ignored-files-and-folders-in-semgrepignore
* https://deploy-preview-1861--semgrep-docs-prod.netlify.app/docs/semgrepignore-v2-reference

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
