### PR TITLE
Add caveat about hosted runners for Azure

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -440,6 +440,8 @@ To add Semgrep into Azure Pipelines:
 
 ### Sample Azure Pipelines configuration snippet
 
+This configuration snippet is tested with hosted Azure runners. If you are using self-hosted runners, you may need to make adjustments to ensure that the necessary software is available.
+
 <Tabs
     defaultValue="azure-semgrep"
     values={[


### PR DESCRIPTION
We test our sample config on Azure hosted runners; this adds a note to let folks using self-hosted runners know they might need to adjust. It's planned to be followed by adding KBs with examples of how this could work for the default *nix self-hosted image.

### Please ensure

~- [ ] A subject matter expert (SME) reviews the content~ xs PR
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
