### PR TITLE
Update secrets triage to fix some errors/old info

### DIFF
--- a/docs/semgrep-secrets/view-triage.md
+++ b/docs/semgrep-secrets/view-triage.md
@@ -77,5 +77,5 @@ To receive PR or MR comments, ensure that:
 **_Figure._** Semgrep Secrets finding in a PR comment.
 
 :::info
-Define which rules and validations states should be in allow, comment, or block mode in the [Policies](/semgrep-secrets/policies) page.
+Define which rules and validation states should be in Allow, Comment, or Block mode in the [Policies](/semgrep-secrets/policies) page.
 :::

--- a/docs/semgrep-secrets/view-triage.md
+++ b/docs/semgrep-secrets/view-triage.md
@@ -36,10 +36,10 @@ You can triage secrets-related findings in Semgrep AppSec Platform on the **Secr
 2. Analyzing if the findings are true or false positives.
 3. Applying a **triage state** to the filtered findings based on the analysis in step 2.
     1. Setting a finding as **Ignored** means that no action is undertaken and the finding is closed. Subsequent scans won't include this finding.
-    2. Setting or retaining a finding as **Open** means that the finding is a true positive and needs to be fixed or resolved.
-        1. Optional: You can create a ticket for **Linear, Jira, or Asana** to assign a developer to fix **Open** findings.
+    2. Setting or retaining a finding as **Open**, **Reviewing**, or **Fixing** means that the finding is a true positive and needs to be fixed or resolved.
+        1. Optional: You can [create a ticket in Jira](/semgrep-appsec-platform/jira) to assign a developer to fix findings.
 
-When commits are added to the PR or MR, Semgrep re-scans the PR or MR and detects if a finding is fixed. The finding is resolved automatically upon scanning. Users do not need to set a finding as **Fixed** manually.
+When commits are added to the PR or MR, Semgrep re-scans the PR or MR and detects if a finding is fixed, or if the secret is no longer valid. The finding changes status automatically upon scanning. Users do not need to set a finding as **Fixed** manually.
 
 ## Common filtering use cases
 
@@ -59,27 +59,23 @@ You can triage findings in bulk by performing the following steps:
 
 1. Begin by ensuring that you display all **Open** findings.
 2. Apply filters with as much specificity as possible. You may have to perform bulk triage several times. By starting with the most specific cases, and closing the findings from those specific cases, you are able to narrow down findings as you work from specific to broad filter criteria.
-3. Click the bulk select check ox.
-4. Click **Triage**, then your selected triage state, typically **Ignore**.
+3. Click the bulk select check box.
+4. Click **Triage**, then your selected triage state, such as **Reviewing** or **Ignored**.
 5. Optional: Repeat this procedure to triage all open findings.
 
 
-## Receive findings in through PR and MR comments
+## Receive findings through PR and MR comments
 
 In addition to viewing your results in Semgrep AppSec Platform, you can set up PR or MR comments from Semgrep, which allows you to view findings-related information directly in your pull requests and merge requests.
 
 To receive PR or MR comments, ensure that:
 
 * You have set up [comments](/category/pr-or-mr-comments) as part of your core deployment.
-* You have defined which rules should be in Allow, Comment, or Block mode in the [Policies](/semgrep-secrets/policies) page.
+* You have defined which rules and validation states should be in Allow, Comment, or Block mode in the [Policies](/semgrep-secrets/policies) page.
 
 ![Semgrep Secrets finding in a PR comment](/img/secrets-pr-comment.png)
 **_Figure._** Semgrep Secrets finding in a PR comment.
 
 :::info
-Define which rules should be in allow, comment, or block mode in the [Policies](/semgrep-secrets/policies) page.
+Define which rules and validations states should be in allow, comment, or block mode in the [Policies](/semgrep-secrets/policies) page.
 :::
-
-<!-- ## Create tickets
-
-You can create tickets in Jira, Linear, or Asana for secrets-related findings. See [<i class="fa-regular fa-file-lines"></i> Ticketing](semgrep-appsec-platform/ticketing/). -->


### PR DESCRIPTION
The Secrets triage page hadn't been updated to reflect the new triage states and ticketing integration changes. It also didn't mention that secrets findings may end up becoming invalid rather than being fully fixed. And we had a secret ox hiding in the doc. 🐂 😆 

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
