### PR TITLE
[KB] Customize Semgrep in pre-commit

### DIFF
--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -20,11 +20,9 @@ Several third-party tools include Semgrep extensions.
 
 ### The LSP Command
 
-All of our official extensions use the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) to communicate
-with Semgrep. This allows us to focus on one codebase that can be shared across most modern editor platforms. To implement a custom extension,
-one can wrap `semgrep lsp` to start the Semgrep Language Server, which will communicate over `stdio`. Alternatively, this protocol is a
-great way to integrate Semgrep into a project, as it can perform incremental scans, and caches various computations to hugely increase performance.
-Please let us know on our community Slack linked below if you do, we'd be more than happy to help in anyway.
+All of the official extensions use the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) to communicate with Semgrep. This allows the team to focus on one codebase that can be shared across most modern editor platforms.
+
+To implement a custom extension, wrap `semgrep lsp` to start the Semgrep Language Server, which communicates over `stdio`. Alternatively, this protocol is a great way to integrate Semgrep into a project, as it can perform incremental scans, and caches various computations to increase performance. Please let us know in our [Community Slack](https://go.semgrep.dev/slack) if you use this approach; we'd be happy to help in any way.
 
 ### Pre-commit
 
@@ -50,6 +48,8 @@ repos:
     - id:  semgrep-ci
 ```
 
+For guidance on customizing Semgrep's behavior in pre-commit, see [Customize Semgrep in pre-commit](/docs/kb/integrations/customize-semgrep-precommit).
+
 #### Run with Semgrep Pro rules
 
 If you would like to run the pre-commit hook **locally** while using Semgrep Pro rules:
@@ -62,7 +62,7 @@ If you would like to run the pre-commit hook **locally** while using Semgrep Pro
 
 ### Semgrep as an engine
 
-Many other tools have functionality powered by Semgrep.
+Many other tools have capabilities powered by Semgrep.
 Add yours [with a pull request](https://github.com/semgrep/semgrep-docs)!
 
 - [DefectDojo](https://github.com/DefectDojo/django-DefectDojo/pull/2781)

--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -18,11 +18,9 @@ Several third-party tools include Semgrep extensions.
 - IntelliJ Ultimate Idea (and most other IntelliJ products) [`semgrep-intellij`](https://plugins.jetbrains.com/plugin/22622-semgrep)
 - Emacs: [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode)
 
-### The LSP Command
+### Use of Language Server Protocol (LSP)
 
 All of the official extensions use the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) to communicate with Semgrep. This allows the team to focus on one codebase that can be shared across most modern editor platforms.
-
-To implement a custom extension, wrap `semgrep lsp` to start the Semgrep Language Server, which communicates over `stdio`. Alternatively, this protocol is a great way to integrate Semgrep into a project, as it can perform incremental scans, and caches various computations to increase performance. Please let us know in our [Community Slack](https://go.semgrep.dev/slack) if you use this approach; we'd be happy to help in any way.
 
 ### Pre-commit
 

--- a/docs/kb/integrations/customize-semgrep-precommit.md
+++ b/docs/kb/integrations/customize-semgrep-precommit.md
@@ -45,7 +45,7 @@ Semgrep Secrets is an ideal product to run before commit, since it can help prev
       args: ["ci", "--dry-run", "--baseline-commit", "HEAD", "--secrets"]
 ```
 
-## Scan with Pro Engine
+## Scan with Pro rules and cross-function analysis
 
 The `semgrep-ci` hook requires the user to be logged in locally and runs with the engine configured in the organization, but the standard `semgrep` hook can also take advantage of local login to run with Pro rules and cross-function analysis.
 

--- a/docs/kb/integrations/customize-semgrep-precommit.md
+++ b/docs/kb/integrations/customize-semgrep-precommit.md
@@ -47,7 +47,7 @@ Semgrep Secrets is an ideal product to run before commit, since it can help prev
 
 ## Scan with Pro Engine
 
-The `semgrep-ci` hook requires the user to be logged in locally and runs with the engine configured in the organization, but the standard `semgrep` hook can also take advantage of local login to run with the Pro Engine.
+The `semgrep-ci` hook requires the user to be logged in locally and runs with the engine configured in the organization, but the standard `semgrep` hook can also take advantage of local login to run with Pro rules and cross-function analysis.
 
 ```yaml
 - id: semgrep

--- a/docs/kb/integrations/customize-semgrep-precommit.md
+++ b/docs/kb/integrations/customize-semgrep-precommit.md
@@ -1,0 +1,63 @@
+---
+description: Understand how to customize Semgrep's behavior when using it with pre-commit.
+tags:
+  - Extensions
+---
+
+# Customize Semgrep in pre-commit
+
+Semgrep offers two standard pre-commit hooks [outlined here](/docs/extensions/overview/#pre-commit).
+
+* The `semgrep` hook is optimized to run with a provided set of rules, either local rules or rules from the Semgrep Registry.
+* The `semgrep-ci` hook is optimized to run with the rules from your organization in the Semgrep AppSec Platform, without sending results to the platform, since results from pre-commit are temporary and not linked to the final code in the repository.
+
+You can also create your own Semgrep hooks for pre-commit if you have particular needs or preferences, such as if you want users to see the output of the Semgrep scan even if it passed, or if you want to limit the scan to a particular Semgrep product.
+
+## Show the scan output
+
+By default, pre-commit does not show the scan output if the hook passes. If you're using the `semgrep-ci` hook, but want your developers to see the output even if non-blocking findings are found, you can set the `verbose` option to print the output. To prevent the output from being too chatty, redirect `stderr` to `/dev/null` so that only the findings are printed, or use `--quiet`.
+
+```yaml
+repos:
+- repo: https://github.com/semgrep/pre-commit
+  rev: 'v1.101.0'
+  hooks:
+    - id: semgrep-verbose
+      entry: semgrep
+      args: ["ci", "--dry-run", "--baseline-commit", "HEAD" "2>/dev/null"]
+      verbose: true
+      pass_filenames: false
+```
+
+## Limit the scan to a particular product
+
+Semgrep Secrets is an ideal product to run before commit, since it can help prevent secrets from ever making it into the Git history, even locally. To run only Secrets in pre-commit, add the product flag to the `args`:
+
+```yaml
+- repo: https://github.com/semgrep/pre-commit
+  rev: 'v1.101.0'
+  hooks:
+    - id:  semgrep-secrets
+      pass_filenames: false
+      args: ["ci", "--dry-run", "--baseline-commit", "HEAD", "--secrets"]
+```
+
+## Customization tips
+
+### Useful arguments
+
+The provided hooks include useful arguments for Semgrep that you may want to include in your hooks as well.
+
+For example, for the `semgrep` hook that runs with a provided `--config`, the arguments also include `--disable-version-check` (skips checking whether there's a new version of Semgrep, speeding things up and avoiding irrelevant output), `--quiet` (only print findings, not other messages) and `--skip-unknown-extensions` (if files are modified that aren't in a recognized language, just skip them).
+
+The `semgrep-ci` hook runs with the pre-commit option `pass_filenames: false` because `semgrep ci` doesn't expect a list of filenames (which is what pre-commit normally provides); it just expects to scan the folder. Adding `baseline-commit HEAD` performs a diff scan; this diff scan only scans the changes being added in the current commit (as intended for a pre-commit hook). It uses `--dry-run` so that findings that have no existence except in the local filesystem aren't added to the platform, which would otherwise result in clutter.
+
+### Entry point
+
+Both of the default hooks use `semgrep` as the `entry`, which means the command executed is just `semgrep` with the `args` provided. However, you can write your own `entry` point:
+
+```bash
+ entry: sh -c 'env SEMGREP_REPO_NAME=pre-commit-diff SEMGREP_BRANCH=$(git branch --show-current) semgrep ci --code --no-suppress-errors --baseline-commit HEAD'
+```
+
+This lets you set environment variables (like `SEMGREP_REPO_NAME`) that can’t be set as command-line arguments.

--- a/docs/kb/integrations/customize-semgrep-precommit.md
+++ b/docs/kb/integrations/customize-semgrep-precommit.md
@@ -10,12 +10,15 @@ Semgrep offers two standard pre-commit hooks [outlined here](/docs/extensions/ov
 
 * The `semgrep` hook is optimized to run with a provided set of rules, either local rules or rules from the Semgrep Registry.
 * The `semgrep-ci` hook is optimized to run with the rules from your organization in the Semgrep AppSec Platform, without sending results to the platform, since results from pre-commit are temporary and not linked to the final code in the repository.
+  * This hook requires the user be logged in locally to fetch the rules from the organization.
 
 You can also create your own Semgrep hooks for pre-commit if you have particular needs or preferences, such as if you want users to see the output of the Semgrep scan even if it passed, or if you want to limit the scan to a particular Semgrep product.
 
 ## Show the scan output
 
-By default, pre-commit does not show the scan output if the hook passes. If you're using the `semgrep-ci` hook, but want your developers to see the output even if non-blocking findings are found, you can set the `verbose` option to print the output. To limit output to findings only (no scan information or diagnostics), redirect `stderr` to `/dev/null`, or use `--quiet`.
+By default, pre-commit does not show the scan output if the hook passes. If you want your developers to see the output even if non-blocking findings are found, you can set the `verbose` option to print the output. To limit output to findings only (no scan information or diagnostics), redirect `stderr` to `/dev/null`, or use `--quiet`.
+
+This example is based on the `semgrep-ci` hook, but a similar adjustment would also work with the `semgrep` hook.
 
 ```yaml
 repos:
@@ -41,6 +44,19 @@ Semgrep Secrets is an ideal product to run before commit, since it can help prev
       pass_filenames: false
       args: ["ci", "--dry-run", "--baseline-commit", "HEAD", "--secrets"]
 ```
+
+## Scan with Pro Engine
+
+The `semgrep-ci` hook requires the user to be logged in locally and runs with the engine configured in the organization, but the standard `semgrep` hook can also take advantage of local login to run with the Pro Engine.
+
+```yaml
+- id: semgrep
+  name: semgrep
+  entry: semgrep
+  args: ["--pro", "--disable-version-check", "--quiet", "--skip-unknown-extensions"]
+```
+
+This provides analysis across modified files during the pre-commit scan, which may catch additional vulnerabilities, or prevent false positives.
 
 ## Customization tips
 

--- a/docs/kb/integrations/customize-semgrep-precommit.md
+++ b/docs/kb/integrations/customize-semgrep-precommit.md
@@ -15,7 +15,7 @@ You can also create your own Semgrep hooks for pre-commit if you have particular
 
 ## Show the scan output
 
-By default, pre-commit does not show the scan output if the hook passes. If you're using the `semgrep-ci` hook, but want your developers to see the output even if non-blocking findings are found, you can set the `verbose` option to print the output. To prevent the output from being too chatty, redirect `stderr` to `/dev/null` so that only the findings are printed, or use `--quiet`.
+By default, pre-commit does not show the scan output if the hook passes. If you're using the `semgrep-ci` hook, but want your developers to see the output even if non-blocking findings are found, you can set the `verbose` option to print the output. To limit output to findings only (no scan information or diagnostics), redirect `stderr` to `/dev/null`, or use `--quiet`.
 
 ```yaml
 repos:

--- a/docs/kb/integrations/customize-semgrep-precommit.md
+++ b/docs/kb/integrations/customize-semgrep-precommit.md
@@ -48,16 +48,24 @@ Semgrep Secrets is an ideal product to run before commit, since it can help prev
 
 The provided hooks include useful arguments for Semgrep that you may want to include in your hooks as well.
 
-For example, for the `semgrep` hook that runs with a provided `--config`, the arguments also include `--disable-version-check` (skips checking whether there's a new version of Semgrep, speeding things up and avoiding irrelevant output), `--quiet` (only print findings, not other messages) and `--skip-unknown-extensions` (if files are modified that aren't in a recognized language, just skip them).
+For example, for the `semgrep` hook that runs with a provided `--config`, the arguments also include:
 
-The `semgrep-ci` hook runs with the pre-commit option `pass_filenames: false` because `semgrep ci` doesn't expect a list of filenames (which is what pre-commit normally provides); it just expects to scan the folder. Adding `baseline-commit HEAD` performs a diff scan; this diff scan only scans the changes being added in the current commit (as intended for a pre-commit hook). It uses `--dry-run` so that findings that have no existence except in the local filesystem aren't added to the platform, which would otherwise result in clutter.
+ * `--disable-version-check`: skip checking whether there's a new version of Semgrep (speeds up the check and avoids irrelevant output)
+ * `--quiet`: only print findings, not other messages
+ * `--skip-unknown-extensions`: if files are modified that aren't in a recognized language, skip them
+
+The `semgrep-ci` hook runs with the pre-commit option `pass_filenames: false`. This is important because `semgrep ci` doesn't expect a list of filenames; it just expects to scan the folder, so you should preserve this option in your usage.
+
+Adding `baseline-commit HEAD` performs a diff scan; this diff scan only scans the changes being added in the current commit (as intended for a pre-commit hook). It uses `--dry-run` so that findings that have no existence except in the local filesystem aren't added to the platform, which would otherwise result in clutter.
 
 ### Entry point
 
-Both of the default hooks use `semgrep` as the `entry`, which means the command executed is just `semgrep` with the `args` provided. However, you can write your own `entry` point:
+Both of the default hooks use `semgrep` as the `entry`, which means the command executed is just `semgrep` with the `args` provided. However, you can write your own `entry` point. This approach is used in the less commonly used `semgrep-docker` hook also available in the [semgrep/pre-commit repository](https://github.com/semgrep/pre-commit/blob/develop/.pre-commit-hooks.yaml).
+
+It can also be used with a standard Semgrep execution to set environment variables in addition to (or instead of) arguments:
 
 ```bash
- entry: sh -c 'env SEMGREP_REPO_NAME=pre-commit-diff SEMGREP_BRANCH=$(git branch --show-current) semgrep ci --code --no-suppress-errors --baseline-commit HEAD'
+ entry: sh -c 'env SEMGREP_RULES=<SEMGREP_RULESET_URL> semgrep scan --code --no-suppress-errors --baseline-commit HEAD'
 ```
 
-This lets you set environment variables (like `SEMGREP_REPO_NAME`) that can’t be set as command-line arguments.
+In this case, setting `SEMGREP_RULES=<SEMGREP_RULESET_URL>` substitutes for supplying `--config` and `<SEMGREP_RULESET_URL>` in the `args`.


### PR DESCRIPTION
I've fielded a few questions about ways to modify Semgrep's behavior in pre-commit, so this guide offers both a couple of specific examples and some more general notes about how the existing hooks work that I hope will help folks self-serve more generally.

I added a link to the related doc, and Vale was bugging me, so I also cleaned it up a bit.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
