### PR TITLE
[KB] Does Semgrep scan compressed files?

### DIFF
--- a/docs/kb/semgrep-ci/scan-compressed-files-artifacts.md
+++ b/docs/kb/semgrep-ci/scan-compressed-files-artifacts.md
@@ -15,6 +15,8 @@ To scan code or text files that are stored in a compressed archive file with Sem
 
 For local scans, this can be done manually. For scans in CI, add appropriate actions to the CI config.
 
+When implementing this method, it's optimal to place the compressed files in a consistent location, so that Semgrep can detect that any findings within the temporary files are the same across scans.
+
 ### What are the limitations of this approach?
 
 When possible, Semgrep AppSec Platform generates [hyperlinks](/docs/semgrep-code/findings#code-page-structure) to a finding's location within a repository and file. If the file is not persistent in the repository, and is scanned at a temporary path, then the hyperlink will lead to that temporary path and will not work properly. This may make it more difficult for developers to identify where and how to fix issues identified in the temporary files.

--- a/docs/kb/semgrep-ci/scan-compressed-files-artifacts.md
+++ b/docs/kb/semgrep-ci/scan-compressed-files-artifacts.md
@@ -1,0 +1,22 @@
+---
+description: Options to scan compressed files or other artifacts with Semgrep.
+tags:
+  - Scans
+  - Semgrep in CI
+---
+
+# Does Semgrep scan compressed files or other non-code files?
+
+Semgrep is a pre-build security tool optimized to search for code and text patterns. It does not scan the files within a compressed archive, nor does it scan binaries (built files).
+
+## How can I scan the files inside a compressed archive file?
+
+To scan code or text files that are stored in a compressed archive file with Semgrep, uncompress the files before performing the scan. When the scan is complete, delete the temporary files that were created.
+
+For local scans, this can be done manually. For scans in CI, add appropriate actions to the CI config.
+
+### What are the limitations of this approach?
+
+When possible, Semgrep AppSec Platform generates hyperlinks to findings within files. If the file is not persistent in the repository, and is scanned at a temporary path, then the hyperlink will lead to that temporary path and will not work properly. This may make it more difficult for developers to identify where and how to fix the issue.
+
+Currently, it is not possible to uncompress files before running a scan in Managed Scans.

--- a/docs/kb/semgrep-ci/scan-compressed-files-artifacts.md
+++ b/docs/kb/semgrep-ci/scan-compressed-files-artifacts.md
@@ -17,6 +17,6 @@ For local scans, this can be done manually. For scans in CI, add appropriate act
 
 ### What are the limitations of this approach?
 
-When possible, Semgrep AppSec Platform generates hyperlinks to findings within files. If the file is not persistent in the repository, and is scanned at a temporary path, then the hyperlink will lead to that temporary path and will not work properly. This may make it more difficult for developers to identify where and how to fix the issue.
+When possible, Semgrep AppSec Platform generates [hyperlinks](/docs/semgrep-code/findings#code-page-structure) to a finding's location within a repository and file. If the file is not persistent in the repository, and is scanned at a temporary path, then the hyperlink will lead to that temporary path and will not work properly. This may make it more difficult for developers to identify where and how to fix issues identified in the temporary files.
 
-Currently, it is not possible to uncompress files before running a scan in Managed Scans.
+Currently, it is not possible to uncompress files before running a scan in [Semgrep Managed Scans](/docs/deployment/managed-scanning/overview).

--- a/docs/kb/semgrep-code/InvalidHeaderValue.md
+++ b/docs/kb/semgrep-code/InvalidHeaderValue.md
@@ -1,9 +1,8 @@
 ---
 description: Troubleshoot "invalid header value" errors in GitHub and Gitlab
 tags:
-  - Scanning
+  - Scans
   - Semgrep Code
-  - Secrets
 append_help_link: true
 ---
 


### PR DESCRIPTION
People ask a lot if Semgrep can scan compressed files/other binaries, let's give them an answer.

![image](https://github.com/user-attachments/assets/7fbf3d26-e532-4221-89b6-6927e947f136)

I noticed that I wanted to add a "Scans" tag here and there was already "Scanning" on the other file I modified. Since we prefer simple verbs (and presumably simple nouns, if tags are nouns ;), I aligned both to "Scans". I removed "Secrets" since it could be confused with Semgrep Secrets and that's not what the other KB is about.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
