### PR TITLE
Cleanup mostly around requirements.txt changes/usage

### DIFF
--- a/docs/kb/semgrep-supply-chain/ssc-python-lockfiles.md
+++ b/docs/kb/semgrep-supply-chain/ssc-python-lockfiles.md
@@ -4,9 +4,6 @@ tags:
   - Semgrep Supply Chain
   - Python
   - Lockfiles
-  - requirements.txt
-  - Pipfile.lock
-  - Poetry.lock
 ---
 
 # Generating Python lockfiles for Semgrep Supply Chain scans
@@ -20,7 +17,7 @@ To correctly scan all dependencies in a project, Semgrep Supply Chain requires a
 * `Pipfile.lock`
 * `Poetry.lock`
 
-You can use any of these three lockfiles to get a successful Semgrep Supply Chain scan. Your lockfiles must have one of these three names in order to be scanned.
+You can use any of these lockfiles to get a successful Semgrep Supply Chain scan. Your lockfiles must have one of these names or naming structures to be scanned.
 
 ## Generating `requirements.txt`
 
@@ -42,7 +39,7 @@ Now, you have successfully generated a `requirements.txt` file with direct and t
 
 #### Example of `requirements.txt` generated from `requirements.in`
 
-Given the following example project [Binder examples](https://github.com/sebastianrevuelta/binder-examples/), the `requirements.in` file contains the following direct dependencies: 
+Given the following example project [Binder examples](https://github.com/sebastianrevuelta/binder-examples/), the `requirements.in` file contains the following direct dependencies:
 
 ```
 numpy
@@ -106,7 +103,7 @@ tzdata==2023.3
     # via pandas
 ```
 
-This file has all direct and transitive dependencies of the example project and can be used by Semgrep as an entry point for the supply chain scan.
+This file has all direct and transitive dependencies of the example project and can be used by Semgrep as an entry point for the Supply Chain scan.
 
 ### Using `pip freeze`
 
@@ -145,7 +142,7 @@ on:
     - cron: '0 1 * * 0'
 name: Semgrep
 jobs:
-  my_first_job: 
+  my_first_job:
     name: requirementsGeneration
     runs-on: ubuntu-latest
     steps:
@@ -175,7 +172,7 @@ jobs:
           name: requirementstxt
       - run: semgrep ci --supply-chain
 
-``` 
+```
 
 ## Generating `Pipfile.lock`
 

--- a/docs/semgrep-supply-chain/overview.md
+++ b/docs/semgrep-supply-chain/overview.md
@@ -45,7 +45,7 @@ Supply Chain offers two levels of support for reachability analysis, [depending 
       * A finding is **conditionally reachable** if the vulnerability can be exploited when specific conditions are met. The finding is reachable if, in addition to the dataflow reachability in code, additional factors, such as the use of a specific operating system, are met. Semgrep cannot determine whether such factors are true, so conditionally reachable findings require manual review.
   * If Semgrep Supply Chain determines that you don't use the vulnerable library package imported or you don't use the vulnerable piece of code of the library or package imported, the finding is flagged as **unreachable**.
   * If Semgrep Supply Chain determines that you use a vulnerable version of a dependency, but Semgrep Supply Chain doesn't have a relevant reachability rule, it flags the finding as **no reachability analysis**.
-* For **[languages where Semgrep Supply Chain doesn't currently offer rules with reachability analysis](/semgrep-supply-chain/glossary/#rules-without-reachability-analysis)** languages, Semgrep Supply Chain's performance is comparable to that of [GitHub's Dependabot](https://github.com/dependabot). Semgrep Supply Chain generates these findings by checking the dependency's version listed in your lockfile or manifest against a list of versions with known vulnerabilities, but it does not run reachability analysis. Because Semgrep Supply Chain doesn't run reachability analysis, it can't determine whether the vulnerability is reachable. Such vulnerabilities are, therefore, flagged as **no reachability analysis**.
+* For **[languages where Semgrep Supply Chain doesn't currently offer rules with reachability analysis](/semgrep-supply-chain/glossary/#rules-without-reachability-analysis)** languages, Semgrep Supply Chain's performance is comparable to that of [GitHub's Dependabot](https://github.com/dependabot). Semgrep Supply Chain generates these findings by checking the dependency version listed in your lockfile against a list of versions with known vulnerabilities, but it does not run reachability analysis. Because Semgrep Supply Chain doesn't run reachability analysis, it can't determine whether the vulnerability is reachable. Such vulnerabilities are, therefore, flagged as **no reachability analysis**.
 
 Specific dependency and code match findings are called **usages**. Semgrep AppSec Platform groups all usages together by vulnerability. For each vulnerability, the UI also displays a CVE number corresponding to the [CVE program record](https://www.cve.org/About/Overview).
 
@@ -55,7 +55,7 @@ A [transitive dependency](/docs/semgrep-supply-chain/glossary/#transitive-or-ind
 
 However, some dependencies are vulnerable simply through their inclusion in a codebase; in such cases, Semgrep Supply Chain generates reachable findings involving these dependencies, even if they're transitive, not direct, dependencies.
 
-Some package ecosystems allow the use of a transitive dependency as if it were a direct dependency. Though this feature is uncommon, Semgrep Supply Chain can scan for such usages and flag transitive dependencies as unreachable if not used directly.
+Some package ecosystems allow the use of a transitive dependency as if it were a direct dependency. Though this feature is uncommon, Semgrep Supply Chain can scan for such usages and flag vulnerabilities in transitive dependencies as unreachable if not used directly.
 
 ## Software bill of materials
 

--- a/docs/semgrep-supply-chain/triage-remediation.md
+++ b/docs/semgrep-supply-chain/triage-remediation.md
@@ -83,7 +83,9 @@ The transitivity of the finding:
 * **Transitive**: Your project's dependency depends on a vulnerable dependency.
 * **Undetermined**: Semgrep had no transitivity information for the dependency as it relates to your project.
 
-Semgrep determines transitivity by the presence of a manifest file corresponding to the lockfile being scanned. If there is no corresponding manifest file&mdash;for example, if you use `requirements.txt` directly as a lockfile for your Python applications&mdash;the dependency transitivity is Undetermined. Undetermined dependencies are treated as direct dependencies for the purpose of reachability.
+Semgrep determines transitivity using information from the manifest. If there is no corresponding manifest file, and the information is not available in the lockfile, the dependency transitivity is Undetermined. This can occur, for example, if you use `requirements.txt` directly as a lockfile for your Python applications.
+
+Undetermined dependencies are treated as direct dependencies for the purpose of reachability.
 
 ### EPSS probability
 

--- a/docs/semgrep-supply-chain/triage-remediation.md
+++ b/docs/semgrep-supply-chain/triage-remediation.md
@@ -83,9 +83,9 @@ The transitivity of the finding:
 * **Transitive**: Your project's dependency depends on a vulnerable dependency.
 * **Undetermined**: Semgrep had no transitivity information for the dependency as it relates to your project.
 
-Semgrep determines transitivity using information from the manifest. If there is no corresponding manifest file, and the information is not available in the lockfile, the dependency transitivity is Undetermined. This can occur, for example, if you use `requirements.txt` directly as a lockfile for your Python applications.
+Semgrep determines transitivity using information from the manifest. If there is no corresponding manifest file, and the information is not available in the lockfile, the dependency transitivity is **Undetermined**. This can occur, for example, if you use `requirements.txt` directly as a lockfile for your Python applications.
 
-Undetermined dependencies are treated as direct dependencies for the purpose of reachability.
+Undetermined dependencies are treated as direct dependencies for the purposes of reachability.
 
 ### EPSS probability
 

--- a/docs/semgrep-supply-chain/triage-remediation.md
+++ b/docs/semgrep-supply-chain/triage-remediation.md
@@ -75,15 +75,15 @@ The triage state of the finding:
 * **Ignored**: Vulnerabilities that have been triaged as **Ignored** by the user. You can filter findings with a status of **Ignored** further by reason: **False positive**, **Acceptable risk**, **No time to fix**, or **No triage reason**.
 * **Fixed**: Vulnerabilities that are no longer detected after a scan. This typically means that the dependency containing the vulnerability has been updated. Semgrep Supply Chain automatically checks if the dependency has been updated and sets the vulnerability's status as **Fixed**.
 
-> You can set the **Fixing** and **Reviewing** statuses only if you are a [Jira beta](https://semgrep.dev/docs/semgrep-appsec-platform/jira) participant.
-
 ### Transitivity
 
-The transitivity of the finding: 
+The transitivity of the finding:
 
 * **Direct**: Your project depends directly on the dependency.
 * **Transitive**: Your project's dependency depends on a vulnerable dependency.
 * **Undetermined**: Semgrep had no transitivity information for the dependency as it relates to your project.
+
+Semgrep determines transitivity by the presence of a manifest file corresponding to the lockfile being scanned. If there is no corresponding manifest file&mdash;for example, if you use `requirements.txt` directly as a lockfile for your Python applications&mdash;the dependency transitivity is Undetermined. Undetermined dependencies are treated as direct dependencies for the purpose of reachability.
 
 ### EPSS probability
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -184,7 +184,7 @@ Additionally, Semgrep offers beta support for the scanning of Java projects **wi
   <tr>
    <td rowspan="4">Python</td>
    <td>pip</td>
-   <td rowspan="2">Any of the following: <ul><li>`*requirement*.txt` file</li><li>Any lockfile in a requirements folder, such as `**/requirements/*.txt`</li><li>`requirements.pip`</li></ul> The file must be generated automatically and have values set to exact versions (pinned dependencies).</td>
+   <td rowspan="2">Any of the following: <ul><li>`*requirement*.txt` file</li><li>Any lockfile in a requirements folder, such as `**/requirement/*.txt or `**/requirements/*.txt`</li><li>`requirements.pip`</li></ul> The file must be generated automatically and have values set to exact versions (pinned dependencies).</td>
    <td style={{"text-align": "center"}}>GA</td>
    <td rowspan="4">✅ (PyPI packages only)</td>
   </tr>

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -184,7 +184,7 @@ Additionally, Semgrep offers beta support for the scanning of Java projects **wi
   <tr>
    <td rowspan="4">Python</td>
    <td>pip</td>
-   <td rowspan="2">Any of the following: <ul><li>`*requirement*.txt` file</li><li>Any lockfile in a requirements folder, such as `**/requirement/*.txt or `**/requirements/*.txt`</li><li>`requirements.pip`</li></ul> The file must be generated automatically and have values set to exact versions (pinned dependencies).</td>
+   <td rowspan="2">Any of the following: <ul><li>`*requirement*.txt` file</li><li>Any lockfile in a requirements folder, such as `**/requirement/*.txt` or `**/requirements/*.txt`</li><li>`requirements.pip`</li></ul> The file must be generated automatically and have values set to exact versions (pinned dependencies).</td>
    <td style={{"text-align": "center"}}>GA</td>
    <td rowspan="4">✅ (PyPI packages only)</td>
   </tr>


### PR DESCRIPTION
A set of updates mostly focused on Python lockfile info, but with a few other bits of cleanup - statuses no longer gated by Jira beta, remove otherwise unused tags.

Note: SME approval will be important for this PR.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
