### PR TITLE
Update artifact workflow versions

### DIFF
--- a/docs/kb/semgrep-supply-chain/ssc-python-lockfiles.md
+++ b/docs/kb/semgrep-supply-chain/ssc-python-lockfiles.md
@@ -152,7 +152,7 @@ jobs:
           pip3 install pip-tools
           pip-compile -o requirements.txt
       - name: Upload Requirements File as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirementstxt
           path: requirements.txt
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download artifact from previous job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: requirementstxt
       - run: semgrep ci --supply-chain


### PR DESCRIPTION
GitHub is [deprecating v3 of their artifact workflows](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), so we should proactively update.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
