### PR TITLE
Correct the subdir paths in monorepo KB article.

### DIFF
--- a/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
+++ b/docs/kb/semgrep-ci/scan-monorepo-in-parts.md
@@ -31,15 +31,15 @@ There are two features provided by Semgrep to split up a repo. Consider a monore
 The easiest way to split this monorepo up is into four separate scans, one for each module. To do this, use the `--subdir` flag with the relevant path to only scan files in that module's code path:
 
 ```
-semgrep ci --subdir /src/moduleA/*
+semgrep ci --subdir src/moduleA/
 ```
 
-In addition to scanning `/src/moduleA/*`, this command sends the results to a project called `monorepo/src/moduleA`. If you want to change the project name, set the `SEMGREP_REPO_DISPLAY_NAME` environment variable, available since Semgrep version 1.61.1.
+In addition to scanning `src/moduleA/`, this command sends the results to a project called `monorepo/src/moduleA`. If you want to change the project name, set the `SEMGREP_REPO_DISPLAY_NAME` environment variable, available since Semgrep version 1.61.1.
 
 For example:
 
 ```
-SEMGREP_REPO_DISPLAY_NAME=monorepo/moduleA semgrep ci --subdir /src/moduleA/*
+SEMGREP_REPO_DISPLAY_NAME=monorepo/moduleA semgrep ci --subdir src/moduleA/
 ```
 
 It is important that scans of different versions never have the same `SEMGREP_REPO_DISPLAY_NAME`. This is necessary to ensure findings have a consistent status and is helpful for developers and security engineers to understand which findings pertain to the module that they are responsible for.
@@ -57,7 +57,7 @@ Unlike `--subdir`, `--include` and `--exclude` don't automatically direct result
 Here's an example using `--include`.
 
 ```
-SEMGREP_REPO_DISPLAY_NAME=monorepo/moduleAB semgrep ci --include=/src/moduleA/* --include=/src/moduleB/*
+SEMGREP_REPO_DISPLAY_NAME=monorepo/moduleAB semgrep ci --include=src/moduleA/ --include=src/moduleB/
 ```
 
 :::info
@@ -160,7 +160,7 @@ jobs:
       # Fetch project source with GitHub Actions Checkout. Use either v3 or v4.
       - uses: actions/checkout@v4
       # Run the "semgrep ci" command on the command line of the docker image.
-      - run: semgrep ci --include=src/moduleA/**
+      - run: semgrep ci --include=src/moduleA/
         env:
           # Connect to Semgrep AppSec Platform through your SEMGREP_APP_TOKEN.
           # Generate a token from Semgrep AppSec Platform > Settings


### PR DESCRIPTION
The subdir paths used in the sample code in the KB article "How to scan a monorepo in parts" cause errors to be thrown.

The paths were of the following incorrect structure "/dirA/dirB/*"

If you use this structure in a semgrep ci command it causes the shell to error:
![image](https://github.com/user-attachments/assets/c7445ff4-9617-47b7-ab40-0f540278ec86)

If the ending asterisk is removed, but the beginning forward-slash is retained, it causes a different error:
![image](https://github.com/user-attachments/assets/dd27a5b7-2adc-4880-9d33-f71dc3c5ab7b)

If the beginning forward-slash is retained, but the ending asterisk remains, it causes a third error: 
![image](https://github.com/user-attachments/assets/1f1cd1db-55fb-4ac2-9864-a9ad9b86932e)

Therefore, both the beginning forward-slash and the ending asterisk must be removed. 
![image](https://github.com/user-attachments/assets/4857d984-9cda-41f5-b873-0c594e1f4107)

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
