### PR TITLE
Remove reference to the asdf-semgrep plugin

### DIFF
--- a/docs/extensions/overview.md
+++ b/docs/extensions/overview.md
@@ -52,10 +52,6 @@ If you would like to run the pre-commit hook **locally** while using Semgrep Pro
 
 <Login />
 
-### Version management
-
-- asdf: [ASDF Semgrep](https://github.com/brentjanderson/asdf-semgrep)
-
 ### Semgrep as an engine
 
 Many other tools have capabilities powered by Semgrep.


### PR DESCRIPTION
The asdf-semgrep plugin has been non-functional since March 2023 due to a change in release artifacts introduced in Semgrep v1.16.0.

See issue here: https://github.com/brentjanderson/asdf-semgrep/issues/1

This was noticed by a Semgrep customer that uses asdf. They requested that we remove reference to non-functioning extensions.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [X] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [X] This change has no security implications or else you have pinged the security team
- [X] Redirects are added if the PR changes page URLs
- [X] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
