### PR TITLE
add electron as a source (xs sized PR)

### DIFF
--- a/docs/semgrep-supply-chain/sbom.md
+++ b/docs/semgrep-supply-chain/sbom.md
@@ -56,6 +56,6 @@ In addition to the [<i class="fas fa-external-link fa-xs"></i> minimum elements 
 | Description | A short description of the vulnerability. |
 | Detail | A longer description of the vulnerability, including the affected versions. |
 | Ratings | Semgrep Supply Chain's severity rating of this vulnerability. |
-| References | Links to the specific CVE. References can come from NIST and GitHub Security Advisory. |
+| References | Links to the specific CVE. References can come from NIST, Electron release notes, and GitHub Security Advisory. |
 | Source | The primary source of this vulnerability's advisory. |
 | Tools | Details about Semgrep, the tool used to generate the SBOM. |

--- a/src/components/reference/_admonition-sot-cves.md
+++ b/src/components/reference/_admonition-sot-cves.md
@@ -1,6 +1,11 @@
 ### Semgrep Supply Chain rule update frequency
 
-Semgrep ingests CVE information and security advisories from sources such as [Reviewed GitHub Security Advisories](https://github.com/advisories?query=type%3Areviewed) to ensure effective rule coverage. Semgrep processes new information at least once per day to:
+Semgrep ingests CVE information and security advisories from the following sources:
 
-* Generate rules for new security advisories;
-* Update rules based on changes to existing security advisories.
+- [<i class="fas fa-external-link fa-xs"></i> Reviewed GitHub Security Advisories](https://github.com/advisories?query=type%3Areviewed)
+- [<i class="fas fa-external-link fa-xs"></i> Electron release notes](https://releases.electronjs.org/releases/stable)
+
+Semgrep processes new information at least once per day to:
+
+* Generate rules for new security advisories
+* Update rules based on changes to existing security advisories


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR

Tiny PR. I checked our **Advisories** tab and we don't show the source of the CVE (yet) so I just listed electron release notes as a source.