### PR TITLE
Make links clearer in extensions overview (quick win)

### DIFF
--- a/docs/extensions/semgrep-intellij.md
+++ b/docs/extensions/semgrep-intellij.md
@@ -1,5 +1,7 @@
 ---
 slug: semgrep-intellij
+title: IntelliJ extension
+hide_title: true
 append_help_link: true
 description: "Learn how to install and use Semgrep's extension for IntelliJ."
 tags:

--- a/docs/extensions/semgrep-vs-code.md
+++ b/docs/extensions/semgrep-vs-code.md
@@ -1,6 +1,6 @@
 ---
 slug: semgrep-vs-code
-title: Semgrep Visual Studio Code extension
+title: Visual Studio Code extension
 hide_title: true
 description: Learn how to install and use Semgrep's extension for Visual Studio Code.
 tags:

--- a/src/components/reference/_ide-list.md
+++ b/src/components/reference/_ide-list.md
@@ -1,3 +1,5 @@
-- Microsoft Visual Studio Code: [<i class="fas fa-external-link fa-xs"></i> `semgrep-vscode`](https://marketplace.visualstudio.com/items?itemName=semgrep.semgrep)
-- IntelliJ Ultimate Idea and many other IntelliJ products: [<i class="fas fa-external-link fa-xs"></i> `semgrep-intellij`](https://plugins.jetbrains.com/plugin/22622-semgrep)
-- Emacs: [<i class="fas fa-external-link fa-xs"></i> `lsp-mode`](https://github.com/emacs-lsp/lsp-mode)
+| Name | Marketplace link | Documentation |
+| -------  | ------ | ------ |
+|  Microsoft Visual Studio Code | [<i class="fas fa-external-link fa-xs"></i> `semgrep-vscode`](https://marketplace.visualstudio.com/items?itemName=semgrep.semgrep) | [Semgrep VS Code extension](/extensions/semgrep-vs-code) |
+| IntelliJ Ultimate Idea<br />and many other IntelliJ products |[<i class="fas fa-external-link fa-xs"></i> `semgrep-intellij`](https://plugins.jetbrains.com/plugin/22622-semgrep) |[Semgrep IntelliJ extension](/extensions/semgrep-intellij) |
+| Emacs | [<i class="fas fa-external-link fa-xs"></i> `lsp-mode`](https://github.com/emacs-lsp/lsp-mode) | See repository README |


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A technical writer reviews the content or PR

### Notes

- See linear and Slack for context.
- Converted to table because listing the links inline might cause the user to skip them (which was the issue)
- Shortened titles of extension docs