### PR TITLE
move filing request for new ci providers to semgrep-docs (quick win)

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -491,4 +491,4 @@ By setting various [CI environment variables](/semgrep-ci/ci-environment-variabl
 - TeamCity CI
 - Travis CI
 
-Is your CI provider missing? Let us know by [filing an issue](https://github.com/semgrep/semgrep/issues/new?assignees=&labels=&template=feature_request.md&title=).
+Is your CI provider missing? Let the Semgrep team know by [filing an issue](https://github.com/semgrep/semgrep-docs/issues/).

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -491,4 +491,4 @@ By setting various [CI environment variables](/semgrep-ci/ci-environment-variabl
 - TeamCity CI
 - Travis CI
 
-Is your CI provider missing? Let the Semgrep team know by [filing an issue](https://github.com/semgrep/semgrep-docs/issues/).
+Is your CI provider missing? Let the Semgrep team know by [<i class="fas fa-external-link fa-xs"></i> filing an issue](https://github.com/semgrep/semgrep-docs/issues/), or [<i class="fas fa-external-link fa-xs"></i> submit a contribution](https://github.com/semgrep/semgrep-docs/pulls/).


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR

Decided to let the issue be filed in semgrep-docs because:
- semgrep/semgrep isn't the right place for semgrep appsec platform requests
- users can still send contributions for Semgrep CE configurations
- we (tech writers) can escalate to our tracking / feature request system.