### PR TITLE
fix: clarify we support all versions of npm, yarn and pnpm for SSC

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -115,20 +115,20 @@ Additionally, Semgrep offers beta support for the scanning of Java projects **wi
   </tr>
   <tr>
    <td rowspan="3">JavaScript or TypeScript</td>
-   <td>npm (all versions)</td>
+   <td>npm</td>
    <td><code>package-lock.json</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✅</td>
    <td rowspan="3" style={{"text-align": "center"}}>GA</td>
   </tr>
   <tr>
-   <td>Yarn (all versions)</td>
+   <td>Yarn</td>
    <td><code>yarn.lock</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✅</td>
   </tr>
   <tr>
-   <td>pnpm (all versions)</td>
+   <td>pnpm</td>
    <td><code>pnpm-lock.yaml</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✅</td>

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -115,20 +115,20 @@ Additionally, Semgrep offers beta support for the scanning of Java projects **wi
   </tr>
   <tr>
    <td rowspan="3">JavaScript or TypeScript</td>
-   <td>npm (Node.js)</td>
+   <td>npm (all versions)</td>
    <td><code>package-lock.json</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✅</td>
    <td rowspan="3" style={{"text-align": "center"}}>GA</td>
   </tr>
   <tr>
-   <td>Yarn, Yarn 2, Yarn 3</td>
+   <td>Yarn (all versions)</td>
    <td><code>yarn.lock</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✅</td>
   </tr>
   <tr>
-   <td>pnpm</td>
+   <td>pnpm (all versions)</td>
    <td><code>pnpm-lock.yaml</code></td>
    <td style={{"text-align": "center"}}>GA</td>
    <td>✅</td>


### PR DESCRIPTION
Yarn is the only package manager we currently mention multiple versions for, and we only say 1-3, even though we also support yarn v4. This change makes it clear we support all versions of npm, yarn and pnpm. I think it would also be reasonable to just drop mention of versions from all three, to keep consistent with the rest of the able.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
