### PR TITLE
Update contributing instructions for OCaml 5

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -11,8 +11,7 @@ The following explains how to build `semgrep-core` so you can make and test chan
 ```bash
 brew install opam
 opam init
-opam switch create 4.14.0 ocaml-base-compiler.4.14.0
-opam switch 4.14.0
+opam switch create semgrep 5.2.1
 eval $(opam env)
 ```
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

In https://github.com/semgrep/semgrep-proprietary/pull/2932, I am updating nearly everything to OCaml 5. For now, we can still build on OCaml 4, but on macOS we need to use OCaml 5 because there are some specific things that we had to change regarding static linking. At this point, the path of least resistance is for contributors to use OCaml 5.

I also slightly simplified the instructions here, and modified them to create an opam switch named `semgrep` (it's a good idea to keep a separate switch for each project).

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
