### PR TITLE
Update ADO PAT token scopes required for SMS

### DIFF
--- a/docs/deployment/managed-scanning/azure.md
+++ b/docs/deployment/managed-scanning/azure.md
@@ -25,8 +25,8 @@ Add Azure DevOps repositories to your Semgrep organization in bulk without addin
   - Once you have Managed Scanning fully configured, you can update the token provided to Semgrep to one that's more restrictive. The scopes you must assign to the token include:
     - `Project and Team: Read & write`
     - `Code: Read`
+    - `Code: Status`
     - `Pull Request Threads: Read & write`
-    - `Service Hooks: Read & manage`
 
 ## Enable Managed Scans and scan your first repository
 


### PR DESCRIPTION
Updating the ADO PAT token scopes for SMS:
- add `Code: Status` scope since it is required for creating commit status and PR status
- remove `Service Hooks` scopes since they are not available in the scopes list when configuring PAT in ADO

Regarding scopes required for managing webhook subscriptions in ADO, I wasn't able to find a definitive answer from ADO docs (more details on it in FS-2005). But when I tested with a PAT that had the scopes in this PR, creating a webhook subscription worked. 

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
