### PR TITLE
Sara/tec 294 docs add GitHub app installation and connection workflow

### DIFF
--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -106,7 +106,7 @@ These instructions are for orgs that set up a non-GitHub SSO **before** performi
 
 
 1. Navigate to the following link: [<i class="fas fa-external-link fa-xs"></i> Semgrep GitHub app](https://github.com/marketplace/semgrep-dev) and install the Semgrep GitHub app onto the GitHub org you want to connect to.
-1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) through your SSO.
+1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) using SSO.
 1. Optional: If you have created more than one Semgrep account, select the account you want to make a connection for by clicking on the **Navigation bar > Your account name > The account you want to connect**.<br />
    <img src="/docs/img/more-accounts-dropdown.png" height="350px" />
 1. From the **Navigation bar**, click **<i class="fa-solid fa-gear"></i> Settings > Source code managers**.

--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -69,7 +69,7 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
    - The **Name of your Bitbucket Workspace**
    - Your **Access token**. Semgrep requires a [workspace-level access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/).
 1. Click **Connect** to save and proceed.
-1. The Bitbucket project is now listed under **Source Code managers**. Click **Test** to verify that the new connection is installed correctly.
+1. The Bitbucket project is now listed under **Source code managers**. Click **Test** to verify that the new connection is installed correctly.
 
 </TabItem>
 <TabItem value='github-cloud'>

--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -92,7 +92,7 @@ These steps are for users that sign in to Semgrep through GitHub.
 
 ### GitHub Cloud with non-GitHub SSO
 
-These instructions are for orgs that set up a non-GitHub SSO **before** performing any of the steps in this document.
+These steps are for users that sign in to Semgrep through a **non-GitHub** SSO provider.
 
 1. Navigate to the following link: [<i class="fas fa-external-link fa-xs"></i> Semgrep GitHub app](https://github.com/marketplace/semgrep-dev) and install the Semgrep GitHub app onto the GitHub org you want to connect to.
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) using SSO.

--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -100,6 +100,11 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
 
 <TabItem value='non-gh'>
 
+:::info
+These instructions are for orgs that set up a non-GitHub SSO **before** performing any of the steps in this document.
+:::
+
+
 1. Navigate to the following link: [<i class="fas fa-external-link fa-xs"></i> Semgrep GitHub app](https://github.com/marketplace/semgrep-dev) and install the Semgrep GitHub app onto the GitHub org you want to connect to.
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) through your SSO.
 1. Optional: If you have created more than one Semgrep account, select the account you want to make a connection for by clicking on the **Navigation bar > Your account name > The account you want to connect**.<br />

--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -56,7 +56,7 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
    - The **Name of your Azure DevOps organization**
    - Your **Access token**. See [User personal access tokens](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) for information on generating a token.
 2. Click **Connect** to save and proceed.
-3. The Azure DevOps organization is now listed under **Source Code managers**. Click **Test** to verify that the new connection is installed correctly.
+3. The Azure DevOps organization is now listed under **Source code managers**. Click **Test** to verify that the new connection is installed correctly.
 
 </TabItem>
 <TabItem value='bitbucket-cloud'>

--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -74,15 +74,9 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
 </TabItem>
 <TabItem value='github-cloud'>
 
-<Tabs
-    defaultValue="default"
-    values={[
-    {label: 'Default GitHub Cloud', value: 'default'},
-    {label: 'GitHub Cloud with non-GitHub SSO', value: 'non-gh'},
-    ]}
->
+### GitHub Cloud with GitHub SSO
 
-<TabItem value='default'>
+These steps are for users that sign in to Semgrep through GitHub.
 
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login).
 1. Optional: If you have created more than one Semgrep account, select the account you want to make a connection for by clicking on the **Navigation bar > Your account name > The account you want to connect**.<br />
@@ -96,14 +90,9 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
 1. After a successful link, you are signed out of Semgrep AppSec Platform automatically, as your credentials have changed after linking an organization.
 1. Sign back in to Semgrep AppSec Platform.
 
-</TabItem>
+### GitHub Cloud with non-GitHub SSO
 
-<TabItem value='non-gh'>
-
-:::info
 These instructions are for orgs that set up a non-GitHub SSO **before** performing any of the steps in this document.
-:::
-
 
 1. Navigate to the following link: [<i class="fas fa-external-link fa-xs"></i> Semgrep GitHub app](https://github.com/marketplace/semgrep-dev) and install the Semgrep GitHub app onto the GitHub org you want to connect to.
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) using SSO.
@@ -115,9 +104,6 @@ These instructions are for orgs that set up a non-GitHub SSO **before** performi
 1. Leave the access token field empty.
 1. Click **Connect**.
 1. Your GitHub org is now listed under **Source Code managers**. Click **Test** to verify that the new connection is installed correctly.
-
-</TabItem>
-</Tabs>
 
 </TabItem>
 

--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -56,7 +56,7 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
    - The **Name of your Azure DevOps organization**
    - Your **Access token**. See [User personal access tokens](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) for information on generating a token.
 2. Click **Connect** to save and proceed.
-3. The Azure DevOps organization is now listed under **Source Code managers**. Click **Test** to verify that the new integration is installed correctly.
+3. The Azure DevOps organization is now listed under **Source Code managers**. Click **Test** to verify that the new connection is installed correctly.
 
 </TabItem>
 <TabItem value='bitbucket-cloud'>
@@ -67,18 +67,28 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
 1. Go to **<i class="fa-solid fa-gear"></i> Settings > Source code managers > Add > Bitbucket Cloud**.
 1. In the **Connect your Bitbucket Workspace** dialog box, provide:
    - The **Name of your Bitbucket Workspace**
-   - Your **Access token**. Semgrep expects a [workspace-level access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/).
+   - Your **Access token**. Semgrep requires a [workspace-level access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/).
 1. Click **Connect** to save and proceed.
-1. The Bitbucket project is now listed under **Source Code managers**. Click **Test** to verify that the new integration is installed correctly.
+1. The Bitbucket project is now listed under **Source Code managers**. Click **Test** to verify that the new connection is installed correctly.
 
 </TabItem>
 <TabItem value='github-cloud'>
+
+<Tabs
+    defaultValue="default"
+    values={[
+    {label: 'Default GitHub Cloud', value: 'default'},
+    {label: 'GitHub Cloud with non-GitHub SSO', value: 'non-gh'},
+    ]}
+>
+
+<TabItem value='default'>
 
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login).
 1. Optional: If you have created more than one Semgrep account, select the account you want to make a connection for by clicking on the **Navigation bar > Your account name > The account you want to connect**.<br />
    <img src="/docs/img/more-accounts-dropdown.png" height="350px" />
 1. From the **Navigation bar**, click **<i class="fa-solid fa-gear"></i> Settings > Source code managers**.
-1. Click **Connect to GitHub**.
+1. Click **Add > GitHub**.
 1. Review the permissions requested by Semgrep, then click **Continue**.
 1. Click the organization you want to install Semgrep on.
 1. Choose to authorize and install Semgrep for **<i class="fa-regular fa-circle-dot"></i> All repositories** or **<i class="fa-regular fa-circle-dot"></i> Only select repositories**.
@@ -88,13 +98,24 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
 
 </TabItem>
 
-<!-- removed temporarily because we're using the "old flow"
-:::tip
-- Getting Assistant recommendations grants Semgrep **code access**.
-- **Leave PR comments** refers to Semgrep's capability to post findings to developers in PRs.
-:::
+<TabItem value='non-gh'>
 
--->
+1. Navigate to the following link: [<i class="fas fa-external-link fa-xs"></i> Semgrep GitHub app](https://github.com/marketplace/semgrep-dev) and install the Semgrep GitHub app onto the GitHub org you want to connect to.
+1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) through your SSO.
+1. Optional: If you have created more than one Semgrep account, select the account you want to make a connection for by clicking on the **Navigation bar > Your account name > The account you want to connect**.<br />
+   <img src="/docs/img/more-accounts-dropdown.png" height="350px" />
+1. From the **Navigation bar**, click **<i class="fa-solid fa-gear"></i> Settings > Source code managers**.
+1. Click **Add > GitHub**.
+1. In the **Name of your GitHub Organization** field, enter the slug of the org that the app was installed on in step 1. For example, if the GitHub URL of your org is `https://github.com/acme-corp`, then the slug is typically `acme-corp`.
+1. Leave the access token field empty.
+1. Click **Connect**.
+1. Your GitHub org is now listed under **Source Code managers**. Click **Test** to verify that the new connection is installed correctly.
+
+</TabItem>
+</Tabs>
+
+</TabItem>
+
 
 <TabItem value='gitlab-cloud'>
 
@@ -106,7 +127,7 @@ If you opted to scan a GitHub or GitLab repository when you initially signed in,
 1. Enter the personal access token generated into the **Access token** field.
 1. Enter your GitLab group's name into the **Name of your GitLab Group** field. If your repositories are organized in subgroups, you only need to provide the name of the top-level group.
 1. Optional, but recommended: if you have multiple GitLab groups in your GitLab account, create a source code manager per group. Repeat steps 1, 3-4 for each GitLab group.
-1. The GitLab groups are now listed under **Source code managers**. Click **Test** to verify that the new integration is configured correctly.
+1. The GitLab groups are now listed under **Source code managers**. Click **Test** to verify that the new connection is configured correctly.
 
 You have successfully connected an org in Semgrep AppSec Platform with an organization in your source code management tool.
 
@@ -135,7 +156,7 @@ You have successfully connected an org in Semgrep AppSec Platform with an organi
    - The **URL** to access your installation of Bitbucket Data Center
    - The **Access Token** that [grants Semgrep permission to communicate with your project](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html). Semgrep expects a [workspace-level access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/)
 2. Click **Connect** to save and proceed.
-3. The Bitbucket project is now listed under **Source code managers**. Click **Test** to verify that the new integration was installed correctly.
+3. The Bitbucket project is now listed under **Source code managers**. Click **Test** to verify that the new connection was installed correctly.
 
 </TabItem>
 <TabItem value='github-enterprise'>
@@ -214,7 +235,7 @@ Connect Semgrep and GitLab Self-Managed accounts by creating a PAT and providing
 1. Enter your GLSM base URL into the **URL** field.
 1. Enter your GitLab group's name into the **Name of your GitLab Group** field. If your repositories are organized in subgroups, you only need to provide the name of the top-level group.
 1. If you have multiple GitLab groups in your GitLab account, you need to create a source code manager per group. Repeat steps 1, 3-5 for each GitLab group.
-1. The GitLab groups are now listed under **Source Code managers**. Click **Test** to verify that the new integration is installed correctly.
+1. The GitLab groups are now listed under **Source Code managers**. Click **Test** to verify that the new connection is installed correctly.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR

- Fixes TEC-294. Additionally adds a callout that says SSO must have been set up first (because "usually" SSO is set up after) before performing the connection.
- Updates "integration" with "connection" because "connect" is used in the Semgrep AppSec Platform UI.
- **I am not sure about using double nested tabs**, feedback welcome.

### Static preview

![Snag_106b5b9](https://github.com/user-attachments/assets/e3f7851e-edb9-4148-8244-c39900e09bd9)

