### PR TITLE
move Wiz doc from KB to main docs

### DIFF
--- a/docs/semgrep-appsec-platform/wiz.md
+++ b/docs/semgrep-appsec-platform/wiz.md
@@ -1,7 +1,7 @@
 ---
 slug: wiz
 append_help_link: true
-title: View Semgrep findings in Wiz's Security Graph
+title: Wiz
 hide_title: true
 description: "Learn how to view Semgrep findings in Wiz's Security Graph."
 tags:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -403,6 +403,8 @@ module.exports = {
           { from: "/semgrep-supply-chain/ignoring-dependencies" , to: "/semgrep-supply-chain/ignoring-dependencies" } ,
           /* FEB 26, 2025 */
           { from: "/faq" , to: "/faq/overview" },
+          /* MAR 4, 2025 */
+          { from: "/kb/integrations/wiz" , to: "/semgrep-appsec-platform/wiz" },
         ]
       }
     ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -176,7 +176,6 @@ module.exports = {
             'semgrep-appsec-platform/webhooks'
           ]
         },
-        'semgrep-appsec-platform/jira',
         'semgrep-appsec-platform/dashboard',
         {
           type: 'category',
@@ -189,6 +188,15 @@ module.exports = {
           items: [
             'extensions/semgrep-vs-code',
             'extensions/semgrep-intellij'
+          ]
+        },
+        {
+          type: 'category',
+          label: 'Integrations',
+          collapsible: true,
+          items: [
+            'semgrep-appsec-platform/jira',
+            'semgrep-appsec-platform/wiz'
           ]
         },
       ]


### PR DESCRIPTION
Verified that https://deploy-preview-2003--semgrep-docs-prod.netlify.app/docs/kb/integrations/wiz redirects properly to https://deploy-preview-2003--semgrep-docs-prod.netlify.app/docs/semgrep-appsec-platform/wiz

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] Redirects are added if the PR changes page URLs
