### PR TITLE
Clarify that contributing through the platform is for new rules

### DIFF
--- a/docs/contributing/contributing-rules.md
+++ b/docs/contributing/contributing-rules.md
@@ -15,12 +15,14 @@ Publish rules to the Semgrep Registry to share them with the Semgrep community a
 
 <dl>
     <dt>For users of Semgrep AppSec Platform</dt>
-    <dd>Contribute rules to the Semgrep Registry through Semgrep AppSec Platform. This workflow is recommended. See <a href="#contribute-through-semgrep-appsec-platform-recommended"> Contribute through Semgrep AppSec Platform (recommended)</a>. This workflow creates the necessary pull request for you and streamlines the whole process.</dd>
+    <dd>Contribute new rules to the Semgrep Registry through Semgrep AppSec Platform. This workflow is recommended. See <a href="#contribute-through-semgrep-appsec-platform-recommended"> Contribute through Semgrep AppSec Platform (recommended)</a>. This workflow creates the necessary pull request for you and streamlines the whole process.</dd>
     <dt>For contributors to the repository through GitHub</dt>
-    <dd>Contribute rules to the Semgrep Registry through a pull request to `semgrep-rules`. See the <a href="#contribute-through-github"> Contribute through GitHub</a> section for detailed information.</dd>
+    <dd>Contribute rules to the Semgrep Registry, or suggest changes to existing rules, through a pull request to `semgrep-rules`. See the <a href="#contribute-through-github"> Contribute through GitHub</a> section for detailed information.</dd>
 </dl>
 
 ## Contribute through Semgrep AppSec Platform (recommended)
+
+This is the recommended path for adding a new rule. To suggest a change to an existing rule, see [Update existing rules in Semgrep Registry](#update-existing-rules-in-semgrep-registry).
 
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login).
 1. Go to the [<i class="fas fa-external-link fa-xs"></i> Semgrep Playground](https://semgrep.dev/playground/new).


### PR DESCRIPTION
No new content, just putting some nudges towards the updating documentation higher on the page and making it more clear that the platform process can't be used to revise already-published rules.

# Thanks for improving Semgrep Docs 😀

:heart:

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- ~~This change has no security implications or else you have pinged the security team~~
- ~~Redirects are added if the PR changes page URLs~~
- ~~If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link~~
