### PR TITLE
replace 20.04 in maven sca example gha workflow

### DIFF
--- a/docs/semgrep-supply-chain/setup-maven.md
+++ b/docs/semgrep-supply-chain/setup-maven.md
@@ -147,7 +147,7 @@ jobs:
   semgrep:
     needs: buildmavenDepTree
     name: Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR


It looks like we missed one instance of `ubuntu-20.04` in our CI examples. This fixes that.
