### PR TITLE
Replace 'scanning root' with 'scan root' because it sounds better

### DIFF
--- a/docs/release-notes/january-2025.md
+++ b/docs/release-notes/january-2025.md
@@ -63,7 +63,7 @@ tags:
 - The `semgrep test` and `semgrep validate` commands have been correctly documented as **EXPERIMENTAL** in `semgrep --help`.
   - Those commands are not GA. It is recommended to use the `semgrep scan --test` and `semgrep scan --validate`.
 - Improve error handling for capabilities ancillary to a scan, such as looking for `nosemgrep` comments and rendering autofixes, to reduce the likelihood of an unexpected error in such a component causing the scan to error.
-- Fix the behavior of Semgrep when running into broken symlinks. If such a path is passed explicitly as a scanning root on the command line, it results in an error. Otherwise, if it's a file discovered while scanning the file system, it's a warning.
+- Fix the behavior of Semgrep when running into broken symlinks. If such a path is passed explicitly as a scan root on the command line, it results in an error. Otherwise, if it's a file discovered while scanning the file system, it's a warning.
 - Fixed an issue with crashes due to an exception in `lines_of_file`. The code should now be more robust and not stop the whole scan when an out-of-bound line access happens during `nosemgrep` analysis or when displaying the lines of a match.
 
 ## ⛓️ Semgrep Supply Chain

--- a/docs/semgrepignore-v2-reference.md
+++ b/docs/semgrepignore-v2-reference.md
@@ -19,38 +19,38 @@ referred to as "v1".
 
 ## The target filtering process
 
-A `semgrep scan` command takes one or more scanning roots as
-arguments. The default scanning root is the current folder, `.`.
-Scanning roots are folders, individual files, or named pipes that should be
+A `semgrep scan` command takes one or more scan roots as
+arguments. The default scan root is the current folder, `.`.
+Scan roots are folders, individual files, or named pipes that should be
 expanded into a list of regular files to be analyzed. Symbolic links are
-allowed as scanning roots.
+allowed as scan roots.
 
 Expanding a folder consists of listing its contents recursively with
 the following exceptions:
 
-* Symbolic links other than the original scanning roots are ignored.
+* Symbolic links other than the original scan roots are ignored.
 * In Git projects, Git submodules are ignored.
 * Paths excluded via Semgrepignore patterns are ignored. Semgrepignore
   patterns can be of different sources which are detailed in the
   upcoming section.
 
-The list of files obtained by expanding the scanning roots are called
+The list of files obtained by expanding the scan roots are called
 **target files**. To obtain target files, Semgrep follows a
 number of fixed rules and some configurable filters.
 
-For each scanning root, Semgrep infers a **project root** (v2 only). The
+For each scan root, Semgrep infers a **project root** (v2 only). The
 project root determines the location of applicable `.semgrepignore`
 files as well as `.gitignore` files in Git projects. In v1 where is no
 notion of a project root, the `.semgrepignore` file is unique and
 looked up in the current folder.
 
-Semgrep determines the project root for each scanning root by first
-obtaining the real path (physical path) to the scanning root. Then,
+Semgrep determines the project root for each scan root by first
+obtaining the real path (physical path) to the scan root. Then,
 Semgrep searches up the file hierarchy for a `.git` folder or
 similar used by one of the popular file version control systems
 (Git, Mercurial, etc.) indicating a project root.
 If no project root is found this way, it
-defaults to the scanning root itself if it is a folder or to its containing
+defaults to the scan root itself if it is a folder or to its containing
 folder if it is a regular file.
 
 <!-- TODO: explain project detection.

--- a/src/components/reference/_cli-help-ci-output.md
+++ b/src/components/reference/_cli-help-ci-output.md
@@ -372,7 +372,7 @@ OPTIONS
            '.gitignore' files to determine which files semgrep should scan.
            As a result of '--no-git-ignore', gitignored files and git
            submodules will be scanned. This flag has no effect if the
-           scanning root is not in a git repository. '--use-git-ignore' is
+           scan root is not in a git repository. '--use-git-ignore' is
            semgrep's default behavior.
 
        -v, --verbose

--- a/src/components/reference/_cli-help-scan-output.md
+++ b/src/components/reference/_cli-help-scan-output.md
@@ -336,10 +336,10 @@ OPTIONS
            option forces the project root to be a specific folder and assumes
            a local project without version control (novcs). This option is
            useful to ensure the '.semgrepignore' file that may exist at the
-           project root is consulted when the scanning root is not the
+           project root is consulted when the scan root is not the
            current folder '.'. A valid project root must be a folder (path
            referencing a directory) whose physical path is a prefix of the
-           physical path of the scanning roots passed on the command line.
+           physical path of the scan roots passed on the command line.
            For example, the command 'semgrep scan --project-root . src' is
            valid if '.' is '/home/me' and 'src' is a directory or a symbolic
            link to a '/home/me/sources' directory or a symbolic link to a
@@ -446,7 +446,7 @@ OPTIONS
            '.gitignore' files to determine which files semgrep should scan.
            As a result of '--no-git-ignore', gitignored files and git
            submodules will be scanned. This flag has no effect if the
-           scanning root is not in a git repository. '--use-git-ignore' is
+           scan root is not in a git repository. '--use-git-ignore' is
            semgrep's default behavior.
 
        -v, --verbose


### PR DESCRIPTION
This a global search-and-replace for "scanning root" that becomes "scan root". I'm the one who originally started using the term "scanning root" but I realized "scan root" makes more sense after noticing a user using the term.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
