### PR TITLE
[xs] Add project_admin permissions

### DIFF
--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -139,16 +139,21 @@ You have successfully connected an org in Semgrep AppSec Platform with an organi
 
 <TabItem value='bitbucket-data-center'>
 
+
+1. Create an HTTP Access Token for your project following the steps outlined in [<i class="fas fa-external-link fa-xs"></i> Bitbucket Data Center documentation](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html). Ensure that the access token is created with `PROJECT_ADMIN` permissions.
+1. Copy the token for use in the next steps.
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login).
 1. Optional: If you have created more than one Semgrep account, select the account you want to make a connection for by clicking on the **Navigation bar > Your account name > The account you want to connect**.<br />
    <img src="/docs/img/more-accounts-dropdown.png" height="350px" />
 1. Go to **<i class="fa-solid fa-gear"></i> Settings** > **Source code managers**, and click **Add > Bitbucket Data Center**.
 1. In the **Connect your Bitbucket project (key)** dialog box, provide:
    - The **Name of your Bitbucket project (key)**. This must be the project key, which you can find by navigating to `<YOUR_BITBUCKET_DATA_CENTER_BASE_URL>/projects`.
-   - The **URL** to access your installation of Bitbucket Data Center
+   - The **URL** to access your installation of Bitbucket Data Center; this is your fully-qualified domain name.
    - The **Access Token** that grants Semgrep permission to communicate with your project. Semgrep expects an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) with `PROJECT_ADMIN` permissions.
-2. Click **Connect** to save and proceed.
-3. The Bitbucket project is now listed under **Source code managers**. Click **Test** to verify that the new connection was installed correctly.
+1. Click **Connect** to save and proceed.
+1. The Bitbucket project is now listed under **Source code managers**. Click **Test** to verify that the new connection was installed correctly.
+1. To enable merge request comments, click **<i class="fa-solid fa-toggle-large-on"></i> Incoming webhooks**.
+1. Optional: Click **Auto scan** to onboard all current and future repositories under your project to Semgrep Managed Scanning.
 
 </TabItem>
 <TabItem value='github-enterprise'>

--- a/docs/deployment/connect-scm.md
+++ b/docs/deployment/connect-scm.md
@@ -146,7 +146,7 @@ You have successfully connected an org in Semgrep AppSec Platform with an organi
 1. In the **Connect your Bitbucket project (key)** dialog box, provide:
    - The **Name of your Bitbucket project (key)**. This must be the project key, which you can find by navigating to `<YOUR_BITBUCKET_DATA_CENTER_BASE_URL>/projects`.
    - The **URL** to access your installation of Bitbucket Data Center
-   - The **Access Token** that [grants Semgrep permission to communicate with your project](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html). Semgrep expects an [HTTP access token](https://confluence.atlassian.com/bitbucketserverm0930/http-access-tokens-1431540960.html).
+   - The **Access Token** that grants Semgrep permission to communicate with your project. Semgrep expects an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) with `PROJECT_ADMIN` permissions.
 2. Click **Connect** to save and proceed.
 3. The Bitbucket project is now listed under **Source code managers**. Click **Test** to verify that the new connection was installed correctly.
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR

1. Simplified the links into 1, since previously both links were the same doc in different versions of BBDC.
2. Clarified that we need `PROJECT_ADMIN` permissions.
3. Refined steps a bit further based on Slack discussion and JK's doc. Details on Slack. You will notice the instructions in the docs instead point the user to the BB docs to generate the HTTP_ACCESS token. Why? Because BB can change its steps any time and the docs are for all users current and future. For specific cases, listing the steps in 1 place is better for the user/demo. But for general cases, where we can't guess if BB suddenly changes its UI, we leverage their content to ensure correctness.

Preview: https://deploy-preview-2028--semgrep-docs-prod.netlify.app/docs/deployment/connect-scm#connect-to-on-premise-orgs-and-projects click **Bitbucket data center**.