### PR TITLE
Update name of button to add integration

### DIFF
--- a/docs/semgrep-appsec-platform/email.md
+++ b/docs/semgrep-appsec-platform/email.md
@@ -17,7 +17,7 @@ You can choose to receive notifications from Semgrep regarding new findings thro
 Perform these steps in Semgrep AppSec Platform to create an email integration and receive notifications:
 
 1. Create an email integration:
-    1. On the navigation menu, click **<i class="fa-solid fa-gear"></i> Settings > Integrations > Add Integration.**
+    1. On the navigation menu, click **<i class="fa-solid fa-gear"></i> Settings > Integrations > Add**.
     2. Click on **Email**.
     3. Enter a **Name** for the integration.
     4. Enter the **Email address** to receive Semgrep findings.

--- a/docs/semgrep-appsec-platform/jira.md
+++ b/docs/semgrep-appsec-platform/jira.md
@@ -45,7 +45,7 @@ To enable the Jira integration, follow these steps:
 
 1. Sign in to [Semgrep AppSec Platform](https://semgrep.dev/login).
 2. Navigate to [**Settings** > **Integrations**](https://semgrep.dev/orgs/-/settings/integrations).
-3. If this is your first integration, click **Set up First Integration**. Otherwise, click **Add integration**. In the drop-down menu that appears, select **Jira**.
+3. If this is your first integration, click **Set up First Integration**. Otherwise, click **Add**. In the drop-down menu that appears, select **Jira**.
 4. Follow the on-screen instructions to grant Semgrep the necessary permissions and set up the integration.
 5. When prompted, select the Jira instance you want to connect to. If you have multiple Jira instances, choose one instance from the **Use app on** drop-down menu.
    * **For deployments that have used a previous version of the Jira integration**: Ensure you're connecting to the same Jira instance you previously connected to. Please contact Semgrep if you want to connect to a different Jira instance.

--- a/docs/semgrep-appsec-platform/notifications.md
+++ b/docs/semgrep-appsec-platform/notifications.md
@@ -23,6 +23,6 @@ To view all integrations available to you in Semgrep AppSec Platform, follow the
 1. Sign in to your [Semgrep AppSec Platform ](https://semgrep.dev/orgs/-/settings/integrations) account.
 2. Click **Settings**.
 3. Click **Integrations**.
-4. If this is your first integration, click **Set up First Integration**. Otherwise, click **Add Integration**.
+4. If this is your first integration, click **Set up First Integration**. Otherwise, click **Add**.
     ![Screenshot of Integrations page while adding the first integration.](/img/integrations.png#md-width)
     **Figure**. The integrations available in Semgrep AppSec Platform.

--- a/docs/semgrep-appsec-platform/slack.md
+++ b/docs/semgrep-appsec-platform/slack.md
@@ -34,7 +34,7 @@ You can select the channels in your Slack workspace that receive finding notific
 To install the Semgrep Slack app, follow these steps:
 
 1. In [Semgrep AppSec Platform](https://semgrep.dev/login), go to **Settings** > **[Integrations](https://semgrep.dev/orgs/-/settings/integrations)**.
-2. On the **[Integrations](https://semgrep.dev/orgs/-/settings/integrations)** page, click **Add Integration** (or **Setup First Integration** if this is your first integration), and then select **Slack**.
+2. On the **[Integrations](https://semgrep.dev/orgs/-/settings/integrations)** page, click **Add** (or **Setup First Integration** if this is your first integration), and then select **Slack**.
 3. Click **Allow**.
 
 ## Set up notifications for findings in Slack

--- a/docs/semgrep-appsec-platform/webhooks.md
+++ b/docs/semgrep-appsec-platform/webhooks.md
@@ -28,7 +28,7 @@ Semgrep sends two types of JSON objects:
 Perform these steps in Semgrep AppSec Platform to set up webhooks:
 
 1. Create a webhook integration:
-    1. On the navigation menu, click **<i class="fa-solid fa-gear"></i> Settings > Integrations > Add Integration.**
+    1. On the navigation menu, click **<i class="fa-solid fa-gear"></i> Settings > Integrations > Add**.
     2. Click **Webhook**.
     3. In the **Name** field, enter a name for the integration.
     4. In the **Webhook URL** field, enter the target webhook URL for the integration.

--- a/src/components/procedure/_integrate-slack.mdx
+++ b/src/components/procedure/_integrate-slack.mdx
@@ -7,7 +7,7 @@ You must be a Slack workspace owner to set up the Semgrep Slack app.
 To install the Semgrep Slack app, follow these steps:
 
 1. Sign in to your Semgrep AppSec Platform account, and then go to **Settings** > **[Integrations](https://semgrep.dev/orgs/-/settings/integrations)**.
-1. On the [Integrations](https://semgrep.dev/orgs/-/settings/integrations) page, click **Add Integration** (or **Setup First Integration** if this is your first integration), and then select **Slack**.
+1. On the [Integrations](https://semgrep.dev/orgs/-/settings/integrations) page, click **Add** (or **Setup First Integration** if this is your first integration), and then select **Slack**.
 1. Click **Allow**.
 1. In your **Slack workspace**, find or create a specific channel for Semgrep notifications.
 1. In the selected **Slack channel**, enter the following slash command:


### PR DESCRIPTION
At some point name of add integration button was changed from "Add Integration" to just "Add". This PR updates all instructions to reflect that, except release notes which are historical artifacts.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
