### PR TITLE
update info re: findings triaged across refs

### DIFF
--- a/src/components/reference/_triage-states.mdx
+++ b/src/components/reference/_triage-states.mdx
@@ -18,7 +18,7 @@ Findings can also be **removed**. Semgrep considers a finding removed if it is n
 Your removed findings do not count toward the fix rate or the number of findings. The removed findings also do not appear in Semgrep AppSec Platform.
 
 :::info Findings triaged across refs
-- Findings triaged (ignored, reopened) in a specific branch, PR, or MR are **not** automatically triaged in all other branches, PRs, and MRs of a particular repository.
+- Findings that are triaged as ignored or reopened in a specific branch, PR, or MR are **not** automatically triaged in all other branches, PRs, and MRs of a particular repository.
 - If you filter for [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References) (refs) on the [Findings](https://semgrep.dev/orgs/-/findings?tab=open) page, then triage a finding, the finding is **NOT** automatically triaged in all other branches, PRs, MRs, and refs.
     - Triaging a finding on the default branch **does** affect all related non-default refs or branch-specific refs with an instance of the finding **when the finding was triaged**.
 - Future instances of a finding found at a later date aren't automatically triaged, even if the finding on the default has been triaged.

--- a/src/components/reference/_triage-states.mdx
+++ b/src/components/reference/_triage-states.mdx
@@ -19,7 +19,10 @@ Your removed findings do not count toward the fix rate or the number of findings
 
 ### Triage behavior across refs and branches
 
-- Findings that are triaged as ignored or reopened in a specific branch, PR, or MR are **not** automatically triaged in all other branches, PRs, and MRs of a particular repository.
-- If you filter for [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References) (refs) on the [Findings](https://semgrep.dev/orgs/-/findings?tab=open) page, then triage a finding, the finding is **NOT** automatically triaged in all other branches, PRs, MRs, and refs.
-    - Triaging a finding on the default branch **does** affect all related non-default refs or branch-specific refs with an instance of the finding **when the finding was triaged**.
-- Future instances of a finding found at a later date aren't automatically triaged, even if the finding on the default has been triaged.
+- When you triage a finding as ignored, reviewing, fixing, or reopened, Semgrep always triages across other branches and [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References) (refs).
+- At scan time, there's automatic triaging that occurs in specific cases, and the behavior changes depending on the type of scan:
+    - **Full scans**: if the current branch includes a finding that was 
+        - Previously introduced in another branch ***and*** 
+        - Triaged to a specific state
+        Then the finding in the current branch is triaged to that same state.
+    - **Diff-aware scan**: findings introduced in a diff-aware scan are **not** automatically triaged at scan time, even if there are other instances of that finding on branches that have been triaged.

--- a/src/components/reference/_triage-states.mdx
+++ b/src/components/reference/_triage-states.mdx
@@ -18,5 +18,8 @@ Findings can also be **removed**. Semgrep considers a finding removed if it is n
 Your removed findings do not count toward the fix rate or the number of findings. The removed findings also do not appear in Semgrep AppSec Platform.
 
 :::info Findings triaged across refs
-Findings triaged (ignored, reopened) in a specific branch, PR, or MR are also triaged in all other branches, PRs, and MRs of a particular repository. Additionally, if you filter for [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References) (refs) on the [Findings](https://semgrep.dev/orgs/-/findings?tab=open) page, then triage a finding, the finding is also automatically triaged in all other branches, PRs, MRs, and refs.
+- Findings triaged (ignored, reopened) in a specific branch, PR, or MR are **not** automatically triaged in all other branches, PRs, and MRs of a particular repository.
+- If you filter for [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References) (refs) on the [Findings](https://semgrep.dev/orgs/-/findings?tab=open) page, then triage a finding, the finding is **NOT** automatically triaged in all other branches, PRs, MRs, and refs.
+    - Triaging a finding on the default branch **does** affect all related non-default refs or branch-specific refs with an instance of the finding **when the finding was triaged**.
+- Future instances of a finding found at a later date aren't automatically triaged, even if the finding on the default has been triaged.
 :::

--- a/src/components/reference/_triage-states.mdx
+++ b/src/components/reference/_triage-states.mdx
@@ -17,9 +17,9 @@ Findings can also be **removed**. Semgrep considers a finding removed if it is n
 
 Your removed findings do not count toward the fix rate or the number of findings. The removed findings also do not appear in Semgrep AppSec Platform.
 
-:::info Findings triaged across refs
+### Triage behavior across refs and branches
+
 - Findings that are triaged as ignored or reopened in a specific branch, PR, or MR are **not** automatically triaged in all other branches, PRs, and MRs of a particular repository.
 - If you filter for [Git references](https://git-scm.com/book/en/v2/Git-Internals-Git-References) (refs) on the [Findings](https://semgrep.dev/orgs/-/findings?tab=open) page, then triage a finding, the finding is **NOT** automatically triaged in all other branches, PRs, MRs, and refs.
     - Triaging a finding on the default branch **does** affect all related non-default refs or branch-specific refs with an instance of the finding **when the finding was triaged**.
 - Future instances of a finding found at a later date aren't automatically triaged, even if the finding on the default has been triaged.
-:::


### PR DESCRIPTION
[Preview](https://deploy-preview-2036--semgrep-docs-prod.netlify.app/docs/semgrep-code/triage-remediation#removed-findings)

For https://linear.app/semgrep/issue/TEC-247/update-info-on-findings-triaged-across-refs

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
