### PR TITLE
clarify why setting up GitLab SMS requires a higher role 

### DIFF
--- a/docs/deployment/managed-scanning/gitlab.md
+++ b/docs/deployment/managed-scanning/gitlab.md
@@ -10,6 +10,7 @@ tags:
   - Semgrep AppSec Platform
 ---
 
+import GitlabRequirements from "/src/components/reference/_gitlab-sms-requirements.mdx"
 import ScanWithSms from "/src/components/procedure/_scan-with-sms.mdx"
 import TurnOffSms from "/src/components/procedure/_turn-off-sms-in-semgrep-appsec-platform.mdx"
 
@@ -19,21 +20,7 @@ Add GitLab repositories to your Semgrep organization in bulk without adding or c
 
 ## Prerequisites and permissions
 
-Semgrep Managed Scanning (SMS) requires one of the following plans:
-
-- GitLab Premium
-- GitLab Ultimate
-- GitLab Self Managed
-
-You must provide a GitLab group access token or personal access token to Semgrep. The token must have the `api` scope assigned to it.
-
-During SMS onboarding, the group or user to which the token is assigned must have one of the following roles: 
-
-- `Maintainer`
-- `Owner`
-- `Admin`
-
-This is because managed scans of GitLab repositories require the enablement of webhooks to facilitate diff-aware scans and the creation of pull request comments by Semgrep. The webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. Once onboarding is complete, you can downgrade the role assigned to the token to `Developer`.
+<GitlabRequirements />
 
 See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
 

--- a/docs/deployment/managed-scanning/gitlab.md
+++ b/docs/deployment/managed-scanning/gitlab.md
@@ -19,13 +19,21 @@ Add GitLab repositories to your Semgrep organization in bulk without adding or c
 
 ## Prerequisites and permissions
 
-Semgrep Managed Scanning requires one of the following plans:
+Semgrep Managed Scanning (SMS) requires one of the following plans:
 
 - GitLab Premium
 - GitLab Ultimate
 - GitLab Self Managed
 
-You must provide a GitLab group access token or personal access token to Semgrep. The token must have the `api` scope assigned to it. During SMS onboarding, the group or user to which the token is assigned must have one of the following roles: `Maintainer`, `Owner`, or `Admin`. Afterwards, you can downgrade the role assigned to the token to `Developer`.
+You must provide a GitLab group access token or personal access token to Semgrep. The token must have the `api` scope assigned to it.
+
+During SMS onboarding, the group or user to which the token is assigned must have one of the following roles: 
+
+- `Maintainer`
+- `Owner`
+- `Admin`
+
+This is because managed scans of GitLab repositories require the enablement of webhooks to facilitate diff-aware scans and the creation of pull request comments by Semgrep. The webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. Once onboarding is complete, you can downgrade the role assigned to the token to `Developer`.
 
 See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
 

--- a/docs/getting-started/quickstart-sms.md
+++ b/docs/getting-started/quickstart-sms.md
@@ -11,6 +11,7 @@ tags:
 ---
 
 import SmsSupport from "/src/components/reference/_sms-support.mdx"
+import GitlabRequirements from "/src/components/reference/_gitlab-sms-requirements.mdx"
 
 # Quickstart for Semgrep Managed Scans
 
@@ -39,9 +40,7 @@ import TabItem from '@theme/TabItem';
 
 ### Prerequisites
 
-Admin access to your Azure DevOps organization.
-
-### Requirements
+You must have admin access to your Azure DevOps organization.
 
 Read access is granted through an access token you generate on Azure DevOps. You can provide this token by [adding Azure DevOps as a source code manager](/deployment/connect-scm#azure-devops-cloud).
 
@@ -68,9 +67,7 @@ Semgrep recommends setting up and configuring Semgrep with an Azure DevOps servi
 
 ### Prerequisites
 
-Admin access to your GitHub organization.
-
-### Requirements
+You must have admin access to your GitHub organization.
 
 To enable and use this feature, you must grant Semgrep **Read access** to your code. Steps are provided in [Add repositories to Semgrep Managed Scans](#add-repositories-to-semgrep-managed-scans).
 
@@ -96,11 +93,7 @@ Read access is permitted through a private Semgrep app that you create and regis
 
 ### Prerequisites
 
-Admin access to your GitLab organization.
-
-### Requirements
-
-Read access is granted through an access token that you generate on GitLab. You can provide this token by [adding GitLab as a source code manager](/deployment/connect-scm).
+<GitlabRequirements />
 
 ### Add a repository
 
@@ -118,9 +111,7 @@ Read access is granted through an access token that you generate on GitLab. You 
 
 ### Prerequisites
 
-Admin access to your Bitbucket organization.
-
-### Requirements
+You must have admin access to your Bitbucket organization.
 
 #### Bitbucket Cloud
 

--- a/src/components/reference/_gitlab-sms-requirements.mdx
+++ b/src/components/reference/_gitlab-sms-requirements.mdx
@@ -1,0 +1,15 @@
+Semgrep Managed Scanning (SMS) requires one of the following plans:
+
+- GitLab Premium
+- GitLab Ultimate
+- GitLab Self Managed
+
+You must provide a GitLab group access token or personal access token to Semgrep. The token must have the `api` scope assigned to it.
+
+During SMS onboarding, the group or user to which the token is assigned must have one of the following roles: 
+
+- `Maintainer`
+- `Owner`
+- `Admin`
+
+This is because managed scans of GitLab repositories require the enablement of webhooks to facilitate diff-aware scans and the creation of pull request comments by Semgrep. The webhooks are enabled by default when you set up Managed Scans and add GitLab as a source code manager. Once onboarding is complete, you can downgrade the role assigned to the token to `Developer`.


### PR DESCRIPTION
The token needs a higher role to set up webhooks, but this can be downgraded

### Please ensure

- [x] A technical writer reviews the content or PR