### PR TITLE
add redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -405,6 +405,13 @@ module.exports = {
           { from: "/faq" , to: "/faq/overview" },
           /* MAR 4, 2025 */
           { from: "/kb/integrations/wiz" , to: "/semgrep-appsec-platform/wiz" },
+          /* MAR 19, 2025 */
+          { from: "/kb/semgrep-cloud-platform/inline-pr-comments" , to: "/kb/semgrep-appsec-platform/inline-pr-comments" },
+          { from: "/kb/semgrep-cloud-platform/missing-pr-comments" , to: "/kb/semgrep-appsec-platform/missing-pr-comments" },
+          { from: "/kb/semgrep-cloud-platform/saml-attributestatement" , to: "/kb/semgrep-appsec-platform/saml-attributestatement" },
+          { from: "/kb/semgrep-cloud-platform/saml-bad-signature" , to: "/kb/semgrep-appsec-platform/saml-bad-signature" },
+          { from: "/kb/semgrep-cloud-platform/saml-stops-working" , to: "/kb/semgrep-appsec-platform/saml-stops-working" },
+          { from: "/kb/semgrep-cloud-platform/sso-attribute-error" , to: "/kb/semgrep-appsec-platform/sso-attribute-error" },
         ]
       }
     ],


### PR DESCRIPTION
Redirects for all docs created prior to the first week of May 2024 under `/kb/semgrep-cloud-platform` to `/kb/semgrep-appsec-platform`

- [x] A technical writer reviews the content or PR
