### PR TITLE
Update link to specify repo over website

### DIFF
--- a/docs/contributing/philosophy.md
+++ b/docs/contributing/philosophy.md
@@ -7,7 +7,7 @@ tags:
 
 # Semgrep Community Edition (CE) philosophy
 
-[Semgrep CE](https://semgrep.dev/) is a lightweight static analysis tool for many languages. It can find bug variants with patterns that look like source code.
+[Semgrep CE](https://github.com/semgrep/semgrep/) is a lightweight static analysis tool for many languages. It can find bug variants with patterns that look like source code.
 
 As you think about contributing to Semgrep CE, consider these design principles that have guided Semgrep CE development so far:
 


### PR DESCRIPTION
We usually link to the site but the site is for AppSec Platform and this page is specifically for CE, so don't see the harm in updating.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR