### PR TITLE
Full steps currently required for removal for Slack

### DIFF
--- a/docs/semgrep-appsec-platform/slack.md
+++ b/docs/semgrep-appsec-platform/slack.md
@@ -104,7 +104,9 @@ This removes **all** Semgrep notifications in **all** channels in your Slack wor
 
 1. In [Semgrep AppSec Platform](https://semgrep.dev/login), go to **Settings** > **[Integrations](https://semgrep.dev/orgs/-/settings/integrations)**.
 2. On the **[Integrations](https://semgrep.dev/orgs/-/settings/integrations)** page, find the Slack integration you want to remove.
-3. Click **Remove integration** > **Remove**.
+3. Expand the **Channels receiving Semgrep notifications** section and review the channels receiving notifications.
+4. In the related channels in your Slack workspace, use the `/semgrep_unsubscribe` command to unsubscribe from those notifications.
+5. After completing this step for all channels, click **Remove integration** > **Remove**.
 
 ## Troubleshooting
 


### PR DESCRIPTION
There's an issue with deletion now where you have to unsubscribe first - it shouldn't be necessary, but if we add it to the instructions people are slightly more likely to have a smooth experience.

One note here, the page says that we should always refer to the Semgrep Slack app, but the app and the integration are technically different things. "Uninstall the Semgrep Slack app" describes the process of uninstalling it on Slack, which is not the process we're describing here, which removes the integration from Semgrep. So we may want to re-evaluate that at some point.

### Please ensure

- [x] A subject matter expert (SME) reviews the content (it currently me, I just tested this)
- [ ] A technical writer reviews the content or PR
