### PR TITLE
Update version info associated with the Semgrepignore v2 rollout

### DIFF
--- a/docs/kb/semgrep-code/semgrepignore-ignored.md
+++ b/docs/kb/semgrep-code/semgrepignore-ignored.md
@@ -12,8 +12,8 @@ If you don't have already a `.semgrepignore` file, refer to our
 scans](/docs/ignoring-files-folders-code). Otherwise, if
 you already have a `.semgrepignore` file, read on.
 
-Starting with Semgrep CE 1.112.0, the Semgrepignore specification has
-changed slightly to better align with Git and Gitignore and to offer
+Starting with Semgrep 1.117.0, the Semgrepignore specification
+changes slightly to better align with Git and Gitignore and to offer
 more flexibility.
 The new specification is referred to as
 [Semgrepignore v2](/docs/semgrepignore-v2-reference).


### PR DESCRIPTION
It's hard to predict version IDs ahead of time... We're now planning to release Semgrepignore v2 only next week but to all users rather than just CE. Next week's release should now be 1.117 (might change again but won't be less than 1.117).

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
