### PR TITLE
Fix documentation relating to .semgrepignore

### DIFF
--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -71,9 +71,7 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 | To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file or [define them through Semgrep AppSec Platform](#define-ignored-files-and-folders-in-semgrep-appsec-platform).|
 | To ignore specific code blocks each time you run a scan. | Create a comment with the word `nosemgrep`. |
 | To ignore files or folders for a particular scan. | Run Semgrep with the flag `--exclude` followed by the pattern or file to be excluded. See [CLI reference](/cli-reference).
-| To include files or folders for a particular scan. | Run Semgrep
-|with the flag `--include` followed by the pattern or file to be
-|included. Any file that isn't matched is excluded. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, resulting in the file's exclusion. |
+| To include files or folders for a particular scan. | Run Semgrep with the flag `--include` followed by the pattern or file to be included. Any file that isn't matched is excluded. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, resulting in the file's exclusion. |
 | To scan all files within Semgrep's scope each time you run Semgrep (only files in `.git` are ignored). | Create an empty `.semgrepignore` file in your repository root directory, and for `semgrep ci` scans, [remove any entries listed in your **Path Ignores** list](#define-ignored-files-and-folders-in-semgrep-appsec-platform) in Semgrep AppSec Platform. |
 | To include files or folders defined within a `.gitignore` for a particular scan. | Run Semgrep with the flag `--no-git-ignore`. |
 | To ignore files or folders for a particular rule. | Edit the rule to set the `paths` key with one or more patterns. See [Rule syntax](/writing-rules/rule-syntax#paths).

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -71,8 +71,10 @@ Semgrep provides several methods to customize ignore behavior. Refer to the foll
 | To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file or [define them through Semgrep AppSec Platform](#define-ignored-files-and-folders-in-semgrep-appsec-platform).|
 | To ignore specific code blocks each time you run a scan. | Create a comment with the word `nosemgrep`. |
 | To ignore files or folders for a particular scan. | Run Semgrep with the flag `--exclude` followed by the pattern or file to be excluded. See [CLI reference](/cli-reference).
-| To include files or folders for a particular scan. | Run Semgrep with the flag `--include` followed by the pattern or file to be included. Any file that isn't matched is excluded. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, resulting in the file's exclusion. |
-| To scan all files within Semgrep's scope each time you run Semgrep (only files in `.git` and the `.gitignore` are ignored). | Create an empty `.semgrepignore` file in your repository root directory or in your project's working directory, and for `semgrep ci` scans, [remove any entries listed in your **Path Ignores** list](#define-ignored-files-and-folders-in-semgrep-appsec-platform) in Semgrep AppSec Platform. |
+| To include files or folders for a particular scan. | Run Semgrep
+|with the flag `--include` followed by the pattern or file to be
+|included. Any file that isn't matched is excluded. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, resulting in the file's exclusion. |
+| To scan all files within Semgrep's scope each time you run Semgrep (only files in `.git` are ignored). | Create an empty `.semgrepignore` file in your repository root directory, and for `semgrep ci` scans, [remove any entries listed in your **Path Ignores** list](#define-ignored-files-and-folders-in-semgrep-appsec-platform) in Semgrep AppSec Platform. |
 | To include files or folders defined within a `.gitignore` for a particular scan. | Run Semgrep with the flag `--no-git-ignore`. |
 | To ignore files or folders for a particular rule. | Edit the rule to set the `paths` key with one or more patterns. See [Rule syntax](/writing-rules/rule-syntax#paths).
 


### PR DESCRIPTION
This fixes two issues:
* `.gitignore` files are not ignored by semgrep scans (in both Semgrepignore v1 and v2)
* a `.semgrepignore` file that's not in the project tree has no effect (new in v2)

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
