### PR TITLE
Add SCM support to limitations too

### DIFF
--- a/docs/semgrep-appsec-platform/wiz.md
+++ b/docs/semgrep-appsec-platform/wiz.md
@@ -51,11 +51,14 @@ By default, the Code findings that Semgrep sends are:
 - From full scans
 - From the default branch of each repository
 
-Semgrep sends findings from all repositories in your organization. Findings previously sent but not included in submissions are marked as fixed in Wiz.
+Semgrep sends findings from all repositories on supported SCMs in your organization. Findings previously sent but not included in submissions are marked as fixed in Wiz.
+
+Currently, findings from repositories on SCMs other than GitHub and GitLab are not supported, as indicated in [Prerequisites and requirements](#prerequisites-and-requirements).
 
 :::caution
 Due to [a limitation of how Wiz handles external enrichment data](https://win.wiz.io/docs/limitations#external-enrichment-limitations), you must run a new SAST scan on your Semgrep project once a week to maintain the data displayed in Wiz.
 :::
+
 
 ## Add the Semgrep integration from the Wiz Integration Network
 

--- a/docs/semgrep-appsec-platform/wiz.md
+++ b/docs/semgrep-appsec-platform/wiz.md
@@ -59,7 +59,6 @@ Currently, findings from repositories on SCMs other than GitHub and GitLab are n
 Due to [a limitation of how Wiz handles external enrichment data](https://win.wiz.io/docs/limitations#external-enrichment-limitations), you must run a new SAST scan on your Semgrep project once a week to maintain the data displayed in Wiz.
 :::
 
-
 ## Add the Semgrep integration from the Wiz Integration Network
 
 To learn how to add the Semgrep integration from the Wiz Integration Network, review [Wiz Docs' Semgrep Integration](https://docs.wiz.io/wiz-docs/docs/semgrep-integration).


### PR DESCRIPTION
SCM support is stated in the previous section but if folks are anything like me they may skip down to Limitations when checking, so I wanted to clarify it there too.

Sidenote: couldn't we just call this section `Requirements`? A pre-requisite is a requirement also. :)

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
