### PR TITLE
add supported languages for metavariable-type

### DIFF
--- a/docs/writing-rules/experiments/metavariable-type.md
+++ b/docs/writing-rules/experiments/metavariable-type.md
@@ -4,7 +4,7 @@ append_help_link: true
 description: "With this experimental field, Semgrep matches captured metavariables with specific types"
 ---
 
-# Matching captured metavariables with specific types
+# Match captured metavariables with specific types
 
 The `metavariable-type` operator is used to compare metavariables against their types. It utilizes the `type` key to specify the string representation of the type expression in the target language. For example, you can use `String` for Java's String type and `string` for Go's string type. Optionally, the `language` key can be used to manually indicate the target language of the type expression.
 
@@ -38,3 +38,22 @@ rules:
           metavariable: $Y
           type: String
 ```
+
+## Supported languages
+
+The `metavariable-type` operator can be used for the following languages:
+
+- C
+- C#
+- C++
+- Go
+- Java 
+- Julia
+- Kotlin
+- Move On Aptos
+- Move On Sui
+- PHP
+- Python 
+- Rust
+- Scala
+- TypeScript


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR

Wonder why this is still experimental? Seems like people have adopted it.