### PR TITLE
update Beyond core deployment sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -141,7 +141,44 @@ module.exports = {
                     }
                   ]
                 },
-                'deployment/beyond-core-deployment'
+                {
+                  type: 'category',
+                  collapsible: true,
+                  label: 'Beyond core deployment',
+                  link: {type: 'doc', id: 'deployment/beyond-core-deployment'},
+                  items: [
+                      {
+                        type: 'category',
+                        label: 'Ignore files, folders, and code',
+                        collapsible: true,
+                        items: [
+                          {
+                            type: 'doc',
+                            id: 'ignoring-files-folders-code',
+                            label: 'Semgrep Code',
+                          },
+                          {
+                            type: 'doc',
+                            id: 'semgrep-supply-chain/ignoring-deps',
+                            label: 'Semgrep Supply Chain',
+                          },
+                        ]
+                      },
+                      'semgrep-code/semgrep-pro-engine-intro',
+                      'semgrep-code/policies',
+                      'semgrep-supply-chain/license-compliance',
+                      {
+                        type: 'doc',
+                        id: 'semgrep-assistant/overview', // document ID
+                        label: 'Enable Assistant', // sidebar label
+                      },
+                      {
+                        type: 'doc',
+                        id: 'writing-rules/overview', // document ID
+                        label: 'Write custom rules', // sidebar label
+                      },
+                  ]
+                },
             ]
         },
         {
@@ -216,7 +253,6 @@ module.exports = {
                 'semgrep-code/findings',
                 'semgrep-code/policies',
                 'semgrep-code/triage-remediation',
-                'ignoring-files-folders-code',
                 'semgrep-code/semgrep-pro-engine-intro',
                 'semgrep-code/semgrep-pro-engine-examples',
                 'semgrep-code/remove-duplicates',


### PR DESCRIPTION
This PR moves both docs on ignoring files, folders, and code/dependencies into **Core deployment**. I thought the best place for it was **Core deployment > Beyond core deployment**, so I moved the docs into this sidebar. However, it looked a bit bare, so I opted to update this section to reflect the chart that exists on the **Beyond core deployment** page. Preview:

![image](https://github.com/user-attachments/assets/14de5ca2-16b2-4e00-8d70-6ea31e3dae80)

### Please ensure

- [ ] A technical writer reviews the content or PR
