### PR TITLE
Load default Semgrepignore patterns from a new location

### DIFF
--- a/replace-on-build.py
+++ b/replace-on-build.py
@@ -32,8 +32,11 @@ def replace_in_file(rep: Replace):
     with open(rep.dst_file,"w") as f:
         f.write(out_data)
 
-
-DEFAULT_SEMGREPIGNORE = subprocess.run(["curl","https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore"],capture_output=True).stdout.decode("utf-8")
+DEFAULT_SEMGREPIGNORE_URL = "https://raw.githubusercontent.com/semgrep/semgrep/develop/src/targeting/default.semgrepignore"
+DEFAULT_SEMGREPIGNORE = subprocess.run(
+    ["curl", DEFAULT_SEMGREPIGNORE_URL],
+    capture_output=True
+).stdout.decode("utf-8")
 RELEASE_NAME = json.loads(subprocess.run(["curl","https://api.github.com/repos/semgrep/semgrep/releases/latest"], capture_output=True).stdout)["tag_name"]
 
 


### PR DESCRIPTION
:heavy_check_mark: BEFORE MERGING: check that https://raw.githubusercontent.com/semgrep/semgrep/develop/src/targeting/default.semgrepignore exists

The old URL will remain available for a while but won't be updated.

This PR depends on https://github.com/semgrep/semgrep-proprietary/pull/3692 being merged and synchronized with the public semgrep repo.

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
