### PR TITLE
Sara/tec 331 advertise the rss feed around the docs

### DIFF
--- a/docs/deployment/beyond-core-deployment.md
+++ b/docs/deployment/beyond-core-deployment.md
@@ -33,7 +33,7 @@ Now that you've finished your Semgrep core deployment, you can either customize 
 
 ## Stay up-to-date on new Semgrep features
 
-Subscribe to:
+Subscribe to the:
 
 - [<i class="fa-solid fa-rss"></i> Semgrep release notes feed](https://semgrep.dev/docs/release-notes/rss.xml)
 - [<i class="fa-solid fa-rss"></i> Semgrep product updates feed](https://semgrep.dev/products/product-updates/rss/)

--- a/docs/deployment/beyond-core-deployment.md
+++ b/docs/deployment/beyond-core-deployment.md
@@ -30,3 +30,10 @@ Now that you've finished your Semgrep core deployment, you can either customize 
 | I want my developers to use Semgrep on their IDE.    | Install and set up available [IDE extensions](/extensions/overview).  |
 | I'm scanning too many projects (repositories onboarded to Semgrep) and want to group them somehow.         | [Tag your projects](/docs/semgrep-appsec-platform/tags).   |
 | I'd like to manage access to the resources that developers can view or change in Semgrep AppSec Platform.         | Configure [roles and users](/docs/deployment/teams).  |
+
+## Stay up-to-date on new Semgrep features
+
+Subscribe to:
+
+- [<i class="fa-solid fa-rss"></i> Semgrep release notes feed](https://semgrep.dev/docs/release-notes/rss.xml)
+- [<i class="fa-solid fa-rss"></i> Semgrep product updates feed](https://semgrep.dev/products/product-updates/rss/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,3 +129,5 @@ See the [Supported languages](/supported-languages#language-maturity-summary) do
 - Assistant Auto-memories: If you triage a finding as Ignored and provide an explanation of why you change the finding's status to Ignored, Assistant automatically determines if it should [create a memory](/semgrep-assistant/customize#add-memory-during-triage) for you. Assistant uses memories to tailor its remediation guidance for your projects.
 
 [See the latest release notes <i class="fa-solid fa-arrow-right"></i>](/release-notes)
+
+<div style={{textAlign: 'right'}}>[<i class="fa-solid fa-rss"></i> Subscribe to RSS feed ](https://semgrep.dev/docs/release-notes/rss.xml)</div>

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -943,3 +943,14 @@ h1.blog {
 h2[class^="title"] {
     font-size: 2.6rem;
 }
+
+.breadcrumbs__blog {
+    margin-bottom: 0.8rem;
+    .breadcrumbs__link {
+        font-size: 0.8rem;
+    }
+}
+
+.blog-index {
+    padding-bottom: 2rem;
+}

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -939,3 +939,7 @@ div[role="group"]:last-of-type::after {
 h1.blog {
     font-size: 3rem;
 }
+
+h2[class^="title"] {
+    font-size: 2.6rem;
+}

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -35,8 +35,14 @@ function BlogListPageContent(props: Props): ReactNode {
   const {metadata, items, sidebar} = props;
   return (
     <BlogLayout sidebar={sidebar}>
-        <nav class="theme-doc-breadcrumbs">Return to docs</nav>
-        <div class='logo-index'>
+        <nav class="theme-doc-breadcrumbs breadcrumbs__blog">
+            <ul class="breadcrumbs">
+                <li class="breadcrumbs__item breadcrumbs__item--active">
+                    <a href="/docs"><span class="breadcrumbs__link">Return to docs</span></a>
+                </li>
+            </ul>
+        </nav>
+        <div class='logo-index blog-index'>
           <a href="https://semgrep.dev">
             <ThemedImage
               alt="Semgrep themed logo"
@@ -48,7 +54,6 @@ function BlogListPageContent(props: Props): ReactNode {
           </a>
           <h1>Semgrep <span style={{color: "#624DEF"}}>release notes</span></h1>
         </div>
-        <hr />
       <BlogPostItems items={items} />
       <BlogListPaginator metadata={metadata} />
     </BlogLayout>

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -13,6 +13,7 @@ import SearchMetadata from '@theme/SearchMetadata';
 import type {Props} from '@theme/BlogListPage';
 import BlogPostItems from '@theme/BlogPostItems';
 import BlogListPageStructuredData from '@theme/BlogListPage/StructuredData';
+import ThemedImage from '@theme/ThemedImage'
 
 function BlogListPageMetadata(props: Props): ReactNode {
   const {metadata} = props;
@@ -34,7 +35,19 @@ function BlogListPageContent(props: Props): ReactNode {
   const {metadata, items, sidebar} = props;
   return (
     <BlogLayout sidebar={sidebar}>
-        <h1 class="blog">Semgrep release notes</h1>
+        <nav class="theme-doc-breadcrumbs">Return to docs</nav>
+        <div class='logo-index'>
+          <a href="https://semgrep.dev">
+            <ThemedImage
+              alt="Semgrep themed logo"
+              height="48px"
+              sources={{
+                light: ('img/semgrep.svg#no-shadow'),
+                dark: ('img/semgrep.svg#no-shadow'),
+              }} />
+          </a>
+          <h1>Semgrep <span style={{color: "#624DEF"}}>release notes</span></h1>
+        </div>
         <hr />
       <BlogPostItems items={items} />
       <BlogListPaginator metadata={metadata} />


### PR DESCRIPTION
What is this PR?

- Adds a "breadcrumb"-like **back to docs** nav at the top
- Provides a highlight style similar to index for Semgrep release notes
- Make blog title stand out by making blog _post_ title smaller
- Advertise RSS feed in various places (core deployment docs)
- ~~Stretch: pagination at top of fold~~ looks ugly no matter what I do. 

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR