### PR TITLE
Jenkins diff scans kb syntax fix

### DIFF
--- a/docs/kb/semgrep-ci/jenkins-diff-scans.md
+++ b/docs/kb/semgrep-ci/jenkins-diff-scans.md
@@ -144,7 +144,7 @@ pipeline {
             -e SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN \
             -e SEMGREP_REPO_NAME=$SEMGREP_REPO_NAME \
             -e SEMGREP_BASELINE_REF=$(git merge-base $GIT_BRANCH $CHANGE_TARGET) \
-            -e SEMGREP_PR_ID = "${env.CHANGE_ID}"
+            -e SEMGREP_PR_ID="$CHANGE_ID"
             -v "$(pwd):$(pwd)" --workdir $(pwd) \
             semgrep/semgrep semgrep ci '''
       }

--- a/docs/kb/semgrep-ci/jenkins-diff-scans.md
+++ b/docs/kb/semgrep-ci/jenkins-diff-scans.md
@@ -144,7 +144,7 @@ pipeline {
             -e SEMGREP_APP_TOKEN=$SEMGREP_APP_TOKEN \
             -e SEMGREP_REPO_NAME=$SEMGREP_REPO_NAME \
             -e SEMGREP_BASELINE_REF=$(git merge-base $GIT_BRANCH $CHANGE_TARGET) \
-            -e SEMGREP_PR_ID="$CHANGE_ID"
+            -e SEMGREP_PR_ID="${env.CHANGE_ID}"
             -v "$(pwd):$(pwd)" --workdir $(pwd) \
             semgrep/semgrep semgrep ci '''
       }


### PR DESCRIPTION
Removing whitespace before and after equals sign so snippet can be copy pasted and behave as intended.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
