### PR TITLE
use absolute path so that it wont break on pg2

### DIFF
--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -48,8 +48,8 @@ function BlogListPageContent(props: Props): ReactNode {
               alt="Semgrep themed logo"
               height="48px"
               sources={{
-                light: ('img/semgrep.svg#no-shadow'),
-                dark: ('img/semgrep.svg#no-shadow'),
+                  light: ('https://semgrep.dev/docs/img/semgrep.svg#no-shadow'),
+                dark: ('https://semgrep.dev/docs/img/semgrep.svg#no-shadow'),
               }} />
           </a>
           <h1>Semgrep <span style={{color: "#624DEF"}}>release notes</span></h1>


### PR DESCRIPTION
This PR updates the img path from relative to absolute for our logo in the release notes.

---

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR

**Before:**
![image](https://github.com/user-attachments/assets/c076b98d-e736-46d1-9318-4be86b34a7fd)
_Note that this doesn't happen on the first page - must be an SPA rendering limitation._

**After**
![image](https://github.com/user-attachments/assets/5700830b-c0b5-4814-b1f3-31d3489878d7)
