### PR TITLE
Beef up per-language documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,15 @@ The code is kept here for easy maintenance.
 
 <h3>Supported languages</h3>
 
+<!-- *************************************************************************
+ARE YOU EDITING THE SUPPORTED LANGUAGES IN ANY WAY? ADDING A FEATURE? ETC?
+
+Don't forget to update:
+- table at Semgrep CE vs Semgrep
+- the individual language's page
+- the supported languages page
+*************************************************************************** -->
+
 | Product | Languages |
 | :-------  | :------ |
 | Semgrep Code      |  **Generally available (GA)**<br />C and C++ • C# • Generic • Go • Java • JavaScript • JSON • Kotlin • Python • TypeScript • Ruby • Rust • JSX • PHP • Scala • Swift • Terraform <br /><br />**Beta**<br />APEX • Elixir<br /><br />**Experimental**<br />Bash • Cairo • Circom • Clojure • Dart • Dockerfile • Hack • HTML • Jsonnet • Julia • Lisp • Lua • Move on Aptos • Move on Sui • OCaml• R • Scheme • Solidity • YAML • XML |

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -23,7 +23,6 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 ## Semgrep Code analyses
 
-* Framework-specific control flow analysis 
 * Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
 * All analyses performed by [Semgrep CE](#c-support-in-semgrep-ce)

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -53,6 +53,10 @@ The following analyses and features are available for C#:
 
 <LangSscFeatures />
 
+:::tip No need for lockfiles
+C# projects can be scanned **without** the need for lockfiles. See [Scan a project without lockfiles (beta)](/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta).
+:::
+
 ## C# support in Semgrep CE
 
 <LangCeIntro />

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -26,6 +26,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 * Framework-specific control flow analysis 
 * Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#c-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -39,8 +39,6 @@ Some examples of rules include:
 
 ## C# support in Semgrep Supply Chain
 
-Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
-
 <LangDefSsc />
 
 ### Supported package managers

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -58,7 +58,8 @@ The following analyses and features are available for JavaScript:
 The Semgrep Registry provides the following popular JavaScript rule sets:
 
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
-<!-- confir tk
+
+<!-- config
 -  [<i class="fas fa-external-link fa-xs"></i> `p/javascript`](https://semgrep.dev/p/javascript)
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
 

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -10,6 +10,13 @@ tags:
 title: C#
 ---
 
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
+
 # C# support
 
 :::tip 
@@ -24,35 +31,40 @@ Semgrep’s C# coverage leverages framework-specific analysis capabilities that 
 
 ## Coverage 
 
-Semgrep aims to provide comprehensive and accurate detection of common OWASP Top 10 issues in source code.
+<LangCoverage />
 
-In addition to rules, the Semgrep engine itself can analyze code and implicit dataflows in the context of the following supported frameworks:
+## C# support in Semgrep Supply Chain
 
-<table>
-    <thead><tr>
-        <td><strong>Framework / library</strong></td>
-        <td><strong>Category</strong></td>
-    </tr></thead>
-    <tbody>
-    <tr>
-        <td>Django</td>
-        <td>Web framework</td>
-    </tr>
-    <tr>
-        <td>Flask</td>
-        <td>Web framework</td>
-    </tr>
-    <tr>
-        <td>FastAPI</td>
-        <td>Web framework</td>
-    </tr>
-    </tbody>
-</table>
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
 
-<details>
-  <summary>**In addition, Semgrep Code supports 100+ libraries & frameworks based on their overall popularity.**</summary>
+<LangDefSsc />
 
-<SupportedLibrariesTable />
+### Supported package managers
 
-</details>
+Semgrep supports the following C# package managers:
 
+ADD tk
+
+### Analyses and features
+
+The following analyses and features are available for JavaScript:
+
+<LangSscFeatures />
+
+## C# support in Semgrep CE
+
+<LangCeIntro />
+
+The Semgrep Registry provides the following popular JavaScript rule sets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+<!-- confir tk
+-  [<i class="fas fa-external-link fa-xs"></i> `p/javascript`](https://semgrep.dev/p/javascript)
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+
+-->
+Sample usage:
+
+```bash
+semgrep scan --config p/csharp
+```

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -1,0 +1,58 @@
+---
+slug: csharp
+append_help_link: true
+description: >-
+  Detailed documentation for Semgrep's C# support. 
+hide_title: true
+tags:
+    - Semgrep Code
+    - Semgrep Supply Chain
+title: C#
+---
+
+# C# support
+
+:::tip 
+Semgrep’s C# coverage leverages framework-specific analysis capabilities that are not present in OSS. As a result, many framework specific Pro rules will **fail** to return findings if run on OSS. To ensure full security coverage, run: `semgrep login && semgrep ci`.
+:::
+
+## Semgrep Code analyses
+
+* Framework-specific control flow analysis 
+* Interfile analysis (cross-file)
+* Interprocedural analysis (cross-function)
+
+## Coverage 
+
+Semgrep aims to provide comprehensive and accurate detection of common OWASP Top 10 issues in source code.
+
+In addition to rules, the Semgrep engine itself can analyze code and implicit dataflows in the context of the following supported frameworks:
+
+<table>
+    <thead><tr>
+        <td><strong>Framework / library</strong></td>
+        <td><strong>Category</strong></td>
+    </tr></thead>
+    <tbody>
+    <tr>
+        <td>Django</td>
+        <td>Web framework</td>
+    </tr>
+    <tr>
+        <td>Flask</td>
+        <td>Web framework</td>
+    </tr>
+    <tr>
+        <td>FastAPI</td>
+        <td>Web framework</td>
+    </tr>
+    </tbody>
+</table>
+
+<details>
+  <summary>**In addition, Semgrep Code supports 100+ libraries & frameworks based on their overall popularity.**</summary>
+
+<SupportedLibrariesTable />
+
+</details>
+

--- a/docs/languages/csharp.md
+++ b/docs/languages/csharp.md
@@ -19,9 +19,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 # C# support
 
-:::tip 
-Semgrep’s C# coverage leverages framework-specific analysis capabilities that are not present in OSS. As a result, many framework specific Pro rules will **fail** to return findings if run on OSS. To ensure full security coverage, run: `semgrep login && semgrep ci`.
-:::
+<LangCallout name="C#" />
 
 ## Semgrep Code analyses
 
@@ -33,6 +31,12 @@ Semgrep’s C# coverage leverages framework-specific analysis capabilities that 
 
 <LangCoverage />
 
+Some examples of rules include:
+
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+
 ## C# support in Semgrep Supply Chain
 
 Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
@@ -41,13 +45,13 @@ Semgrep Supply Chain is a software composition analysis (SCA) tool that detects 
 
 ### Supported package managers
 
-Semgrep supports the following C# package managers:
+Semgrep supports the following C# package manager:
 
-ADD tk
+- NuGet
 
 ### Analyses and features
 
-The following analyses and features are available for JavaScript:
+The following analyses and features are available for C#:
 
 <LangSscFeatures />
 
@@ -55,14 +59,15 @@ The following analyses and features are available for JavaScript:
 
 <LangCeIntro />
 
-The Semgrep Registry provides the following popular JavaScript rule sets:
+The Semgrep Registry provides the following  C# rule sets:
 
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
 
 <!-- config
--  [<i class="fas fa-external-link fa-xs"></i> `p/javascript`](https://semgrep.dev/p/javascript)
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
-
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
 -->
 Sample usage:
 

--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -1,0 +1,74 @@
+---
+slug: go
+append_help_link: true
+description: >-
+  Detailed documentation for Semgrep's Go support. 
+hide_title: true
+tags:
+    - Semgrep Code
+    - Semgrep Supply Chain
+title: Go
+---
+
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
+
+# Go support
+
+<LangCallout name="Go" />
+
+## Semgrep Code analyses
+
+* Interfile analysis (cross-file)
+* Interprocedural analysis (cross-function)
+
+## Coverage 
+
+<LangCoverage />
+
+Some examples of rules include:
+
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use user input to manually construct an SQL string](https://semgrep.dev/orgs/ooo_semgrep/editor/r/go.aws-lambda.security.tainted-sql-string.tainted-sql-string?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-943: Improper neutralization of special elements in data query. Avoid NoSQL Injection in Mongo with Gin](https://semgrep.dev/orgs/ooo_semgrep/editor/r/go.gin.nosql.gin-mongo-nosql-taint.gin-mongo-nosqli-taint?editorMode=advanced)
+
+## Go support in Semgrep Supply Chain
+
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+
+<LangDefSsc />
+
+### Supported package managers
+
+Semgrep supports the following Go package manager:
+
+- Go modules (`go.mod`)
+
+### Analyses and features
+
+The following analyses and features are available for Go:
+
+<LangSscFeatures />
+
+## Go support in Semgrep CE
+
+<LangCeIntro />
+
+The Semgrep Registry provides the following Go rule sets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+- [<i class="fas fa-external-link fa-xs"></i> `p/golang`](https://semgrep.dev/p/golang)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gosec`](https://semgrep.dev/p/gosec)
+
+<!-- config
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+-->
+Sample usage:
+
+```bash
+semgrep scan --config p/golang
+```

--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -25,6 +25,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 * Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#go-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -32,8 +32,8 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use user input to manually construct an SQL string](https://semgrep.dev/orgs/ooo_semgrep/editor/r/go.aws-lambda.security.tainted-sql-string.tainted-sql-string?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-943: Improper neutralization of special elements in data query. Avoid NoSQL Injection in Mongo with Gin](https://semgrep.dev/orgs/ooo_semgrep/editor/r/go.gin.nosql.gin-mongo-nosql-taint.gin-mongo-nosqli-taint?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use user input to manually construct an SQL string](https://semgrep.dev/playground/r/go.aws-lambda.security.tainted-sql-string.tainted-sql-string?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-943: Improper neutralization of special elements in data query. Avoid NoSQL Injection in Mongo with Gin](https://semgrep.dev/playground/r/go.gin.nosql.gin-mongo-nosql-taint.gin-mongo-nosqli-taint?editorMode=advanced)
 
 ## Go support in Semgrep Supply Chain
 

--- a/docs/languages/go.md
+++ b/docs/languages/go.md
@@ -37,8 +37,6 @@ Some examples of rules include:
 
 ## Go support in Semgrep Supply Chain
 
-Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
-
 <LangDefSsc />
 
 ### Supported package managers

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -33,8 +33,8 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-327: Use of a broken or risky cryptographic algorithm. Don't use the `none` algorithm](https://semgrep.dev/orgs/ooo_semgrep/editor/r/java.java-jwt.security.jwt-none-alg.java-jwt-none-alg?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-78: OS command injection. Sanitize your variables before using them as input to a `java.lang.Runtime` call](https://semgrep.dev/orgs/ooo_semgrep/editor/r/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-327: Use of a broken or risky cryptographic algorithm. Don't use the `none` algorithm](https://semgrep.dev/playground/r/java.java-jwt.security.jwt-none-alg.java-jwt-none-alg?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-78: OS command injection. Sanitize your variables before using them as input to a `java.lang.Runtime` call](https://semgrep.dev/playground/r/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call?editorMode=advanced)
 
 ## Java support in Semgrep Supply Chain
 

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -1,0 +1,76 @@
+---
+slug: java
+append_help_link: true
+description: >-
+  Detailed documentation for Semgrep's Java support. 
+hide_title: true
+tags:
+    - Semgrep Code
+    - Semgrep Supply Chain
+title: Java
+---
+
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
+
+# Java support
+
+<LangCallout name="Java" />
+
+## Semgrep Code analyses
+
+* Framework-specific control flow analysis 
+* Interfile analysis (cross-file)
+* Interprocedural analysis (cross-function)
+
+## Coverage 
+
+<LangCoverage />
+
+Some examples of rules include:
+
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+
+## C# support in Semgrep Supply Chain
+
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+
+<LangDefSsc />
+
+### Supported package managers
+
+Semgrep supports the following C# package manager:
+
+- NuGet
+
+### Analyses and features
+
+The following analyses and features are available for C#:
+
+<LangSscFeatures />
+
+## C# support in Semgrep CE
+
+<LangCeIntro />
+
+The Semgrep Registry provides the following  C# rule sets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+
+<!-- config
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+-->
+Sample usage:
+
+```bash
+semgrep scan --config p/csharp
+```

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -26,6 +26,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 * [Language-specific analysis](/semgrep-code/java)
 * Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#java-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -23,7 +23,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 ## Semgrep Code analyses
 
-* Framework-specific control flow analysis 
+* [Language-specific analysis](/semgrep-code/java)
 * Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
 
@@ -33,37 +33,48 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-327: Use of a broken or risky cryptographic algorithm. Don't use the `none` algorithm](https://semgrep.dev/orgs/ooo_semgrep/editor/r/java.java-jwt.security.jwt-none-alg.java-jwt-none-alg?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-78: OS command injection. Sanitize your variables before using them as input to a `java.lang.Runtime` call](https://semgrep.dev/orgs/ooo_semgrep/editor/r/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call?editorMode=advanced)
 
-## C# support in Semgrep Supply Chain
-
-Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+## Java support in Semgrep Supply Chain
 
 <LangDefSsc />
 
 ### Supported package managers
 
-Semgrep supports the following C# package manager:
+Semgrep supports the following Java package managers:
 
-- NuGet
+- Gradle
+- Maven
 
 ### Analyses and features
 
-The following analyses and features are available for C#:
+The following analyses and features are available for Java:
 
-<LangSscFeatures />
+<dl>
+<dt>Reachability analysis</dt>
+<dd>
+Reachability refers to whether or not a vulnerable code pattern from a dependency is used in the codebase that imports it. In Semgrep Supply Chain, both a dependency's vulnerable version and code pattern must match for a vulnerability to be considered reachable.
+</dd>
+<dt>License detection</dt>
+<dd>
+Semgrep Supply Chain's **license compliance** feature enables you to explicitly allow or disallow (block) a package's use in your repository based on its license. For example, your company policy may disallow the use of packages with the Creative Commons Attribution-NonCommercial (CC-BY-NC) license.
+</dd>
+<dt>SBOM generation</dt>
+<dd>
+Semgrep enables you to generate a software bill of materials (SBOM) to assess your third-party dependencies and comply with auditing procedures. Semgrep Supply Chain (SSC) can generate an SBOM for each repository you have added to Semgrep AppSec Platform.
+</dd>
+</dl>
 
-## C# support in Semgrep CE
+## Java support in Semgrep CE
 
 <LangCeIntro />
 
-The Semgrep Registry provides the following  C# rule sets:
+The Semgrep Registry provides the following Java rulesets:
 
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
-- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
-- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+- [<i class="fas fa-external-link fa-xs"></i> `p/java`](https://semgrep.dev/p/java)
+- [<i class="fas fa-external-link fa-xs"></i> `p/findsecbugs`](https://semgrep.dev/p/findsecbugs)
 
 <!-- config
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
@@ -72,5 +83,5 @@ The Semgrep Registry provides the following  C# rule sets:
 Sample usage:
 
 ```bash
-semgrep scan --config p/csharp
+semgrep scan --config p/java
 ```

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -18,7 +18,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 # JavaScript support
 
-<LangCallout />
+<LangCallout name="JavaScript" />
 
 ## JavaScript support in Semgrep Code
 
@@ -162,11 +162,12 @@ The following analyses and features are available for JavaScript:
 <!-- use a component here -->
 
 
-The Semgrep Registry provides the following popular JavaScript rule sets:
+The Semgrep Registry provides the following JavaScript rule sets:
 
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
 -  [<i class="fas fa-external-link fa-xs"></i> `p/javascript`](https://semgrep.dev/p/javascript)
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+- [<i class="fas fa-external-link fa-xs"></i> `p/xss`](https://semgrep.dev/p/trailofbits)
 
 Sample usage:
 

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -138,8 +138,6 @@ Results as of **February 25, 2025**:
 
 ## JavaScript support in Semgrep Supply Chain
 
-Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
-
 <LangDefSsc />
 
 ### Supported package managers
@@ -162,7 +160,7 @@ The following analyses and features are available for JavaScript:
 <!-- use a component here -->
 
 
-The Semgrep Registry provides the following JavaScript rule sets:
+The Semgrep Registry provides the following JavaScript rulesets:
 
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
 -  [<i class="fas fa-external-link fa-xs"></i> `p/javascript`](https://semgrep.dev/p/javascript)

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -29,6 +29,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 - Framework-specific control flow analysis
 - Interfile analysis (cross-file)
 - Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#javascript-support-in-semgrep-ce)
 
 ### Coverage
 

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -5,27 +5,33 @@ hide_title: true
 description: >-
   Detailed documentation for Semgrep's JavaScript support. 
 tags:
-  - Semgrep Code 
+  - Semgrep Code
+  - Semgrep Supply Chain
 ---
 
 # JavaScript frameworks and analyses
 
 :::tip 
-Semgrep’s JavaScript coverage leverages framework-specific analysis capabilities that are not present in OSS. As a result, many framework specific Pro rules will **fail** to return findings if run on OSS. To ensure full security coverage, run: `semgrep login && semgrep ci`.
+Semgrep’s JavaScript coverage leverages framework-specific analysis capabilities that are not present in Semgrep CE. As a result, many framework specific Pro rules will **fail** to return findings if run on Semgrep CE. To ensure full security coverage, run: `semgrep login && semgrep ci`.
 :::
 
-## Semgrep Code analyses
+## Semgrep Code
+
+Semgrep Code is a static application security testing (SAST) tool that detects security vulnerabilities in your first-party code.
+
+### Semgrep Code analyses for JavaScript
 
 - Framework-specific control flow analysis
 - Inter-file analysis (cross-file)
 - Inter-procedural analysis (cross-function)
 
-### Coverage
+#### Coverage
 
-Semgrep aims to provide comprehensive and accurate detection of common OWASP Top 10 issues in source code.
+Semgrep aims to provide comprehensive and accurate detection of common OWASP Top 10 issues in source code. Semgrep uses **rules**, which are instructions based on which it detects patterns in code. These rules are usually organized in rulesets.
+
+By default, Semgrep Code provides you the [<i class="fas fa-external-link fa-xs"></i> `p/comment`](https://semgrep.dev/p/comment) and [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default) rulesets. These rulesets provide the most accurate and comprehensive coverage across Semgrep's supported languages.
 
 In addition to rules, the Semgrep engine itself can analyze code and implicit dataflows in the context of the following supported frameworks:
-
 
 | Supported frameworks | Type of framework |
 | -------              | ------            |
@@ -114,7 +120,7 @@ In addition to rules, the Semgrep engine itself can analyze code and implicit da
 
 </details>
 
-## Benchmark results exclusive of [AI](https://semgrep.dev/docs/semgrep-assistant/overview) processing
+### Benchmark results exclusive of [AI](https://semgrep.dev/docs/semgrep-assistant/overview) processing
 
 Semgrep's benchmarking process involves scanning open source repositories, triaging the findings, and making iterative rule updates. This process was developed and is used internally by the Semgrep security research team to monitor and improve rule performance.
 
@@ -126,3 +132,61 @@ Results as of **February 25, 2025**:
 | Lines of code scanned | ~8 million |
 | Repositories scanned | 153 |
 | Findings triaged to date | ~600 |
+
+## Semgrep Supply Chain
+
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+
+### Supported package managers
+
+Semgrep supports the following JavaScript package managers:
+
+- npm
+- Yarn
+- pnpm
+
+### Analyses and features
+
+The following analyses and features are available for JavaScript:
+
+<dl>
+<dt>Reachability analysis</dt>
+<dd></dd>
+<dt>License detection</dt>
+<dd></dd>
+<dt>Malicious dependency detection</dt>
+<dd></dd>
+<dt>SBOM generation</dt>
+<dd></dd>
+</dl>
+
+## Semgrep CE
+
+<!-- use a component here -->
+
+Semgrep CE is a fast, lightweight program analysis tool that can help you detect bugs in your code. It makes use of Semgrep's LGPL 2.1 open source engine.
+
+### Analyses
+
+- Single file, cross function constant propagation
+- Single function taint analysis
+- Semantic analysis 
+
+### Coverage
+
+:::tip
+- Check the `license` of a rule to ensure it meets your licensing requirements. See [Licensing](/licensing) for more details.
+:::
+
+The Semgrep Registry provides the following popular JavaScript rule sets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+-  [<i class="fas fa-external-link fa-xs"></i> `p/javascript`](https://semgrep.dev/p/javascript)
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+
+Sample usage:
+
+```bash
+semgrep scan --config p/javascript
+```
+

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -9,27 +9,30 @@ tags:
   - Semgrep Supply Chain
 ---
 
-# JavaScript frameworks and analyses
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
-:::tip 
-Semgrep’s JavaScript coverage leverages framework-specific analysis capabilities that are not present in Semgrep CE. As a result, many framework specific Pro rules will **fail** to return findings if run on Semgrep CE. To ensure full security coverage, run: `semgrep login && semgrep ci`.
-:::
+# JavaScript support
 
-## Semgrep Code
+<LangCallout />
 
-Semgrep Code is a static application security testing (SAST) tool that detects security vulnerabilities in your first-party code.
+## JavaScript support in Semgrep Code
 
-### Semgrep Code analyses for JavaScript
+<LangDefCode />
+
+### Analyses and frameworks
 
 - Framework-specific control flow analysis
-- Inter-file analysis (cross-file)
-- Inter-procedural analysis (cross-function)
+- Interfile analysis (cross-file)
+- Interprocedural analysis (cross-function)
 
-#### Coverage
+### Coverage
 
-Semgrep aims to provide comprehensive and accurate detection of common OWASP Top 10 issues in source code. Semgrep uses **rules**, which are instructions based on which it detects patterns in code. These rules are usually organized in rulesets.
-
-By default, Semgrep Code provides you the [<i class="fas fa-external-link fa-xs"></i> `p/comment`](https://semgrep.dev/p/comment) and [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default) rulesets. These rulesets provide the most accurate and comprehensive coverage across Semgrep's supported languages.
+<LangCoverage />
 
 In addition to rules, the Semgrep engine itself can analyze code and implicit dataflows in the context of the following supported frameworks:
 
@@ -120,7 +123,7 @@ In addition to rules, the Semgrep engine itself can analyze code and implicit da
 
 </details>
 
-### Benchmark results exclusive of [AI](https://semgrep.dev/docs/semgrep-assistant/overview) processing
+#### Benchmark results exclusive of [AI](/semgrep-assistant/overview) processing
 
 Semgrep's benchmarking process involves scanning open source repositories, triaging the findings, and making iterative rule updates. This process was developed and is used internally by the Semgrep security research team to monitor and improve rule performance.
 
@@ -133,9 +136,11 @@ Results as of **February 25, 2025**:
 | Repositories scanned | 153 |
 | Findings triaged to date | ~600 |
 
-## Semgrep Supply Chain
+## JavaScript support in Semgrep Supply Chain
 
 Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+
+<LangDefSsc />
 
 ### Supported package managers
 
@@ -149,34 +154,13 @@ Semgrep supports the following JavaScript package managers:
 
 The following analyses and features are available for JavaScript:
 
-<dl>
-<dt>Reachability analysis</dt>
-<dd></dd>
-<dt>License detection</dt>
-<dd></dd>
-<dt>Malicious dependency detection</dt>
-<dd></dd>
-<dt>SBOM generation</dt>
-<dd></dd>
-</dl>
+<LangSscFeatures />
 
-## Semgrep CE
+## JavaScript support in Semgrep CE
 
+<LangCeIntro />
 <!-- use a component here -->
 
-Semgrep CE is a fast, lightweight program analysis tool that can help you detect bugs in your code. It makes use of Semgrep's LGPL 2.1 open source engine.
-
-### Analyses
-
-- Single file, cross function constant propagation
-- Single function taint analysis
-- Semantic analysis 
-
-### Coverage
-
-:::tip
-- Check the `license` of a rule to ensure it meets your licensing requirements. See [Licensing](/licensing) for more details.
-:::
 
 The Semgrep Registry provides the following popular JavaScript rule sets:
 
@@ -189,4 +173,3 @@ Sample usage:
 ```bash
 semgrep scan --config p/javascript
 ```
-

--- a/docs/languages/kotlin.md
+++ b/docs/languages/kotlin.md
@@ -25,6 +25,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 * Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#kotlin-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/kotlin.md
+++ b/docs/languages/kotlin.md
@@ -23,15 +23,20 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 ## Semgrep Code analyses
 
+* Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
 
 ## Coverage 
 
 <LangCoverage />
 
-Some examples of rules include:
+The following is an example of a Kotlin rule:
 
-tk
+- [<i class="fas fa-external-link fa-xs"></i> CWE-327: Use of a broken or risky cryptographic algorithm. NullCipher does not encrypt anything; avoid](https://semgrep.dev/playground/r/kotlin.lang.security.no-null-cipher.no-null-cipher?editorMode=advanced)
+
+Many, but not all Kotlin rules require a Semgrep account. Sign in to Semgrep AppSec Platform to view this rule:
+
+- [<i class="fas fa-external-link fa-xs"></i> CWE-776: XML entity expansion. Securely configure your XML parser](https://semgrep.dev/orgs/-/editor/r/kotlin.xxe.xmlreader-xxe.xmlreader-xxe?editorMode=advanced)
 
 ## Kotlin support in Semgrep Supply Chain
 
@@ -45,11 +50,12 @@ Kotlin projects can be scanned **without** the need for lockfiles. See [Scan a p
 
 Semgrep supports the following Kotlin package manager:
 
+- Gradle
 - Maven
 
 ### Analyses and features
 
-The following analyses and features are available for Scala:
+The following analyses and features are available for Kotlin:
 
 <dl>
 <dt>Reachability analysis</dt>
@@ -66,16 +72,14 @@ Semgrep enables you to generate a software bill of materials (SBOM) to assess yo
 </dd>
 </dl>
 
-## Scala support in Semgrep CE
+## Kotlin support in Semgrep CE
 
 <LangCeIntro />
 
-The Semgrep Registry provides the following Scala rule sets:
+The Semgrep Registry provides the following Kotlin rule sets (many rules require a Semgrep account):
 
-tk
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
-- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
-- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+- [<i class="fas fa-external-link fa-xs"></i> `p/kotlin`](https://semgrep.dev/p/kotlin)
 
 <!-- config
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
@@ -84,5 +88,5 @@ tk
 Sample usage:
 
 ```bash
-semgrep scan --config p/scala
+semgrep scan --config p/kotlin
 ```

--- a/docs/languages/kotlin.md
+++ b/docs/languages/kotlin.md
@@ -1,13 +1,13 @@
 ---
-slug: java
+slug: kotlin
 append_help_link: true
 description: >-
-  Detailed documentation for Semgrep's Java support. 
+  Detailed documentation for Semgrep's Kotlin support. 
 hide_title: true
 tags:
     - Semgrep Code
     - Semgrep Supply Chain
-title: Java
+title: Kotlin
 ---
 
 import LangCallout from "/src/components/concept/_lang-callout.md"
@@ -17,14 +17,12 @@ import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
 import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
 import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
-# Java support
+# Kotlin support
 
-<LangCallout name="Java" />
+<LangCallout name="Kotlin" />
 
 ## Semgrep Code analyses
 
-* [Language-specific analysis](/semgrep-code/java)
-* Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
 
 ## Coverage 
@@ -33,23 +31,25 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-327: Use of a broken or risky cryptographic algorithm. Don't use the `none` algorithm](https://semgrep.dev/orgs/ooo_semgrep/editor/r/java.java-jwt.security.jwt-none-alg.java-jwt-none-alg?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-78: OS command injection. Sanitize your variables before using them as input to a `java.lang.Runtime` call](https://semgrep.dev/orgs/ooo_semgrep/editor/r/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call?editorMode=advanced)
+tk
 
-## Java support in Semgrep Supply Chain
+## Kotlin support in Semgrep Supply Chain
 
 <LangDefSsc />
 
+:::tip No need for lockfiles
+Kotlin projects can be scanned **without** the need for lockfiles. See [Scan a project without lockfiles (beta)](/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta).
+:::
+
 ### Supported package managers
 
-Semgrep supports the following Java package managers:
+Semgrep supports the following Kotlin package manager:
 
-- Gradle
 - Maven
 
 ### Analyses and features
 
-The following analyses and features are available for Java:
+The following analyses and features are available for Scala:
 
 <dl>
 <dt>Reachability analysis</dt>
@@ -66,19 +66,16 @@ Semgrep enables you to generate a software bill of materials (SBOM) to assess yo
 </dd>
 </dl>
 
-:::tip No need for lockfiles
-Java projects can be scanned **without** the need for lockfiles. See [Scan a project without lockfiles (beta)](/semgrep-supply-chain/getting-started#scan-a-project-without-lockfiles-beta).
-:::
-
-## Java support in Semgrep CE
+## Scala support in Semgrep CE
 
 <LangCeIntro />
 
-The Semgrep Registry provides the following Java rulesets:
+The Semgrep Registry provides the following Scala rule sets:
 
+tk
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
-- [<i class="fas fa-external-link fa-xs"></i> `p/java`](https://semgrep.dev/p/java)
-- [<i class="fas fa-external-link fa-xs"></i> `p/findsecbugs`](https://semgrep.dev/p/findsecbugs)
+- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
 
 <!-- config
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
@@ -87,5 +84,5 @@ The Semgrep Registry provides the following Java rulesets:
 Sample usage:
 
 ```bash
-semgrep scan --config p/java
+semgrep scan --config p/scala
 ```

--- a/docs/languages/kotlin.md
+++ b/docs/languages/kotlin.md
@@ -49,7 +49,7 @@ Kotlin projects can be scanned **without** the need for lockfiles. See [Scan a p
 
 ### Supported package managers
 
-Semgrep supports the following Kotlin package manager:
+Semgrep supports the following Kotlin package managers:
 
 - Gradle
 - Maven

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -11,12 +11,16 @@ title: Python
 ---
 
 import SupportedLibrariesTable from '/src/components/reference/_supported-libraries-python-table.md'
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 # Python support
 
-:::tip 
-Semgrep’s Python coverage leverages framework-specific analysis capabilities that are not present in OSS. As a result, many framework specific Pro rules will **fail** to return findings if run on OSS. To ensure full security coverage, run: `semgrep login && semgrep ci`.
-:::
+<LangCallout name="Python" />
 
 ## Semgrep Code frameworks and analyses
 

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -29,8 +29,9 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 ### Analyses and frameworks
 
 * Framework-specific control flow analysis 
-* Inter-file analysis (cross-file)
-* Inter-procedural analysis (cross-function)
+* Interfile analysis (cross-file)
+* Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#python-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -12,13 +12,13 @@ title: Python
 
 import SupportedLibrariesTable from '/src/components/reference/_supported-libraries-python-table.md'
 
-# Python frameworks and analyses
+# Python support
 
 :::tip 
 Semgrep’s Python coverage leverages framework-specific analysis capabilities that are not present in OSS. As a result, many framework specific Pro rules will **fail** to return findings if run on OSS. To ensure full security coverage, run: `semgrep login && semgrep ci`.
 :::
 
-## Semgrep Code analyses
+## Semgrep Code frameworks and analyses
 
 * Framework-specific control flow analysis 
 * Inter-file analysis (cross-file)

--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -22,7 +22,11 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 <LangCallout name="Python" />
 
-## Semgrep Code frameworks and analyses
+## Python support in Semgrep Code
+
+<LangDefCode />
+
+### Analyses and frameworks
 
 * Framework-specific control flow analysis 
 * Inter-file analysis (cross-file)
@@ -30,7 +34,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 ## Coverage 
 
-Semgrep aims to provide comprehensive and accurate detection of common OWASP Top 10 issues in source code.
+<LangCoverage />
 
 In addition to rules, the Semgrep engine itself can analyze code and implicit dataflows in the context of the following supported frameworks:
 
@@ -89,3 +93,42 @@ Results as of **September 9, 2024**:
     
     </tbody>
 </table>
+
+## Python support in Semgrep Supply Chain
+
+<LangDefSsc />
+
+### Supported package managers
+
+Semgrep supports the following Python package managers:
+
+- pip
+- pip-tools
+- Pipenv
+- Poetry
+
+### Analyses and features
+
+The following analyses and features are available for Python:
+
+<LangSscFeatures />
+
+## Python support in Semgrep CE
+
+<LangCeIntro />
+<!-- use a component here -->
+
+
+The Semgrep Registry provides the following JavaScript rulesets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+-  [<i class="fas fa-external-link fa-xs"></i> `p/python`](https://semgrep.dev/p/python)
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+- [<i class="fas fa-external-link fa-xs"></i> `p/xss`](https://semgrep.dev/p/trailofbits)
+
+Sample usage:
+
+```bash
+semgrep scan --config p/python
+```
+

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -31,8 +31,8 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-502: Deserialization of untrusted data. Using `load` and `object_load` can cause remote code execution; use JSON securely instead](https://semgrep.dev/orgs/ooo_semgrep/editor/r/ruby.lang.security.bad-deserialization.bad-deserialization?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-185: Incorrect regular expression. Incorrectly-bounded regex should be terminated correctly](https://semgrep.dev/orgs/ooo_semgrep/editor/r/ruby.rails.security.brakeman.check-validation-regex.check-validation-regex?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-502: Deserialization of untrusted data. Using `load` and `object_load` can cause remote code execution; use JSON securely instead](https://semgrep.dev/playground/r/ruby.lang.security.bad-deserialization.bad-deserialization?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-185: Incorrect regular expression. Incorrectly-bounded regex should be terminated correctly](https://semgrep.dev/playground/r/ruby.rails.security.brakeman.check-validation-regex.check-validation-regex?editorMode=advanced)
 
 ## Ruby support in Semgrep Supply Chain
 

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -24,6 +24,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 ## Semgrep Code analyses
 
 * Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#ruby-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -1,0 +1,76 @@
+---
+slug: ruby
+append_help_link: true
+description: >-
+  Detailed documentation for Semgrep's Ruby support. 
+hide_title: true
+tags:
+    - Semgrep Code
+    - Semgrep Supply Chain
+title: Ruby
+---
+
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
+
+# Ruby support
+
+<LangCallout name="Ruby" />
+
+## Semgrep Code analyses
+
+* Framework-specific control flow analysis 
+* Interfile analysis (cross-file)
+* Interprocedural analysis (cross-function)
+
+## Coverage 
+
+<LangCoverage />
+
+Some examples of rules include:
+
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+
+## C# support in Semgrep Supply Chain
+
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+
+<LangDefSsc />
+
+### Supported package managers
+
+Semgrep supports the following C# package manager:
+
+- NuGet
+
+### Analyses and features
+
+The following analyses and features are available for C#:
+
+<LangSscFeatures />
+
+## C# support in Semgrep CE
+
+<LangCeIntro />
+
+The Semgrep Registry provides the following  C# rule sets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+
+<!-- config
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+-->
+Sample usage:
+
+```bash
+semgrep scan --config p/csharp
+```

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -23,8 +23,6 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 ## Semgrep Code analyses
 
-* Framework-specific control flow analysis 
-* Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
 
 ## Coverage 
@@ -33,37 +31,34 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-502: Deserialization of untrusted data. Using `load` and `object_load` can cause remote code execution; use JSON securely instead](https://semgrep.dev/orgs/ooo_semgrep/editor/r/ruby.lang.security.bad-deserialization.bad-deserialization?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-185: Incorrect regular expression. Incorrectly-bounded regex should be terminated correctly](https://semgrep.dev/orgs/ooo_semgrep/editor/r/ruby.rails.security.brakeman.check-validation-regex.check-validation-regex?editorMode=advanced)
 
-## C# support in Semgrep Supply Chain
-
-Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+## Ruby support in Semgrep Supply Chain
 
 <LangDefSsc />
 
 ### Supported package managers
 
-Semgrep supports the following C# package manager:
+Semgrep supports the following Ruby package manager:
 
-- NuGet
+- RubyGems
 
 ### Analyses and features
 
-The following analyses and features are available for C#:
+The following analyses and features are available for Ruby:
 
 <LangSscFeatures />
 
-## C# support in Semgrep CE
+## Ruby support in Semgrep CE
 
 <LangCeIntro />
 
-The Semgrep Registry provides the following  C# rule sets:
+The Semgrep Registry provides the following Ruby rulesets:
 
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
-- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
-- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+- [<i class="fas fa-external-link fa-xs"></i> `p/ruby`](https://semgrep.dev/p/ruby)
+- [<i class="fas fa-external-link fa-xs"></i> `p/brakeman`](https://semgrep.dev/p/brakeman)
 
 <!-- config
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
@@ -71,6 +66,7 @@ The Semgrep Registry provides the following  C# rule sets:
 -->
 Sample usage:
 
+
 ```bash
-semgrep scan --config p/csharp
+semgrep scan --config p/ruby
 ```

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -24,6 +24,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 ## Semgrep Code analyses
 
 * Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#scala-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -31,7 +31,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-tk
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Avoid using unsanitized user input when generating SQL strings](https://semgrep.dev/playground/r/scala.play.security.tainted-slick-sqli.tainted-slick-sqli?editorMode=advanced)
 
 ## Scala support in Semgrep Supply Chain
 
@@ -70,8 +70,7 @@ The Semgrep Registry provides the following Scala rule sets:
 
 tk
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
-- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
-- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+- [<i class="fas fa-external-link fa-xs"></i> `p/scala`](https://semgrep.dev/p/scala)
 
 <!-- config
 - [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -32,6 +32,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 Some examples of rules include:
 
 - [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Avoid using unsanitized user input when generating SQL strings](https://semgrep.dev/playground/r/scala.play.security.tainted-slick-sqli.tainted-slick-sqli?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-78: OS command injection. Sanitize variables that are used in external processes.](https://semgrep.dev/playground/r/scala.lang.security.audit.dangerous-seq-run.dangerous-seq-run)
 
 ## Scala support in Semgrep Supply Chain
 

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -1,0 +1,76 @@
+---
+slug: scala
+append_help_link: true
+description: >-
+  Detailed documentation for Semgrep's Scala support. 
+hide_title: true
+tags:
+    - Semgrep Code
+    - Semgrep Supply Chain
+title: Scala
+---
+
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
+
+# Scala support
+
+<LangCallout name="Scala" />
+
+## Semgrep Code analyses
+
+* Framework-specific control flow analysis 
+* Interfile analysis (cross-file)
+* Interprocedural analysis (cross-function)
+
+## Coverage 
+
+<LangCoverage />
+
+Some examples of rules include:
+
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+
+## C# support in Semgrep Supply Chain
+
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+
+<LangDefSsc />
+
+### Supported package managers
+
+Semgrep supports the following C# package manager:
+
+- NuGet
+
+### Analyses and features
+
+The following analyses and features are available for C#:
+
+<LangSscFeatures />
+
+## C# support in Semgrep CE
+
+<LangCeIntro />
+
+The Semgrep Registry provides the following  C# rule sets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+
+<!-- config
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+-->
+Sample usage:
+
+```bash
+semgrep scan --config p/csharp
+```

--- a/docs/languages/scala.md
+++ b/docs/languages/scala.md
@@ -23,8 +23,6 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 ## Semgrep Code analyses
 
-* Framework-specific control flow analysis 
-* Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
 
 ## Coverage 
@@ -33,34 +31,44 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+tk
 
-## C# support in Semgrep Supply Chain
-
-Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+## Scala support in Semgrep Supply Chain
 
 <LangDefSsc />
 
 ### Supported package managers
 
-Semgrep supports the following C# package manager:
+Semgrep supports the following Scala package manager:
 
-- NuGet
+- Maven
 
 ### Analyses and features
 
-The following analyses and features are available for C#:
+The following analyses and features are available for Scala:
 
-<LangSscFeatures />
+<dl>
+<dt>Reachability analysis</dt>
+<dd>
+Reachability refers to whether or not a vulnerable code pattern from a dependency is used in the codebase that imports it. In Semgrep Supply Chain, both a dependency's vulnerable version and code pattern must match for a vulnerability to be considered reachable.
+</dd>
+<dt>License detection</dt>
+<dd>
+Semgrep Supply Chain's **license compliance** feature enables you to explicitly allow or disallow (block) a package's use in your repository based on its license. For example, your company policy may disallow the use of packages with the Creative Commons Attribution-NonCommercial (CC-BY-NC) license.
+</dd>
+<dt>SBOM generation</dt>
+<dd>
+Semgrep enables you to generate a software bill of materials (SBOM) to assess your third-party dependencies and comply with auditing procedures. Semgrep Supply Chain (SSC) can generate an SBOM for each repository you have added to Semgrep AppSec Platform.
+</dd>
+</dl>
 
-## C# support in Semgrep CE
+## Scala support in Semgrep CE
 
 <LangCeIntro />
 
-The Semgrep Registry provides the following  C# rule sets:
+The Semgrep Registry provides the following Scala rule sets:
 
+tk
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
 - [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
 - [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
@@ -72,5 +80,5 @@ The Semgrep Registry provides the following  C# rule sets:
 Sample usage:
 
 ```bash
-semgrep scan --config p/csharp
+semgrep scan --config p/scala
 ```

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -23,8 +23,6 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 ## Semgrep Code analyses
 
-* Framework-specific control flow analysis 
-* Interfile analysis (cross-file)
 * Interprocedural analysis (cross-function)
 
 ## Coverage 
@@ -33,34 +31,44 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
-- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+tk
 
-## C# support in Semgrep Supply Chain
-
-Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+## Swift support in Semgrep Supply Chain
 
 <LangDefSsc />
 
 ### Supported package managers
 
-Semgrep supports the following C# package manager:
+Semgrep supports the following Swift package manager:
 
-- NuGet
+- SwiftPM
 
 ### Analyses and features
 
-The following analyses and features are available for C#:
+The following analyses and features are available for Swift:
 
-<LangSscFeatures />
+<dl>
+<dt>Reachability analysis</dt>
+<dd>
+Reachability refers to whether or not a vulnerable code pattern from a dependency is used in the codebase that imports it. In Semgrep Supply Chain, both a dependency's vulnerable version and code pattern must match for a vulnerability to be considered reachable.
+</dd>
+<dt>License detection</dt>
+<dd>
+Semgrep Supply Chain's **license compliance** feature enables you to explicitly allow or disallow (block) a package's use in your repository based on its license. For example, your company policy may disallow the use of packages with the Creative Commons Attribution-NonCommercial (CC-BY-NC) license.
+</dd>
+<dt>SBOM generation</dt>
+<dd>
+Semgrep enables you to generate a software bill of materials (SBOM) to assess your third-party dependencies and comply with auditing procedures. Semgrep Supply Chain (SSC) can generate an SBOM for each repository you have added to Semgrep AppSec Platform.
+</dd>
+</dl>
 
-## C# support in Semgrep CE
+## Swift support in Semgrep CE
 
 <LangCeIntro />
 
-The Semgrep Registry provides the following  C# rule sets:
+The Semgrep Registry provides the following Swift rule sets:
 
+tk
 - [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
 - [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
 - [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
@@ -71,6 +79,7 @@ The Semgrep Registry provides the following  C# rule sets:
 -->
 Sample usage:
 
+tk
 ```bash
 semgrep scan --config p/csharp
 ```

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -1,5 +1,3 @@
----
-slug: swift
 append_help_link: true
 description: >-
   Detailed documentation for Semgrep's Swift support. 
@@ -31,7 +29,10 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 
 Some examples of rules include:
 
-tk
+- [<i class="fas fa-external-link fa-xs"></i> CWE-477: Use of obsolete function. `ptrace` API is forbidden from iOS applications](https://semgrep.dev/orgs/-/editor/r/swift.lang.forbidden.forbidden-ios-api.swift-forbidden-ios-apis?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-327: Use of a broken or risky cryptographic algorithm. Avoid MD2](https://semgrep.dev/orgs/-/editor/r/swift.commoncrypto.insecure-hashing-algorithm-md2.insecure-hashing-algorithm-md2?editorMode=advanced)
+
+To view these rules, sign in to Semgrep AppSec Platform.
 
 ## Swift support in Semgrep Supply Chain
 
@@ -62,24 +63,3 @@ Semgrep enables you to generate a software bill of materials (SBOM) to assess yo
 </dd>
 </dl>
 
-## Swift support in Semgrep CE
-
-<LangCeIntro />
-
-The Semgrep Registry provides the following Swift rule sets:
-
-tk
-- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
-- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
-- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
-
-<!-- config
-- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
-- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
--->
-Sample usage:
-
-tk
-```bash
-semgrep scan --config p/csharp
-```

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -1,0 +1,76 @@
+---
+slug: swift
+append_help_link: true
+description: >-
+  Detailed documentation for Semgrep's Swift support. 
+hide_title: true
+tags:
+    - Semgrep Code
+    - Semgrep Supply Chain
+title: Swift
+---
+
+import LangCallout from "/src/components/concept/_lang-callout.md"
+import LangCoverage from "/src/components/concept/_lang-coverage.md"
+import LangDefCode from "/src/components/concept/_lang-def-code.md"
+import LangDefSsc from "/src/components/concept/_lang-def-ssc.md"
+import LangCeIntro from "/src/components/concept/_lang-ce-intro.md"
+import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
+
+# Swift support
+
+<LangCallout name="Swift" />
+
+## Semgrep Code analyses
+
+* Framework-specific control flow analysis 
+* Interfile analysis (cross-file)
+* Interprocedural analysis (cross-function)
+
+## Coverage 
+
+<LangCoverage />
+
+Some examples of rules include:
+
+- [<i class="fas fa-external-link fa-xs"></i> CWE-89: SQL injection. Don't use formatted strings in SQL statements; prefer prepared statements](https://semgrep.dev/playground/r/csharp.lang.security.sqli.csharp-sqli.csharp-sqli?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-90: LDAP injection. Avoid LDAP queries constructed dynamically on user-controlled input](https://semgrep.dev/playground/r/csharp.dotnet.security.audit.ldap-injection.ldap-injection?editorMode=advanced)
+- [<i class="fas fa-external-link fa-xs"></i> CWE-347: Improper verification of cryptographic signature. Use signed security tokens](https://semgrep.dev/playground/r/csharp.lang.security.cryptography.unsigned-security-token.unsigned-security-token?editorMode=advanced)
+
+## C# support in Semgrep Supply Chain
+
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.
+
+<LangDefSsc />
+
+### Supported package managers
+
+Semgrep supports the following C# package manager:
+
+- NuGet
+
+### Analyses and features
+
+The following analyses and features are available for C#:
+
+<LangSscFeatures />
+
+## C# support in Semgrep CE
+
+<LangCeIntro />
+
+The Semgrep Registry provides the following  C# rule sets:
+
+- [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default)
+- [<i class="fas fa-external-link fa-xs"></i> `p/csharp`](https://semgrep.dev/p/csharp)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+
+<!-- config
+- [<i class="fas fa-external-link fa-xs"></i> `p/trailofbits`](https://semgrep.dev/p/trailofbits)
+- [<i class="fas fa-external-link fa-xs"></i> `p/gitlab`](https://semgrep.dev/p/gitlab)
+-->
+Sample usage:
+
+```bash
+semgrep scan --config p/csharp
+```

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -23,6 +23,7 @@ import LangSscFeatures from "/src/components/concept/_lang-ssc-features.md"
 ## Semgrep Code analyses
 
 * Interprocedural analysis (cross-function)
+* All analyses performed by [Semgrep CE](#swift-support-in-semgrep-ce)
 
 ## Coverage 
 

--- a/docs/languages/swift.md
+++ b/docs/languages/swift.md
@@ -1,3 +1,4 @@
+---
 append_help_link: true
 description: >-
   Detailed documentation for Semgrep's Swift support. 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -33,6 +33,15 @@ The following table lists all **Generally available (GA)** and **Beta** language
 
 Languages are arranged by feature completeness from most to least. **Cross-file (interfile)** analysis for Semgrep Code and **reachability** analysis for Semgrep Supply Chain are the most advanced analyses that Semgrep provides; see [Feature definitions](#feature-definitions) for more details.
 
+<!-- *************************************************************************
+ARE YOU EDITING THE SUPPORTED LANGUAGES IN ANY WAY? ADDING A FEATURE? ETC?
+
+Don't forget to update:
+- table at Semgrep CE vs Semgrep
+- the individual language's page
+- and most importantly, the index!!
+*************************************************************************** -->
+
 <SupportedLanguagesTable />
 
 ### Language maturity levels
@@ -239,6 +248,16 @@ The following table lists all Semgrep-supported package managers for each langua
 _<strong>*</strong>Supply Chain does not analyze the transitivity of packages for these language and manifest file or lockfile combinations. All dependencies are listed as **No Reachability Analysis.**_<br />
 
 ### Feature support
+
+<!-- *************************************************************************
+ARE YOU EDITING THE SUPPORTED LANGUAGES IN ANY WAY? ADDING A FEATURE? ETC?
+
+Don't forget to update:
+- table at Semgrep CE vs Semgrep
+- the individual language's page
+- and most importantly, the index!!
+*************************************************************************** -->
+
 
 The following table lists all Supply Chain features for each language. Languages with **reachability** support are listed first.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -48,9 +48,14 @@ module.exports = {
                 label: 'Supported languages',
                 link: {type: 'doc', id: 'supported-languages'},
                 items: [
+                    'languages/csharp',
+                    'languages/go',
+                    'languages/java',
                     'languages/javascript',
                     'languages/python',
-                    'languages/csharp',
+                    'languages/ruby',
+                    'languages/scala',
+                    'languages/swift',
                 ]
             },
             {

--- a/sidebars.js
+++ b/sidebars.js
@@ -50,6 +50,7 @@ module.exports = {
                 items: [
                     'languages/javascript',
                     'languages/python',
+                    'languages/csharp',
                 ]
             },
             {

--- a/sidebars.js
+++ b/sidebars.js
@@ -52,6 +52,7 @@ module.exports = {
                     'languages/go',
                     'languages/java',
                     'languages/javascript',
+                    'languages/kotlin',
                     'languages/python',
                     'languages/ruby',
                     'languages/scala',

--- a/src/components/concept/_lang-callout.md
+++ b/src/components/concept/_lang-callout.md
@@ -1,0 +1,4 @@
+
+:::tip 
+Semgrep’s JavaScript coverage leverages framework-specific analysis capabilities that are not present in Semgrep CE. As a result, many framework specific Pro rules will **fail** to return findings if run on Semgrep CE. To ensure full security coverage, run: `semgrep login && semgrep ci`.
+:::

--- a/src/components/concept/_lang-callout.md
+++ b/src/components/concept/_lang-callout.md
@@ -1,4 +1,4 @@
 
 :::tip 
-Semgrep’s JavaScript coverage leverages framework-specific analysis capabilities that are not present in Semgrep CE. As a result, many framework specific Pro rules will **fail** to return findings if run on Semgrep CE. To ensure full security coverage, run: `semgrep login && semgrep ci`.
+Semgrep’s {props.name} coverage leverages framework-specific analysis capabilities that are not present in Semgrep CE. As a result, many framework specific Pro rules will **fail** to return findings if run on Semgrep CE. To ensure full security coverage, run: `semgrep login && semgrep ci`.
 :::

--- a/src/components/concept/_lang-ce-intro.md
+++ b/src/components/concept/_lang-ce-intro.md
@@ -2,7 +2,7 @@ Semgrep CE is a fast, lightweight program analysis tool that can help you detect
 
 ### Analyses
 
-- Single file, cross function constant propagation
+- Single-file, cross-function constant propagation
 - Single-function taint analysis
 - Semantic analysis 
 

--- a/src/components/concept/_lang-ce-intro.md
+++ b/src/components/concept/_lang-ce-intro.md
@@ -3,7 +3,7 @@ Semgrep CE is a fast, lightweight program analysis tool that can help you detect
 ### Analyses
 
 - Single file, cross function constant propagation
-- Single function taint analysis
+- Single-function taint analysis
 - Semantic analysis 
 
 ### Coverage

--- a/src/components/concept/_lang-ce-intro.md
+++ b/src/components/concept/_lang-ce-intro.md
@@ -1,0 +1,13 @@
+Semgrep CE is a fast, lightweight program analysis tool that can help you detect bugs in your code. It makes use of Semgrep's LGPL 2.1 open source engine.
+
+### Analyses
+
+- Single file, cross function constant propagation
+- Single function taint analysis
+- Semantic analysis 
+
+### Coverage
+
+:::tip
+- Check the `license` of a rule to ensure it meets your licensing requirements. See [Licensing](/licensing) for more details.
+:::

--- a/src/components/concept/_lang-code-analyses.md
+++ b/src/components/concept/_lang-code-analyses.md
@@ -1,0 +1,2 @@
+- Interfile analysis (cross-file)
+- Interprocedural analysis (cross-function)

--- a/src/components/concept/_lang-coverage.md
+++ b/src/components/concept/_lang-coverage.md
@@ -1,0 +1,3 @@
+Semgrep aims to provide comprehensive and accurate detection of common OWASP Top 10 issues in source code. Semgrep uses **rules**, which are instructions based on which it detects patterns in code. These rules are usually organized in rulesets.
+
+By default, Semgrep Code provides you with the [<i class="fas fa-external-link fa-xs"></i> `p/comment`](https://semgrep.dev/p/comment) and [<i class="fas fa-external-link fa-xs"></i> `p/default`](https://semgrep.dev/p/default) rulesets. These rulesets provide the most accurate and comprehensive coverage across Semgrep's supported languages.

--- a/src/components/concept/_lang-def-code.md
+++ b/src/components/concept/_lang-def-code.md
@@ -1,0 +1,1 @@
+Semgrep Code is a static application security testing (SAST) tool that detects security vulnerabilities in your first-party code.

--- a/src/components/concept/_lang-def-ssc.md
+++ b/src/components/concept/_lang-def-ssc.md
@@ -1,0 +1,1 @@
+Semgrep Supply Chain is a software composition analysis (SCA) tool that detects security vulnerabilities in your codebase introduced by open source dependencies.

--- a/src/components/concept/_lang-ssc-features.md
+++ b/src/components/concept/_lang-ssc-features.md
@@ -5,7 +5,7 @@ Reachability refers to whether or not a vulnerable code pattern from a dependenc
 </dd>
 <dt>License detection</dt>
 <dd>
-Semgrep Supply Chain's **license compliance** feature enables you to explicitly allow or disallow (block) a package's use in your repository based on its license. For example, your company policy may disallow the use of packages with the Creative Commons Attribution-NonCommercial (CC-BY-NC) license.
+Semgrep Supply Chain's **license compliance** feature enables you to explicitly allow or disallow (block) a package's use in your repository based on its license. For example, your company policy may disallow the use of packages with the Creative Commons Attribution-NonCommercial (CC-BY-NC) license. Semgrep can help enforce this restriction.
 </dd>
 <dt>Malicious dependency detection</dt>
 <dd>

--- a/src/components/concept/_lang-ssc-features.md
+++ b/src/components/concept/_lang-ssc-features.md
@@ -1,0 +1,18 @@
+<dl>
+<dt>Reachability analysis</dt>
+<dd>
+Reachability refers to whether or not a vulnerable code pattern from a dependency is used in the codebase that imports it. In Semgrep Supply Chain, both a dependency's vulnerable version and code pattern must match for a vulnerability to be considered reachable.
+</dd>
+<dt>License detection</dt>
+<dd>
+Semgrep Supply Chain's **license compliance** feature enables you to explicitly allow or disallow (block) a package's use in your repository based on its license. For example, your company policy may disallow the use of packages with the Creative Commons Attribution-NonCommercial (CC-BY-NC) license.
+</dd>
+<dt>Malicious dependency detection</dt>
+<dd>
+Semgrep is able to detect malicious dependencies in your projects and in pull requests (PRs) or merge requests (MRs).
+</dd>
+<dt>SBOM generation</dt>
+<dd>
+Semgrep enables you to generate a software bill of materials (SBOM) to assess your third-party dependencies and comply with auditing procedures. Semgrep Supply Chain (SSC) can generate an SBOM for each repository you have added to Semgrep AppSec Platform.
+</dd>
+</dl>

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -11,7 +11,7 @@
     </tr></thead>
     <tbody>
     <tr>
-      <td>C#</td>
+      <td>[C#](/languages/csharp)</td>
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • Supports up to C# 13<br />
@@ -22,7 +22,7 @@
          • Can detect malicious dependencies</td>
     </tr>
     <tr>
-      <td>Go</td>
+      <td>[Go](/languages/go)</td>
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • 60+ Pro rules </td>
@@ -32,7 +32,7 @@
          • Can detect malicious dependencies</td>
     </tr>
     <tr>
-      <td>Java</td>
+      <td>[Java](/languages/java)</td>
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • Framework-specific control flow analysis<br />
@@ -42,7 +42,7 @@
          • Can detect open source licenses</td>
     </tr>
     <tr>
-      <td><a href="/docs/languages/javascript">JavaScript</a></td>
+      <td>[JavaScript](/languages/javascript)</td>
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • Framework-specific control flow analysis<br />
@@ -53,7 +53,7 @@
          • Can detect malicious dependencies</td>
     </tr>
     <tr>
-      <td>Kotlin</td>
+      <td>[Kotlin](/languages/kotlin)</td>
       <td><strong>Generally available </strong><br />
          • Cross-file dataflow analysis<br />
          • 60+ Pro rules</td>
@@ -100,7 +100,7 @@
          • Can detect open source licenses</td>
     </tr>
     <tr>
-      <td>Ruby</td>
+      <td>[Ruby](/languages/ruby)</td>
       <td><strong>Generally available </strong><br />
          • Cross-function dataflow analysis<br />
          • 20+ Pro rules</td>
@@ -110,7 +110,7 @@
          • Can detect malicious dependencies</td>
     </tr>
      <tr>
-      <td>Scala</td>
+      <td>[Scala](/languages/scala)</td>
       <td><strong>Generally available </strong><br />
          • Cross-function dataflow analysis<br />
          • Community rules</td>
@@ -119,7 +119,7 @@
          • Can detect open source licenses</td>
     </tr>
     <tr>
-      <td>Swift</td>
+      <td>[Swift](/languages/swift)</td>
       <td><strong>Generally available </strong><br />
          • Cross-function dataflow analysis<br />
          • 50+ Pro rules</td>


### PR DESCRIPTION
# RFC

The supported languages page is a popular TOFU doc. Having documentation for the user's specific programming language sends the signal that we are committed to providing support for that language, in addition to consolidating in one place all the information the user needs about how Semgrep supports that language.

Currently, these docs only provide information for Semgrep Code.

This update aims to provide concise feature coverage for **both SSC and Code** for existing language pages **and** add more language-specific pages (for C#, Java, see full list below).

These language-specific pages are more "formulaic" in a way as the page is meant to be a reference for every Semgrep feature available for that language (do we support lockfileless scanning for X language? do we have license detection for Y?)

Because these pages are TOFU docs we rehash commonly known concepts in Semgrep (What is a rule?) This is to help the reader wrap their head around Semgrep terms. 

### Page list

- [x] C#
- [x] Go
- [x] Java
- [x] Ruby
- [x] Scala
- [x] Swift - note that Swift does not have a Semgrep CE section (too few rules for CE use)
- [x] Kotlin
----

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] The council has decided to send a fellowship to Mordor, i.e. we will commit to building out these pages and keeping them up-to-date.
- [x] Update links in supported languages table, add comment to help future editors
