### PR TITLE
mention outbound UDP requirement for broker

### DIFF
--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -30,6 +30,7 @@ The Semgrep Network Broker is available to Enterprise tier users.
   - If you will be using the broker with a dedicated Semgrep tenant, please note that in your request.
 - **Docker** must be installed on the server where you install the network broker.
 - Ensure that you allocate at least 1 CPU and 512 MB RAM for each instance of Semgrep Network Broker that you run.
+- Ensure that you allow outbound Internet access to `wireguard.semgrep.dev` on UDP port 51820
 
 ## Configure Semgrep Network Broker
 

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -30,7 +30,7 @@ The Semgrep Network Broker is available to Enterprise tier users.
   - If you will be using the broker with a dedicated Semgrep tenant, please note that in your request.
 - **Docker** must be installed on the server where you install the network broker.
 - Ensure that you allocate at least 1 CPU and 512 MB RAM for each instance of Semgrep Network Broker that you run.
-- Ensure that you allow outbound Internet access to `wireguard.semgrep.dev` on UDP port 51820
+- Ensure that you allow outbound access to `wireguard.semgrep.dev` on UDP port `51820`.
 
 ## Configure Semgrep Network Broker
 


### PR DESCRIPTION
Currently we document Broker's outbound UDP requirement on its [repository's README](https://github.com/semgrep/semgrep-network-broker/blob/develop/README.md) but not here.

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR