### PR TITLE
chore(sms): Specify BitBucket Data Center version supported for SMS diff scans and triage by PR comments

### DIFF
--- a/docs/deployment/managed-scanning/bitbucket.md
+++ b/docs/deployment/managed-scanning/bitbucket.md
@@ -22,7 +22,7 @@ Add Bitbucket repositories to your Semgrep organization in bulk without adding o
 Semgrep Managed Scanning requires one of the following plans:
 
 - Bitbucket Cloud Premium
-- Bitbucket Data Center
+- Bitbucket Data Center (v8.8 or above for diff-aware scans)
 
 ### Bitbucket Cloud
 

--- a/docs/getting-started/quickstart-sms.md
+++ b/docs/getting-started/quickstart-sms.md
@@ -126,6 +126,7 @@ You must have admin access to your Bitbucket organization.
 
 #### Bitbucket Data Center
 
+- v8.8 or above for diff-aware scans
 - Read access is granted through an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) you generate on Bitbucket. You can provide this token by [adding Bitbucket as a source code manager](/deployment/connect-scm#connect-to-on-premise-orgs-and-projects).
 - The user generating the workspace token must be a **Product Admin** for the workspace. The token must be created with `PROJECT_ADMIN` permissions.
 

--- a/docs/semgrep-code/triage-remediation.md
+++ b/docs/semgrep-code/triage-remediation.md
@@ -188,7 +188,7 @@ Triaging a finding as **Ignored** through a comment in Azure DevOps changes the 
 
 ### Prerequisites
 
-- You have one or more repositories hosted by Bitbucket Cloud Premium.
+- You have one or more repositories hosted by Bitbucket Cloud Premium, or Bitbucket Data Center v8.8 or above.
 - You have completed a [Semgrep core deployment](/deployment/core-deployment). Particularly, you must have a successful connection to Bitbucket.
 
 ### Enable triage through Bitbucket PR comments

--- a/src/components/reference/_sms-support.mdx
+++ b/src/components/reference/_sms-support.mdx
@@ -1,5 +1,5 @@
 Semgrep Managed Scans is in **public beta** for all existing Semgrep AppSec Platform users with:
-  - Bitbucket Cloud Premium plans or Bitbucket Data Center
+  - Bitbucket Cloud Premium plans or Bitbucket Data Center (v8.8 or above for diff-aware scans)
   - Hosted GitHub (GitHub.com) and GitHub Enterprise Server plans
   - GitLab Cloud and GitLab self-managed plans and a Premium or Ultimate subscription
   - Azure DevOps Cloud repositories


### PR DESCRIPTION
SMS diff scans and triage by PR comments rely on project webhooks for BitBucket Data Center. Since project webhooks are introduced in BBDC v8.8 or above, we only support SMS diff scans and triage by PR comments for BBDC v8.8 or above. Updating docs to specify BBDC version.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
