### PR TITLE
Update autofix.md to differentiate between AI and rule-based autofix

### DIFF
--- a/docs/writing-rules/autofix.md
+++ b/docs/writing-rules/autofix.md
@@ -13,7 +13,7 @@ Semgrep's rule format supports a `fix:` key that supports the replacement of met
 You can apply the autofix directly to the file using the `--autofix` flag. To test the autofix before applying it, use both the `--autofix` and `--dryrun` flags.
 
 ```tip
-Rule-based autofix is deterministic and separate from the Semgrep Assistant autofix feature. The Assistant autofix feature uses AI to generate a fix.
+Rule-based autofix is deterministic and separate from the [Semgrep Assistant autofix feature](/semgrep-assistant/overview#autofix). The Assistant autofix feature uses AI to generate a suggested code fix.
 ```
 
 ## Example autofix snippet

--- a/docs/writing-rules/autofix.md
+++ b/docs/writing-rules/autofix.md
@@ -12,6 +12,10 @@ Semgrep's rule format supports a `fix:` key that supports the replacement of met
 
 You can apply the autofix directly to the file using the `--autofix` flag. To test the autofix before applying it, use both the `--autofix` and `--dryrun` flags.
 
+```tip
+Rule-based autofix is deterministic and separate from the Semgrep Assistant autofix feature. The Assistant autofix feature uses AI to generate a fix.
+```
+
 ## Example autofix snippet
 
 Sample autofix (view in [Playground](https://semgrep.dev/s/R6g)):


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A technical writer reviews the content or PR
- [x] Add link to AI autofix.

I was going through the pricing page and realized people may not know we have 2 kinds of autofix.
