### PR TITLE
Update to ignoring documentation, troubleshooting, etc.

### DIFF
--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -247,7 +247,8 @@ Because Semgrep ignore logic is configured at the file, repository, and platform
 
 - It is recommended to only create an custom, user-defined `.semgrepignore` file if you are **overriding** the Semgrep defaults. This means defining all other items to ignore through the global or project path ignores.
   - This method works well if your organization primarily scans using the `semgrep ci` command.
-- Be aware that creating a user-defined `.semgrepignore` file enables developers to edit it. Don't exclude the `.semgrepignore` file from Git tracking to keep a log of changes to it.
+- Be aware that creating a user-defined `.semgrepignore` file enables developers to edit it.
+- Include the `.semgrepignore` file in Git tracking to keep a log of changes and ensure it's applied consistently.
 - To **include** a file or folder for scanning, ensure that you have checked the following places:
   - Global path ignores
   - Project path ignores

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -245,7 +245,7 @@ This section focuses on ignoring as excluding or skipping files, not as a triage
 
 Because Semgrep ignore logic is configured at the file, repository, and platform level, you may sometimes encounter unexpected behavior.
 
-- It is recommended to only create an custom, user-defined `.semgrepignore` file if you are **overriding** the Semgrep defaults, if possible. This means defining all other items to ignore through the global or project path ignores.
+- It is recommended to only create an custom, user-defined `.semgrepignore` file if you are **overriding** the Semgrep defaults. This means defining all other items to ignore through the global or project path ignores.
   - This method works well if your organization primarily scans using the `semgrep ci` command.
 - Be aware that creating a user-defined `.semgrepignore` file enables developers to edit it. Don't exclude the `.semgrepignore` file from Git tracking to keep a log of changes to it.
 - To **include** a file or folder for scanning, ensure that you have checked the following places:

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -249,7 +249,7 @@ Because Semgrep ignore logic is configured at the file, repository, and platform
   - This method works well if your organization primarily scans using the `semgrep ci` command.
 - Be aware that creating a user-defined `.semgrepignore` file enables developers to edit it.
 - Include the `.semgrepignore` file in Git tracking to keep a log of changes and ensure it's applied consistently.
-- To **include** a file or folder for scanning, ensure that you have checked the following places:
+- To **include** a file or folder for scanning, ensure it's not in any of the following places:
   - Global path ignores
   - Project path ignores
   - User-defined `.semgrepignore`

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -27,8 +27,8 @@ All Semgrep environments (CLI, CI, and Semgrep AppSec Platform) adhere to user-d
 | Method  | Usage    |
 |:--------|:---------|
 | To ignore blocks of code: Add a `nosemgrep` annotation | Create a comment, followed by a space (` `), followed by `nosemgrep` at the first line or preceding line of the pattern match. This generates a finding that is automatically ignored. <br /><br />For example:<br /><br />` // nosemgrep` &nbsp; &nbsp; &nbsp;<br />`// nosemgrep: rule-id` <br /> `# nosemgrep` |
-| For **teams or organizations** deploying Semgrep as part of a security program: <br /><br /><ul><li>Ignore files and folders through the use of Semgrep AppSec Platform's **Project or Global ignores**</li><li>Override the implicit ignorelist through the use of a `.semgrepignore` file.</li></ul> | Navigate to **Projects > <PL>PROJECT_NAME</PL> > Details > Settings > Path ignores**.<br /><br /> ![Set ignore paths for a project in Semgrep AppSec Platform.](/img/per-project-ignores.png) |
-| For **individuals** scanning repositories or local codebases, or Semgrep CE users:<br /><br />Ignore files and folders through a `.semgrepignore` file | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
+| For Semgrep AppSec Platform users: <br /><br /><ul><li>Ignore files and folders through the use of Semgrep AppSec Platform's **Project or Global ignores**</li><li>Override the implicit ignorelist through the use of a `.semgrepignore` file.</li></ul> | Navigate to **Projects > <PL>PROJECT_NAME</PL> > Details > Settings > Path ignores**.<br /><br /> ![Set ignore paths for a project in Semgrep AppSec Platform.](/img/per-project-ignores.png) |
+| For Semgrep CE users:<br /><br />Ignore files and folders through a `.semgrepignore` file | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
  
 
 ## Understand Semgrep defaults
@@ -37,13 +37,15 @@ Without user customization, Semgrep refers to the following to define ignored fi
 
 * Semgrep's default `.semgrepignore` file
 * Your repository's `.gitignore` file (if it exists)
-* For Semgrep AppSec Platform users: each project (repository) in Semgrep **includes** a list of ignored files and folders by default in the **Path ignores** list
+* For Semgrep AppSec Platform users: each project (repository) in Semgrep has a list of ignored files and folders in its project details page.
 
 In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repository's default template](https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore):
 
 ```
 DEFAULT_SEMGREPIGNORE_TEXT
 ```
+```
+
 
 ## Override defaults
 
@@ -52,7 +54,7 @@ The default `.semgrepignore` file causes Semgrep to skip these folders:
 * `/tests`, `/test`
 * `/vendors`
 
-To include these folders or override the defaults:
+To include these folders:
 
 1. Create a `.semgrepignore` file at the repository root without those paths.
 1. For Platform users: remove the folders from the project ignore list in **Projects > <PL>PROJECT_NAME</PL> > Details page > Settings > Path ignores > Code (SAST) & Supply Chain (SCA)**.
@@ -245,7 +247,7 @@ This section focuses on ignoring as excluding or skipping files, not as a triage
 
 Because Semgrep ignore logic is configured at the file, repository, and platform level, you may sometimes encounter unexpected behavior.
 
-- It is recommended to only create an custom, user-defined `.semgrepignore` file if you are **overriding** the Semgrep defaults. This means defining all other items to ignore through the global or project path ignores.
+- It is recommended to only create an custom, user-defined `.semgrepignore` file if you are **overriding** the Semgrep defaults, if possible. This means defining all other items to ignore through the global or project path ignores.
   - This method works well if your organization primarily scans using the `semgrep ci` command.
 - Be aware that creating a user-defined `.semgrepignore` file enables developers to edit it.
 - Include the `.semgrepignore` file in Git tracking to keep a log of changes and ensure it's applied consistently.

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -11,6 +11,7 @@ tags:
      generated .md file -->
 
 import IgnoreIndividualFindingNoGrouping from "/src/components/procedure/_ignore-individual-finding-no-grouping.mdx"
+import PL from '@site/src/components/Placeholder';
 
 # Ignore files, folders, and code
 
@@ -26,8 +27,9 @@ All Semgrep environments (CLI, CI, and Semgrep AppSec Platform) adhere to user-d
 | Method  | Usage    |
 |:--------|:---------|
 | To ignore blocks of code: Add a `nosemgrep` annotation | Create a comment, followed by a space (` `), followed by `nosemgrep` at the first line or preceding line of the pattern match. This generates a finding that is automatically ignored. <br /><br />For example:<br /><br />` // nosemgrep` &nbsp; &nbsp; &nbsp;<br />`// nosemgrep: rule-id` <br /> `# nosemgrep` |
-| For **teams or organizations** deploying Semgrep as part of a security program: <br /><br /><ul><li>Ignore files and folders through the use of Semgrep AppSec Platform's **Project or Global ignores**</li><li>Override implicit defaults through the use of a `.semgrepignore` file.</li></ul> | |
-| For **individuals** scanning repositories or local codebases, or Semgrep CE users:<br /><br />Ignore files and folders through a `.semgrepignore` file | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) | 
+| For **teams or organizations** deploying Semgrep as part of a security program: <br /><br /><ul><li>Ignore files and folders through the use of Semgrep AppSec Platform's **Project or Global ignores**</li><li>Override the implicit ignorelist through the use of a `.semgrepignore` file.</li></ul> | Navigate to **Projects > <PL>PROJECT_NAME</PL> > Details > Settings > Path ignores**.<br /><br /> ![Set ignore paths for a project in Semgrep AppSec Platform.](/img/per-project-ignores.png) |
+| For **individuals** scanning repositories or local codebases, or Semgrep CE users:<br /><br />Ignore files and folders through a `.semgrepignore` file | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
+ 
 
 ## Understand Semgrep defaults
 
@@ -35,6 +37,7 @@ Without user customization, Semgrep refers to the following to define ignored fi
 
 * Semgrep's default `.semgrepignore` file
 * Your repository's `.gitignore` file (if it exists)
+* For Semgrep AppSec Platform users: each project (repository) in Semgrep includes a list of ignored files and folders by default in 
 
 In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repository's default template](https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore):
 
@@ -42,67 +45,18 @@ In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repo
 DEFAULT_SEMGREPIGNORE_TEXT
 ```
 
-## Define ignored files and folders in Semgrep AppSec Platform
+## Override defaults
 
-Another method for users to define ignore patterns is through Semgrep AppSec Platform. These patterns follow the same syntax as `.semgrepignore` in the preceding section. You can define patterns for individual projects, or you can define them at the organization level so that they're applied to all projects owned by that organization.
-
-Including files and folders through this method is **additive**. When you run a scan using `semgrep ci`, Semgrep looks for a `.semgrepignore` within the repository. If no `.semgrepignore` file is found, Semgrep temporarily creates one and adds items from Semgrep AppSec Platform's Path Ignores.
-
-Adding items to Semgrep AppSec Platform's **Path Ignores** box doesn't override default Semgrep ignore patterns included with its CLI tool, since the patterns are additive. However, items added to `.semgrepignore` override default Semgrep CLI patterns.
-
-All files and folders defined using Semgrep AppSec Platform's **Path Ignores** feature, both for a specific project and globally, are additive.
-
-### Define files and folders for a specific project
-
-1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login?return_path=/manage/projects).
-2. From the sidebar, click **[Projects](https://semgrep.dev/orgs/-/projects)**.
-3. Find the project you want to modify, then click its **<i class="far fa-window-restore"></i> icon** under **Details**.
-4. Click the **Settings** tab.
-5. To define files and folders that Semgrep can ignore:
-   1. Click **Code (SAST) & Supply Chain (SCA)** or **Secrets** to expand and display the **Path Ignores** box.
-   2. Enter files and folders to ignore in the relevant **Path Ignores** box.
-   3. Click **Save changes**.
-
-![Set ignore paths for a project in Semgrep AppSec Platform.](/img/per-project-ignores.png#md-width)
-_**Figure**. Set ignore paths for a project in Semgrep AppSec Platform._
-
-### Define files and folders for all projects of an organization
-
-1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login?return_path=/manage/projects).
-2. Go to **Settings > Deployment** and navigate to the **Global ignore paths** section.
-3. To define files and folders that Semgrep can ignore:
-   1. Click **Code (SAST) & Supply Chain (SCA)** or **Secrets** to expand and display the **Path Ignores** box.
-   2. Enter files and folders to ignore in the relevant path ignores box.
-   3. Click **Save changes**.
-
-![Set global ignore paths for all projects of an organization in Semgrep AppSec Platform.](/img/global-ignore-paths.png#md-width)
-_**Figure**. Set global ignore paths for all projects of an organization in Semgrep AppSec Platform._
-
-### Add items to `.semgrepignore` during findings triage
-
-You can also add files to `.semgrepignore` while triaging individual findings using Semgrep AppSec Platform:
-
-1. On the Semgrep Code [Findings](https://semgrep.dev/orgs/-/findings?tab=open) page, click the **Status** filter, and then select the **Open** status to see all open findings.
-2. Click the finding you want ignored to open its **Details** page.
-3. Select **Ignored**, and optionally, select an **Ignore reason**.
-4. Click to expand **Ignore files in future scans...**.
-5. Select the files you want ignored in future scans.
-6. Click **Change status** to save.
-
-## Best practices when combining `.semgrepignore` and Platform ignore settings
-
-The default (implicit) `.semgrepignore` file causes Semgrep to skip these folders:
+The default `.semgrepignore` file causes Semgrep to skip these folders:
 
 * `/tests`, `/test`
 * `/vendors`
 
-To include these folders, copy the default `.semgrepignore` file and **remove** those paths.
+To include these folders or override the defaults:
 
-It can become difficult to maintain or remember whether to define ignored files and folders in a custom `.semgrepignore` file or the Platform. 
+1. Create a `.semgrepignore` file at the repository root without those paths.
+1. For Platform users: remove the folders from the project ignore list in **Projects > <PL>PROJECT_NAME</PL> > Details page > Settings > Path ignores > Code (SAST) & Supply Chain (SCA)**.
 
-- In general, create a local `.semgrepignore` file only to override defaults. There is no other way to override the implicit ignore list except through the `.semgrepignore` file.
-- Use the Platform 
-Semgrep ignores
 
 ## Files, folders, and code beyond Semgrep's scope
 
@@ -150,6 +104,56 @@ support multiple `.semgrepignore` files and match the Gitignore
 specification more closely.
 :::
 
+## Define ignored files and folders in Semgrep AppSec Platform
+
+Another method for users to define ignore patterns is through Semgrep AppSec Platform. These patterns follow the same syntax as `.semgrepignore` in the preceding section. You can define patterns for individual projects, or you can define them at the organization level so that they're applied to all projects owned by that organization.
+
+Ignoring files and folders through this method is **additive**.
+
+Adding items to Semgrep AppSec Platform's **Path Ignores** box **doesn't** override default Semgrep ignore patterns included with its CLI tool, since the patterns are additive. To override a Semgrep default, both an existing local `.semgrepignore` file and the **Path ignores** box must be configured. See [Override defaults](#override-defaults).
+
+All files and folders defined using Semgrep AppSec Platform's **Path Ignores** feature, both for a specific project and globally, are additive.
+
+:::tip
+This method is utilized by the `semgrep ci` command. For `semgrep scan`, you can only define ignored files and folders through `.semgrepignore`.
+:::
+
+### Define files and folders for a specific project
+
+1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login?return_path=/manage/projects).
+2. From the sidebar, click **[Projects](https://semgrep.dev/orgs/-/projects)**.
+3. Find the project you want to modify, then click its **<i class="far fa-window-restore"></i> icon** under **Details**.
+4. Click the **Settings** tab.
+5. To define files and folders that Semgrep can ignore:
+   1. Click **Code (SAST) & Supply Chain (SCA)** or **Secrets** to expand and display the **Path Ignores** box.
+   2. Enter files and folders to ignore in the relevant **Path Ignores** box.
+   3. Click **Save changes**.
+
+![Set ignore paths for a project in Semgrep AppSec Platform.](/img/per-project-ignores.png#md-width)
+_**Figure**. Set ignore paths for a project in Semgrep AppSec Platform._
+
+### Define files and folders for all projects of an organization
+
+1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login?return_path=/manage/projects).
+2. Go to **Settings > Deployment** and navigate to the **Global ignore paths** section.
+3. To define files and folders that Semgrep can ignore:
+   1. Click **Code (SAST) & Supply Chain (SCA)** or **Secrets** to expand and display the **Path Ignores** box.
+   2. Enter files and folders to ignore in the relevant path ignores box.
+   3. Click **Save changes**.
+
+![Set global ignore paths for all projects of an organization in Semgrep AppSec Platform.](/img/global-ignore-paths.png#md-width)
+_**Figure**. Set global ignore paths for all projects of an organization in Semgrep AppSec Platform._
+
+### Add items to `.semgrepignore` during findings triage
+
+You can also add files to `.semgrepignore` while triaging individual findings using Semgrep AppSec Platform:
+
+1. On the Semgrep Code [Findings](https://semgrep.dev/orgs/-/findings?tab=open) page, click the **Status** filter, and then select the **Open** status to see all open findings.
+2. Click the finding you want ignored to open its **Details** page.
+3. Select **Ignored**, and optionally, select an **Ignore reason**.
+4. Click to expand **Ignore files in future scans...**.
+5. Select the files you want ignored in future scans.
+6. Click **Change status** to save.
 
 ## Ignore code through nosemgrep
 
@@ -231,8 +235,26 @@ Semgrep AppSec Platform users can disable rules and rulesets through the Policie
 
 * [Manage findings](/semgrep-code/triage-remediation#manage-findings)
 * [Ignore findings through PR and MR comments](/docs/semgrep-code/triage-remediation#triage-findings-through-pr-and-mr-comments)
-
 ## Troubleshooting
+
+### Tips to prevent unexpected ignore behavior
+
+:::tip
+This section focuses on ignoring as excluding or skipping files, not as a triage action. 
+:::
+
+Because Semgrep ignore logic is configured at the file, repository, and platform level, you may sometimes encounter unexpected behavior.
+
+- It is recommended to only create an custom, user-defined `.semgrepignore` file if you are **overriding** the Semgrep defaults, if possible. This means defining all other items to ignore through the global or project path ignores.
+  - This method works well if your organization primarily scans using the `semgrep ci` command.
+- Be aware that creating a user-defined `.semgrepignore` file enables developers to edit it. Don't exclude the `.semgrepignore` file from Git tracking to keep a log of changes to it.
+- To **include** a file or folder for scanning, ensure that you have checked the following places:
+  - Global path ignores
+  - Project path ignores
+  - User-defined `.semgrepignore`
+  - Semgrep defaults (implicit) `.semgrepignore`
+
+### `SAST_EXCLUDED_PATHS`
 
 **For GitLab users**: if you use [the `SAST_EXCLUDED_PATHS` variable](https://docs.gitlab.com/ee/user/application_security/sast/#vulnerability-filters) to specify paths excluded from analysis, you may find that Semgrep doesn't honor these items. This is due to default Semgrep behavior. To explicitly exclude files, you must do one of the following steps:
 

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -26,8 +26,8 @@ All Semgrep environments (CLI, CI, and Semgrep AppSec Platform) adhere to user-d
 | Method  | Usage    |
 |:--------|:---------|
 | To ignore blocks of code: Add a `nosemgrep` annotation | Create a comment, followed by a space (` `), followed by `nosemgrep` at the first line or preceding line of the pattern match. This generates a finding that is automatically ignored. <br /><br />For example:<br /><br />` // nosemgrep` &nbsp; &nbsp; &nbsp;<br />`// nosemgrep: rule-id` <br /> `# nosemgrep` |
-| For **teams or organizations** deploying Semgrep as part of a security program: <br /><br />Ignore files and folders through the use of Semgrep AppSec Platform's **Project or Global ignores** | |
-| For **individuals** scanning repositories or local codebases, or Semgrep CE users:<br /><br />Ignore files and folders through a `.semgrepignore` file | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
+| For **teams or organizations** deploying Semgrep as part of a security program: <br /><br /><ul><li>Ignore files and folders through the use of Semgrep AppSec Platform's **Project or Global ignores**</li><li>Override implicit defaults through the use of a `.semgrepignore` file.</li></ul> | |
+| For **individuals** scanning repositories or local codebases, or Semgrep CE users:<br /><br />Ignore files and folders through a `.semgrepignore` file | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) | 
 
 ## Understand Semgrep defaults
 
@@ -41,61 +41,6 @@ In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repo
 ```
 DEFAULT_SEMGREPIGNORE_TEXT
 ```
-
-:::caution
-The default `.semgrepignore` file causes Semgrep to skip these folders:
-
-* `/tests`, `/test`
-* `/vendors`
-
-To include these folders, create a `.semgrepignore` file without those paths.
-:::
-
-## Files, folders, and code beyond Semgrep's scope
-
-There are files that Semgrep ignores even without `.semgrepignore`:
-
-* Large files (maximum file size defaults to 1 MB)
-* Binary files
-* Unknown file extensions (file extensions not matched with any supported programming language)
-
-Large files and unknown file extensions are included or excluded through command line flags (See [CLI reference](/docs/cli-reference)). Binary files are never scanned.
-
-This document defines **files, folders and code** as those that are **relevant to a Semgrep scan**. For example, `.jpg` files are not a part of Semgrep's scope and therefore are not part of the scope of this document.
-
-## Customize ignore behavior
-
-Semgrep provides several methods to customize ignore behavior. Refer to the following table to see which method suits your goal:
-
-| Goal | Method |
-|:---- |:------ |
-| To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file or [define them through Semgrep AppSec Platform](#define-ignored-files-and-folders-in-semgrep-appsec-platform).|
-| To ignore specific code blocks each time you run a scan. | Create a comment with the word `nosemgrep`. |
-| To ignore files or folders for a particular scan. | Run Semgrep with the flag `--exclude` followed by the pattern or file to be excluded. See [CLI reference](/cli-reference).
-| To include files or folders for a particular scan. | Run Semgrep with the flag `--include` followed by the pattern or file to be included. Any file that isn't matched is excluded. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, resulting in the file's exclusion. |
-| To scan all files within Semgrep's scope each time you run Semgrep (only files in `.git` are ignored). | Create an empty `.semgrepignore` file in your repository root directory, and for `semgrep ci` scans, [remove any entries listed in your **Path Ignores** list](#define-ignored-files-and-folders-in-semgrep-appsec-platform) in Semgrep AppSec Platform. |
-| To include files or folders defined within a `.gitignore` for a particular scan. | Run Semgrep with the flag `--no-git-ignore`. |
-| To ignore files or folders for a particular rule. | Edit the rule to set the `paths` key with one or more patterns. See [Rule syntax](/writing-rules/rule-syntax#paths).
-
-## Define ignored files and folders in `.semgrepignore`
-
-`.semgrepignore` syntax mirrors `.gitignore` syntax, with the following modifications:
-
-* "Include" patterns (lines starting with `!`) are unsupported.
-* "Character range" patterns (lines including a collection of characters inside brackets) are unsupported.
-* An `:include ...` directive is added, which allows another file to be included in the ignore pattern list; typically this included file would be the project `.gitignore`. No attempt at cycle detection is made.
-* Any line that begins with a colon, but not `:include`, raises an error.
-* `\:` is added to escape leading colons.
-
-Unsupported patterns are silently removed from the pattern list (this is done so that `.gitignore` files may be included without raising errors). The removal is logged.
-
-For a description of `.gitignore` syntax, see [.gitignore documentation](https://git-scm.com/docs/gitignore).
-
-:::caution
-[Semgrepignore is being revised](/semgrepignore-v2-reference) to
-support multiple `.semgrepignore` files and match the Gitignore
-specification more closely.
-:::
 
 ## Define ignored files and folders in Semgrep AppSec Platform
 
@@ -143,6 +88,68 @@ You can also add files to `.semgrepignore` while triaging individual findings us
 4. Click to expand **Ignore files in future scans...**.
 5. Select the files you want ignored in future scans.
 6. Click **Change status** to save.
+
+## Best practices when combining `.semgrepignore` and Platform ignore settings
+
+The default (implicit) `.semgrepignore` file causes Semgrep to skip these folders:
+
+* `/tests`, `/test`
+* `/vendors`
+
+To include these folders, copy the default `.semgrepignore` file and **remove** those paths.
+
+It can become difficult to maintain or remember whether to define ignored files and folders in a custom `.semgrepignore` file or the Platform. 
+
+- In general, create a local `.semgrepignore` file only to override defaults. There is no other way to override the implicit ignore list except through the `.semgrepignore` file.
+- Use the Platform 
+Semgrep ignores
+
+## Files, folders, and code beyond Semgrep's scope
+
+There are files that Semgrep ignores even without `.semgrepignore`:
+
+* Large files (maximum file size defaults to 1 MB)
+* Binary files
+* Unknown file extensions (file extensions not matched with any supported programming language)
+
+Large files and unknown file extensions are included or excluded through command line flags (See [CLI reference](/docs/cli-reference)). Binary files are never scanned.
+
+This document defines **files, folders and code** as those that are **relevant to a Semgrep scan**. For example, `.jpg` files are not a part of Semgrep's scope and therefore are not part of the scope of this document.
+
+## Customize ignore behavior
+
+Semgrep provides several methods to customize ignore behavior. Refer to the following table to see which method suits your goal:
+
+| Goal | Method |
+|:---- |:------ |
+| To ignore custom files and folders each time you run a scan. | Add these files to your `.semgrepignore` file or [define them through Semgrep AppSec Platform](#define-ignored-files-and-folders-in-semgrep-appsec-platform).|
+| To ignore specific code blocks each time you run a scan. | Create a comment with the word `nosemgrep`. |
+| To ignore files or folders for a particular scan. | Run Semgrep with the flag `--exclude` followed by the pattern or file to be excluded. See [CLI reference](/cli-reference).
+| To include files or folders for a particular scan. | Run Semgrep with the flag `--include` followed by the pattern or file to be included. Any file that isn't matched is excluded. See CLI reference. When including a pattern from a `.gitignore` or `.semgrepignore` file, `--include` does not override either, resulting in the file's exclusion. |
+| To scan all files within Semgrep's scope each time you run Semgrep (only files in `.git` are ignored). | Create an empty `.semgrepignore` file in your repository root directory, and for `semgrep ci` scans, [remove any entries listed in your **Path Ignores** list](#define-ignored-files-and-folders-in-semgrep-appsec-platform) in Semgrep AppSec Platform. |
+| To include files or folders defined within a `.gitignore` for a particular scan. | Run Semgrep with the flag `--no-git-ignore`. |
+| To ignore files or folders for a particular rule. | Edit the rule to set the `paths` key with one or more patterns. See [Rule syntax](/writing-rules/rule-syntax#paths).
+
+## Define ignored files and folders in `.semgrepignore`
+
+`.semgrepignore` syntax mirrors `.gitignore` syntax, with the following modifications:
+
+* "Include" patterns (lines starting with `!`) are unsupported.
+* "Character range" patterns (lines including a collection of characters inside brackets) are unsupported.
+* An `:include ...` directive is added, which allows another file to be included in the ignore pattern list; typically this included file would be the project `.gitignore`. No attempt at cycle detection is made.
+* Any line that begins with a colon, but not `:include`, raises an error.
+* `\:` is added to escape leading colons.
+
+Unsupported patterns are silently removed from the pattern list (this is done so that `.gitignore` files may be included without raising errors). The removal is logged.
+
+For a description of `.gitignore` syntax, see [.gitignore documentation](https://git-scm.com/docs/gitignore).
+
+:::caution
+[Semgrepignore is being revised](/semgrepignore-v2-reference) to
+support multiple `.semgrepignore` files and match the Gitignore
+specification more closely.
+:::
+
 
 ## Ignore code through nosemgrep
 

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -37,7 +37,7 @@ Without user customization, Semgrep refers to the following to define ignored fi
 
 * Semgrep's default `.semgrepignore` file
 * Your repository's `.gitignore` file (if it exists)
-* For Semgrep AppSec Platform users: each project (repository) in Semgrep includes a list of ignored files and folders by default in 
+* For Semgrep AppSec Platform users: each project (repository) in Semgrep **includes** a list of ignored files and folders by default in the **Path ignores** list.
 
 In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repository's default template](https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore):
 

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -44,7 +44,6 @@ In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repo
 ```
 DEFAULT_SEMGREPIGNORE_TEXT
 ```
-```
 
 
 ## Override defaults

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -23,10 +23,11 @@ All Semgrep environments (CLI, CI, and Semgrep AppSec Platform) adhere to user-d
 
 ## Reference summary
 
-| Method  | Usage    | Examples |
-|:--------|:---------|:---------|
-| To ignore blocks of code: `nosemgrep` | Create a comment, followed by a space (` `), followed by `nosemgrep` at the first line or preceding line of the pattern match. This generates a finding that is automatically ignored. | ` // nosemgrep` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `// nosemgrep: rule-id` <br /> `# nosemgrep` |
-| To ignore files and folders: `.semgrepignore` | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
+| Method  | Usage    |
+|:--------|:---------|
+| To ignore blocks of code: Add a `nosemgrep` annotation | Create a comment, followed by a space (` `), followed by `nosemgrep` at the first line or preceding line of the pattern match. This generates a finding that is automatically ignored. <br /><br />For example:<br /><br />` // nosemgrep` &nbsp; &nbsp; &nbsp;<br />`// nosemgrep: rule-id` <br /> `# nosemgrep` |
+| For **teams or organizations** deploying Semgrep as part of a security program: <br /><br />Ignore files and folders through the use of Semgrep AppSec Platform's **Project or Global ignores** | |
+| For **individuals** scanning repositories or local codebases, or Semgrep CE users:<br /><br />Ignore files and folders through a `.semgrepignore` file | Create a `.semgrepignore` file in your **repository's root directory** or your **project's working directory** and add patterns for files and folders there. Patterns follow `.gitignore` syntax with some caveats. See [Defining ignored files and folders in `.semgrepignore`](#define-ignored-files-and-folders-in-semgrepignore). | [`.semgrepignore` sample file](https://raw.githubusercontent.com/semgrep/semgrep/develop/cli/src/semgrep/templates/.semgrepignore) |
 
 ## Understand Semgrep defaults
 

--- a/docs/ignoring-files-folders-code.md.template
+++ b/docs/ignoring-files-folders-code.md.template
@@ -37,7 +37,7 @@ Without user customization, Semgrep refers to the following to define ignored fi
 
 * Semgrep's default `.semgrepignore` file
 * Your repository's `.gitignore` file (if it exists)
-* For Semgrep AppSec Platform users: each project (repository) in Semgrep **includes** a list of ignored files and folders by default in the **Path ignores** list.
+* For Semgrep AppSec Platform users: each project (repository) in Semgrep **includes** a list of ignored files and folders by default in the **Path ignores** list
 
 In the absence of a user-generated `.semgrepignore`, Semgrep refers to [its repository's default template](https://github.com/semgrep/semgrep/blob/develop/cli/src/semgrep/templates/.semgrepignore):
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR

## About this PR

The information and discussion about how Semgrep handles ignorelists is spread across our comms channels and some very old tickets. I decided to place the information here in one place so that we have a unified location and place where we can refine how the various ignore features best add value to the user experience.

The central discussion involves Platform ignores vs `.semgrepignore`. The `nosem` annotation is largely straightfoward. 

## Summary table

> Don't forget! SAP local project ignorelist EXISTS as does implicit `.semgrepignore` BY DEFAULT when a project is scanned by `semgrep ci`.

Goal | User-defined .semgrepignore | Platform ignores | End result | Why? |
|--|--|--|--|--|
| Ignore `somefile` | Added to user-defined semgrepignore | No changes | Success | Defined in semgrepignore
| Ignore `/tests/` | No existing user-defined semgrepignore | No changes | Success | Part of default (implicit) semgrepignore + also defined in SAP project ignores
| Ignore `/tests/` | Added to user-defined semgrepignore | No changes | Success | Part of user-defined semgrepignore + also defined in SAP project ignores
| Ignore `/tests/` | With existing user-defined semgrepignore that does NOT contain /tests | No changes (`/tests` is part of default SAP list) | Success | Ignore is successful because of SAP project ignores.
| Include `/tests/` | No existing user-defined semgrepignore | REMOVED from SAP project ignores | FAIL - skipped - ignored | Unexpected behavior - if something was removed from the SAP project ignore, it should be ignored, but the lack of a semgrepignore is overriding it (semgrepignore logic takes precedence) |
| Include `/tests/` | With user-defined semgrepignore without `/tests` on ignore list) | No changes | FAIL - skipped - ignored | On an unchanged SAP local project ignorelist, `/tests` is present. |
| Include `/tests/` | With user-defined semgrepignore without `/tests` on ignore list) | REMOVED `/tests` | Success  |Both SAP project ignore list and user-defined semgrepignore without tests is needed. |

### Notes

- I believe that the SAP definitions are added as part of `--exclude` patterns based on what I'm seeing in the log.
- SAP project definitions exist by default as do implicit (no semgrepignore file) definitions. Meaning to say that the "instruction" to ignore `/tests/` is in 2 places.
  - To ignore something, it only needs to be ignored in 1 place at the minimum, but will be skipped.
  - To include something, it needs to be REMOVED from an explicit semgrepignore list AND from SAP > project/global ignores


