### PR TITLE
nit: fix comment to be a valid markdown comment

### DIFF
--- a/docs/contributing/adding-a-language.md
+++ b/docs/contributing/adding-a-language.md
@@ -286,7 +286,7 @@ Parsing errors that are due to an incomplete or incorrect grammar should be reco
 
 We keep failing test cases in a `fail/` folder, preferably in the form of the minimal program suitable for a bug report, with a comment describing what was expected and what's going on.
 
-/* tried to make this more descriptive but should check with Nat if I understood the goal correctly */
+<!-- tried to make this more descriptive but should check with Nat if I understood the goal correctly -->
 
 ## Update the `semgrep` repository
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

Noticed by @mjambon .

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
