### PR TITLE
revert to 30 days

### DIFF
--- a/docs/usage-and-billing.mdx
+++ b/docs/usage-and-billing.mdx
@@ -47,7 +47,7 @@ If you are a small team, such as an **11-person team**, you may be eligible for 
 
 ### Usage computation
 
-Contributors are calculated using `git log` over the **past 90 days** (a rolling interval), not the beginning of each month. The start date is either:
+Contributors are calculated using `git log` over the **past 30 days** (a rolling interval), not the beginning of each month. The start date is either:
 
 - The date of your license purchase.
 - The date of account creation, if you and your team are within usage limits.


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link

It looks like some queries are 90 days, some queries are 30 days (see [Slack thread](https://semgrepinc.slack.com/archives/C0370TA46PL/p1747329065427949?thread_ts=1747327975.632319&cid=C0370TA46PL)) - we cannot consistently say 90 days until all sources equally report it. 