### PR TITLE
chore(sca): add uv to supported python package managers

### DIFF
--- a/docs/languages/python.md
+++ b/docs/languages/python.md
@@ -107,6 +107,7 @@ Semgrep supports the following Python package managers:
 - pip-tools
 - Pipenv
 - Poetry
+- uv
 
 ### Analyses and features
 

--- a/docs/semgrep-supply-chain/upgrade-guidance.md
+++ b/docs/semgrep-supply-chain/upgrade-guidance.md
@@ -31,6 +31,7 @@ This feature is in **private beta**. To join the beta, reach out to the [Semgrep
   - `pip-tools`
   - `pipenv`
   - Poetry
+  - uv
 - GitHub Cloud and GitHub Enterprise Server (self-hosted)
   - This **includes** projects added to Semgrep through Semgrep Managed Scans 
 

--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -191,7 +191,7 @@ The following table lists all Semgrep-supported package managers for each langua
    <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
 </tr>
   <tr>
-   <td rowspan="4">Python</td>
+   <td rowspan="5">Python</td>
    <td>pip</td>
    <td rowspan="2">Any of the following: <ul><li>`*requirement*.txt` or `*requirement*.pip`</li><li>Any manifest file in a requirements folder, such as `**/requirements/*.txt` or `**/requirements/*.pip`</li></ul> The file must be generated automatically and have values set to exact versions (pinned dependencies).</td>
   </tr>
@@ -205,6 +205,10 @@ The following table lists all Semgrep-supported package managers for each langua
   <tr>
    <td>Poetry</td>
    <td><code>poetry.lock</code></td>
+  </tr>
+  <tr>
+   <td>uv</td>
+   <td><code>uv.lock</code></td>
   </tr>
   <tr>
    <td>Ruby</td>


### PR DESCRIPTION
We added uv support in v1.22.0

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
