### PR TITLE
PHP License support [SC-2445]

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -340,8 +340,14 @@ The following table lists all Supply Chain features for each language. Languages
 <td align="center">--</td>
 </tr>
 <tr>
-<td>Rust</td>
+<td>PHP</td>
 <td align="center" width="180px" rowspan="4">No reachability analysis. However, Semgrep can compare a package's version against a list of versions with known vulnerabilities.</td>
+<td align="center">--</td>
+<td align="center">✅</td>
+<td align="center">--</td>
+</tr>
+<tr>
+<td>Rust</td>
 <td align="center">--</td>
 <td align="center">✅</td>
 <td align="center">✅</td>
@@ -354,12 +360,6 @@ The following table lists all Supply Chain features for each language. Languages
 </tr>
 <tr>
 <td>Elixir</td>
-<td align="center">--</td>
-<td align="center">--</td>
-<td align="center">--</td>
-</tr>
-<tr>
-<td>PHP</td>
 <td align="center">--</td>
 <td align="center">--</td>
 <td align="center">--</td>

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -141,7 +141,8 @@
       <td><strong>Generally available </strong><br />
          • Cross-function dataflow analysis<br />
          • 20+ Pro rules</td>
-      <td><strong>Beta</strong></td>
+      <td><strong>Beta</strong><br />
+         • Can detect open source licenses</td>
     </tr>
     <tr>
       <td>Terraform</td>


### PR DESCRIPTION
context: https://github.com/semgrep/semgrep-app/pull/21015

I expect this to be behind a FF for a very short time because the functionality is pretty simple. Imo it is fine to update the docs now. I doubt anyone will notice, and if they open a ticket we can add them to the beta

I put PHP above Rust because we'll have Reachability coverage soon

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
