### PR TITLE
Sara/quickupdate/php reachability in index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ Don't forget to update:
 | Product | Languages |
 | :-------  | :------ |
 | Semgrep Code      |  **Generally available (GA)**<br />C and C++ • C# • Generic • Go • Java • JavaScript • JSON • Kotlin • Python • TypeScript • Ruby • Rust • JSX • PHP • Scala • Swift • Terraform <br /><br />**Beta**<br />APEX • Elixir<br /><br />**Experimental**<br />Bash • Cairo • Circom • Clojure • Dart • Dockerfile • Hack • HTML • Jsonnet • Julia • Lisp • Lua • Move on Aptos • Move on Sui • OCaml• R • Scheme • Solidity • YAML • XML |
-| Semgrep Supply Chain | **Generally available reachability**<br />C# • Go • Java • JavaScript and TypeScript • Kotlin • Python • Ruby • Scala • Swift<br /><br />**Beta or languages without support for reachability analysis**<br />Dart • Elixir • PHP  • Rust |
+| Semgrep Supply Chain | **Generally available reachability**<br />C# • Go • Java • JavaScript and TypeScript • Kotlin • Python • Ruby • Scala • Swift • PHP<br /><br />**Languages without support for reachability analysis**<br />Dart • Elixir • Rust |
 | Semgrep Secrets | Language-agnostic; can detect 630+ types of credentials or keys. |
 
 See the [Supported languages](/supported-languages#language-maturity-summary) documentation for more details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ Don't forget to update:
 | Product | Languages |
 | :-------  | :------ |
 | Semgrep Code      |  **Generally available (GA)**<br />C and C++ • C# • Generic • Go • Java • JavaScript • JSON • Kotlin • Python • TypeScript • Ruby • Rust • JSX • PHP • Scala • Swift • Terraform <br /><br />**Beta**<br />APEX • Elixir<br /><br />**Experimental**<br />Bash • Cairo • Circom • Clojure • Dart • Dockerfile • Hack • HTML • Jsonnet • Julia • Lisp • Lua • Move on Aptos • Move on Sui • OCaml• R • Scheme • Solidity • YAML • XML |
-| Semgrep Supply Chain | **Generally available reachability**<br />C# • Go • Java • JavaScript and TypeScript • Kotlin • Python • Ruby • Scala • Swift • PHP<br /><br />**Languages without support for reachability analysis**<br />Dart • Elixir • Rust |
+| Semgrep Supply Chain | **Generally available reachability**<br />C# • Go • Java • JavaScript and TypeScript • Kotlin • PHP • Python • Ruby • Scala • Swift <br /><br />**Languages without support for reachability analysis**<br />Dart • Elixir • Rust |
 | Semgrep Secrets | Language-agnostic; can detect 630+ types of credentials or keys. |
 
 See the [Supported languages](/supported-languages#language-maturity-summary) documentation for more details.

--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -143,6 +143,7 @@
          • Cross-function dataflow analysis<br />
          • 20+ Pro rules</td>
       <td><strong>Beta</strong><br />
+         • Reachability analysis<br />
          • Can detect open source licenses</td>
     </tr>
     <tr>


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A technical writer reviews the content or PR

### XS size PR deets

- Updated the index to include PHP in languages with reachability analysis. This is a follow up from a previous PR that has already been merged: https://github.com/semgrep/semgrep-docs/pull/2176
- As this is an XS size PR, it's set to auto-merge.