### PR TITLE
Specify you want an SSO admin before disabling SCM auth

### DIFF
--- a/docs/deployment/sso.md
+++ b/docs/deployment/sso.md
@@ -91,7 +91,7 @@ If you have SSO enabled, you can turn off login using GitHub or GitLab credentia
 4. GitLab users: Click the **GitLab SSO** <i class="fa-solid fa-toggle-large-on"></i> toggle to turn off logins using GitLab.
 
 :::warning
-Ensure that you have at least one user who can log in through SSO before disabling sign in with GitHub or GitLab.
+Ensure that you have at least one user who can log in as an admin through SSO before disabling sign in with GitHub or GitLab.
 :::
 
 ## See also


### PR DESCRIPTION
Just added a detail to the warning since folks get stuck here sometimes. Dunno if this will help, but it won't hurt.

https://deploy-preview-2185--semgrep-docs-prod.netlify.app/docs/deployment/sso#turn-off-sign-in-with-github--gitlab

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [x] This change has no security implications ~or else you have pinged the security team~
- [x] ~Redirects are added if the PR changes page URLs~
- [x] ~If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link~
