### PR TITLE
Make contributor count start from 90 days beforehand

### DIFF
--- a/docs/usage-and-billing.mdx
+++ b/docs/usage-and-billing.mdx
@@ -24,7 +24,7 @@ Several Semgrep AppSec Platform products are free under the **Team** tier for **
 - Semgrep Code
 - Semgrep Supply Chain
 
-A **contributor** is someone who has made at least **one** commit to a Semgrep-scanned **private** repository within the last month, starting from the **date of license purchase** if a license was purchased, or the date of account creation, for accounts using Semgrep within usage limits.
+A **contributor** is someone who has made at least **one** commit to a Semgrep-scanned **private** repository within the last 90 days, starting from the **date of license purchase** if a license was purchased, or the date of account creation, for accounts using Semgrep within usage limits.
 
 Any type of Semgrep AppSec Platform scan counts towards the contributor total. This includes:
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content

I understand that the **computation** of a contributor's usage is through a 90 day rolling interval and that pricing models including ours uses a per-month wording (semgrep.dev/pricing) - my question is, how do we bridge the two? Is there something I'm missing in this equation?