### PR TITLE
Deprecate Turbo Mode in Docs

### DIFF
--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -18,7 +18,7 @@ import ForkExistingRule from '/src/components/reference/_fork_existing_rule.md'
 
 ![Semgrep Editor's splash screen](/img/editor-splashscreen.png)
 
-**Semgrep Editor** allows you to write rules, verify their performance through tests, and add them to your organization's [Policies page](/semgrep-code/policies) to enforce code standards and increase code security.
+**Semgrep Editor** allows you to write rules, verify their performance through tests, and add them to your organization’s [Policies page](/semgrep-code/policies) to enforce code standards and increase code security.
 
 The Editor is free to use on all subscription tiers.
 
@@ -28,7 +28,7 @@ The Editor is free to use on all subscription tiers.
 2. Click **Rules > Editor**.
 3. Do any of the following steps:
     1. To create a new rule, click on the <i class="fa-solid fa-circle-plus"></i> **(+) plus sign** or <i class="fa-solid fa-file-plus"></i> **Create new rule** button.
-    2. To open any rule you've recently edited, select it from the **Recent** list.
+    2. To open any rule you’ve recently edited, select it from the **Recent** list.
     3. To view a sample rule, select it from the **Examples** list. The rule renders within the Editor.
     4. To start a tutorial or read the docs, select it from the **Learn** list. This navigates you away from the Editor.
 
@@ -141,7 +141,7 @@ Advanced mode is a YAML editor that allows you to write rules using [Semgrep syn
 :::info Rules syntax
 Refer to [Rule syntax](/writing-rules/rule-syntax) for all possible fields and values to create a rule.
 
-To quickly learn Semgrep patterns and syntax, explore the Editor's library of rules from the **public [Rule Registry](https://semgrep.dev/explore)**. Rules from the Registry can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. Semgrep Editor enables you to **adapt these rules** for your own organization's use by [forking](#write-a-new-rule-by-forking-an-existing-rule) them.
+To quickly learn Semgrep patterns and syntax, explore the Editor’s library of rules from the **public [Rule Registry](https://semgrep.dev/explore)**. Rules from the Registry can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. Semgrep Editor enables you to **adapt these rules** for your own organization's use by [forking](#write-a-new-rule-by-forking-an-existing-rule) them.
 :::
 
 To write a rule in advanced mode:
@@ -215,20 +215,20 @@ To run your rule against selected repositories or projects:
 ![Code search results in Semgrep Editor](/img/code-search-results.png)
 ***Figure.*** Code search results in Semgrep Editor
 
-## Set a rule's visibility and share a rule
+## Set a rule’s visibility and share a rule
 
-Upon saving, a rule's visibility is **private** by default. A private rule is visible only to members within an organization.
+Upon saving, a rule’s visibility is **private** by default. A private rule is visible only to members within an organization.
 
 - To share a rule outside your organization, click **Share > Public > Confirm**. If you want to share this specific version of the rule, you can also toggle Permalink. This provides a shortlink to this version of the rule, which will not change if the rule is modified.
 - To share a private rule with those who can access it, click **Share** and copy the **URL link**.
 
 Some older rules in Semgrep AppSec Platform may be **unlisted** rather than private. These rules are marked with an icon without a lock, and can be shared with anyone, including those who cannot access Semgrep AppSec Platform.
 
-To change an unlisted rule's visibility to private for increased security, click **Share > Private > Confirm**.
+To change an unlisted rule’s visibility to private for increased security, click **Share > Private > Confirm**.
 
 ## Rename a rule
 
-To rename a rule, enter the new name in the YAML editor's `id` field. The, save the rule by entering <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd> on Mac) or clicking the **Save** button.
+To rename a rule, enter the new name in the YAML editor’s `id` field. The, save the rule by entering <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd> on Mac) or clicking the **Save** button.
 
 ## Delete a rule
 

--- a/docs/semgrep-code/editor.md
+++ b/docs/semgrep-code/editor.md
@@ -10,7 +10,6 @@ tags:
 description: "Semgrep Editor is a powerful tool within Semgrep AppSec Platform to write rules and quickly apply these rules across an organization to enforce coding standards across an organization."
 ---
 
-import EnableTurboMode from "/src/components/procedure/_enable-turbo-mode.md"
 import DeleteCustomRule from "/src/components/procedure/_delete-custom-rule.mdx"
 import InstallPrivateGitHubApp from "/src/components/procedure/_install-private-github-app.mdx"
 import ForkExistingRule from '/src/components/reference/_fork_existing_rule.md'
@@ -19,7 +18,7 @@ import ForkExistingRule from '/src/components/reference/_fork_existing_rule.md'
 
 ![Semgrep Editor's splash screen](/img/editor-splashscreen.png)
 
-**Semgrep Editor** allows you to write rules, verify their performance through tests, and add them to your organization’s [Policies page](/semgrep-code/policies) to enforce code standards and increase code security.
+**Semgrep Editor** allows you to write rules, verify their performance through tests, and add them to your organization's [Policies page](/semgrep-code/policies) to enforce code standards and increase code security.
 
 The Editor is free to use on all subscription tiers.
 
@@ -29,7 +28,7 @@ The Editor is free to use on all subscription tiers.
 2. Click **Rules > Editor**.
 3. Do any of the following steps:
     1. To create a new rule, click on the <i class="fa-solid fa-circle-plus"></i> **(+) plus sign** or <i class="fa-solid fa-file-plus"></i> **Create new rule** button.
-    2. To open any rule you’ve recently edited, select it from the **Recent** list.
+    2. To open any rule you've recently edited, select it from the **Recent** list.
     3. To view a sample rule, select it from the **Examples** list. The rule renders within the Editor.
     4. To start a tutorial or read the docs, select it from the **Learn** list. This navigates you away from the Editor.
 
@@ -142,7 +141,7 @@ Advanced mode is a YAML editor that allows you to write rules using [Semgrep syn
 :::info Rules syntax
 Refer to [Rule syntax](/writing-rules/rule-syntax) for all possible fields and values to create a rule.
 
-To quickly learn Semgrep patterns and syntax, explore the Editor’s library of rules from the **public [Rule Registry](https://semgrep.dev/explore)**. Rules from the Registry can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. Semgrep Editor enables you to **adapt these rules** for your own organization’s use by [forking](#write-a-new-rule-by-forking-an-existing-rule) them.
+To quickly learn Semgrep patterns and syntax, explore the Editor's library of rules from the **public [Rule Registry](https://semgrep.dev/explore)**. Rules from the Registry can detect OWASP vulnerabilities, best practice violations, and security issues for a wide variety of languages and frameworks. Semgrep Editor enables you to **adapt these rules** for your own organization's use by [forking](#write-a-new-rule-by-forking-an-existing-rule) them.
 :::
 
 To write a rule in advanced mode:
@@ -179,9 +178,7 @@ In addition to testing for matches, you can test that your rule doesn't match wh
 
 Once you've written a rule and created comment annotations, you can run your rule against your comment annotations by clicking **Run**. You can also press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (<kbd>⌘</kbd>+<kbd>Enter</kbd> on Mac).
 
-### Turbo mode (beta)
 
-<EnableTurboMode />
 
 ## Code search (beta)
 
@@ -218,9 +215,9 @@ To run your rule against selected repositories or projects:
 ![Code search results in Semgrep Editor](/img/code-search-results.png)
 ***Figure.*** Code search results in Semgrep Editor
 
-## Set a rule’s visibility and share a rule
+## Set a rule's visibility and share a rule
 
-Upon saving, a rule’s visibility is **private** by default. A private rule is visible only to members within an organization.
+Upon saving, a rule's visibility is **private** by default. A private rule is visible only to members within an organization.
 
 - To share a rule outside your organization, click **Share > Public > Confirm**. If you want to share this specific version of the rule, you can also toggle Permalink. This provides a shortlink to this version of the rule, which will not change if the rule is modified.
 - To share a private rule with those who can access it, click **Share** and copy the **URL link**.
@@ -231,7 +228,7 @@ To change an unlisted rule's visibility to private for increased security, click
 
 ## Rename a rule
 
-To rename a rule, enter the new name in the YAML editor’s `id` field. The, save the rule by entering <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd> on Mac) or clicking the **Save** button.
+To rename a rule, enter the new name in the YAML editor's `id` field. The, save the rule by entering <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd> on Mac) or clicking the **Save** button.
 
 ## Delete a rule
 

--- a/docs/writing-rules/experiments/deprecated-experiments.md
+++ b/docs/writing-rules/experiments/deprecated-experiments.md
@@ -140,3 +140,13 @@ The value of `reduce` key must be one of the following:
 Although extract mode supports JSON array decoding with the `json` key, it does not support other additional processing for the extracted text, such as unescaping strings.
 
 While extract mode can help to enable rules which try and track taint across a language boundary within a file, taint rules cannot have a source and sink split across the original file and extracted text.
+
+## Turbo Mode
+
+:::note 
+As of June 16th, 2025, Turbo Mode has been deprecated and removed from the Semgrep Playground. 
+:::
+
+Turbo Mode was a feature in the Semgrep Editor that automatically ran your rule against Semgrep CE after every keystroke or change to the rule. 
+
+

--- a/src/components/procedure/_enable-turbo-mode.md
+++ b/src/components/procedure/_enable-turbo-mode.md
@@ -1,9 +1,0 @@
-The **Turbo** option runs your rule automatically against Semgrep CE after every keystroke or change to the rule.
-
-Click the <i class="fa-solid fa-toggle-large-on"></i> **Turbo mode** toggle to enable.
-
-The **Run** button is hidden in Turbo mode because Semgrep scans after any changes to the rule. Turbo mode works with the editor in either structure or advanced mode.
-
-![Screenshot of Playground in Turbo mode](/img/playground-turbo.png)
-
-Turbo mode is unavailable with Semgrep cross-file analysis.


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
