### PR TITLE
chore: remove js lsp stuff

### DIFF
--- a/docs/extensions/semgrep-vs-code.md
+++ b/docs/extensions/semgrep-vs-code.md
@@ -8,7 +8,7 @@ tags:
 ---
 
 import IdeLimitations from "/src/components/reference/_ide-limitations.md"
-import QuickstartVSCode from "/src/components/procedure/_quickstart-vscode.md" 
+import QuickstartVSCode from "/src/components/procedure/_quickstart-vscode.md"
 
 # Semgrep Visual Studio Code extension
 
@@ -91,10 +91,7 @@ To configure the Semgrep extension, open its **Extension Settings** page:
 
 The following experimental features should only be used upon recommendation by Semgrep:
 
-- **Semgrep > Use JS**: Use the JavaScript version of the extension. Enabled by default for Windows users.
-- **Semgrep > Heap Size JS**: Set the maximum heap size in MB for the JavaScript version of the extension. Increase if the extension crashes while downloading rules.
 - **Semgrep > Ignore CLI Version**: Ignore the CLI Version and enable all extension features.
-- **Semgrep > Stack Size JS**: Set the maximum stack size in KB for the JavaScript version of the extension.
 
 ## Limitations
 


### PR DESCRIPTION
We removed the ability to use the Javascript-native distribution of Semgrep in the LSP in https://github.com/semgrep/semgrep-vscode/pull/224, this just updates the docs to be in line with it.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
