### PR TITLE
Update _supported-languages-table.mdx

### DIFF
--- a/src/components/reference/_supported-languages-table.mdx
+++ b/src/components/reference/_supported-languages-table.mdx
@@ -15,7 +15,7 @@
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • Supports up to C# 13<br />
-         • 40+ Pro rules </td>
+         • 170+ Pro rules </td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
          • Can detect open source licenses<br />
@@ -25,7 +25,7 @@
       <td>[Go](/languages/go)</td>
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
-         • 60+ Pro rules </td>
+         • 80+ Pro rules </td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
          • Can detect open source licenses<br />
@@ -36,7 +36,7 @@
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • Framework-specific control flow analysis<br />
-         • 160+ Pro rules </td>
+         • 190+ Pro rules </td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
          • Can detect open source licenses</td>
@@ -46,7 +46,7 @@
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • Framework-specific control flow analysis<br />
-         • 70+ Pro rules</td>
+         • 250+ Pro rules</td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
          • Can detect open source licenses<br />
@@ -66,7 +66,7 @@
       <td><strong>Generally available</strong><br />
          • Cross-file dataflow analysis<br />
          • Framework-specific control flow analysis<br />
-         • 300+ Pro rules<br />
+         • 710+ Pro rules<br />
          • See [Python-specific support details](/docs/languages/python)</td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
@@ -78,7 +78,7 @@
       <td><strong>Generally available </strong><br />
          • Cross-file dataflow analysis<br />
          • Framework-specific control flow analysis<br />
-         • 70+ Pro rules</td>
+         • 230+ Pro rules</td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
          • Can detect malicious dependencies<br />
@@ -104,7 +104,7 @@
       <td>[Ruby](/languages/ruby)</td>
       <td><strong>Generally available </strong><br />
          • Cross-function dataflow analysis<br />
-         • 20+ Pro rules</td>
+         • 40+ Pro rules</td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
          • Can detect open source licenses<br />
@@ -123,7 +123,7 @@
       <td>[Swift](/languages/swift)</td>
       <td><strong>Generally available </strong><br />
          • Cross-function dataflow analysis<br />
-         • 50+ Pro rules</td>
+         • 60+ Pro rules</td>
       <td><strong>Generally available</strong><br />
          • Reachability analysis<br />
          • Can detect open source licenses</td>
@@ -141,7 +141,7 @@
       <td>PHP</td>
       <td><strong>Generally available </strong><br />
          • Cross-function dataflow analysis<br />
-         • 20+ Pro rules</td>
+         • 50+ Pro rules</td>
       <td><strong>Beta</strong><br />
          • Reachability analysis<br />
          • Can detect open source licenses</td>
@@ -189,7 +189,6 @@
 - Cairo
 - Circom
 - Clojure
-- Dart
 - Dockerfile
 - Hack
 - HTML


### PR DESCRIPTION
C# Pro Rules = 170+ 
Go = 80+
Java Pro Rules = 190+ 
Javascript - 250+ 
Python - 710+ 
TypeScript - 230+ 
Ruby - 40+
Swift - 60+ 
PHP - 50+ 

Removed Dart from the experimental list, dupe.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
