### PR TITLE
update roles and scopes information

### DIFF
--- a/docs/deployment/managed-scanning/gitlab.md
+++ b/docs/deployment/managed-scanning/gitlab.md
@@ -66,7 +66,8 @@ You can enabled managed scanning for additional repositories after onboarding us
 
 ### If the page doesn't display any repositories
 
-1. Ensure that you've connected your GitLab account by following the steps in [Connect a source code manager](/deployment/connect-scm) and confirm the PAT is created with the required `API` scope and [a role of, at minimum, Reporter](https://docs.gitlab.com/ee/user/permissions.html#roles).
+1. Ensure that you've connected your GitLab account by following the steps in [Connect a source code manager](/deployment/connect-scm) and confirm the [PAT is created with the required `API` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) by someone assigned the [role of **Maintainer** or **Owner**](https://docs.gitlab.com/ee/user/permissions.html#roles).
+   1. Once you successfully create the connection, the role for the person who owns the token can be downgraded to **Developer**.
 2. In Semgrep AppSec Platform, click **<i class="fa-solid fa-folder-open"></i> Projects**.
 3. If the page doesn't display the repository you want to add, click **Can't find your project? > Sync projects**.
 4. If the page doesn't display any repositories, click **Sync projects**.

--- a/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.md
+++ b/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.md
@@ -48,7 +48,7 @@ PR comments appear for the following types of scans under these conditions:
 ### Prerequisites
 
 In addition to finishing the previous steps in your deployment journey, it is recommended that you complete a **full scan** on your **default branch** for the repository in which you want to receive comments.
-- You must have a Bitbucket Data Center HTTP access token. Ensure that the [token HTTP access token that you create](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) has been granted **Project write** permissions. You'll provide this token to your CI provider during the setup process.
+- You must have a Bitbucket Data Center HTTP access token. Ensure that the [HTTP access token that you create](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) has been granted **Project write** permissions. You'll provide this token to your CI provider during the setup process.
 - Semgrep has been tested with Bitbucket Data Center v8.19. If you are using a different version of BBDC and there are issues, please contact [<i class="fa-regular fa-envelope"></i> support@semgrep.com](mailto:support@semgrep.com).
 
 ### Confirm your Semgrep account's connection

--- a/docs/semgrep-appsec-platform/gitlab-mr-comments.md
+++ b/docs/semgrep-appsec-platform/gitlab-mr-comments.md
@@ -57,7 +57,7 @@ To enable MR comments, connect your GitLab organization to Semgrep AppSec Platfo
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login?return_path=/manage/projects).
 1. Go to **Settings > Source code managers**.
 1. Click **Add connection** and select **GitLab**.
-3. Create a GitLab personal access token (PAT) with `api` scope:
+3. Create a GitLab [personal access token (PAT) with `api` scope](https://docs.gitlab.com/ee/user/permissions.html#roles):
    1. Log in to your GitLab account, and go to [<i class="fas fa-external-link fa-xs"></i> Profile > Access Tokens](https://gitlab.com/-/profile/personal_access_tokens).
    2. Add a token with `api` scope.
    3. Copy the generated token.

--- a/docs/semgrep-appsec-platform/gitlab-mr-comments.md
+++ b/docs/semgrep-appsec-platform/gitlab-mr-comments.md
@@ -57,10 +57,11 @@ To enable MR comments, connect your GitLab organization to Semgrep AppSec Platfo
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login?return_path=/manage/projects).
 1. Go to **Settings > Source code managers**.
 1. Click **Add connection** and select **GitLab**.
-3. Create a GitLab [personal access token (PAT) with `api` scope](https://docs.gitlab.com/ee/user/permissions.html#roles):
-   1. Log in to your GitLab account, and go to [<i class="fas fa-external-link fa-xs"></i> Profile > Access Tokens](https://gitlab.com/-/profile/personal_access_tokens).
-   2. Add a token with `api` scope.
-   3. Copy the generated token.
+3. Create a GitLab [personal access token (PAT) with `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes):
+   1. Ensure that you're using an account that has been [assigned a role of `Developer` or higher](https://docs.gitlab.com/user/permissions/#roles), and log in to GitLab.
+   2. Go to [<i class="fas fa-external-link fa-xs"></i> Profile > Access Tokens](https://gitlab.com/-/profile/personal_access_tokens).
+   3. Add a token with `api` scope.
+   4. Copy the generated token.
 4. Return to Semgrep AppSec Platform, and in the **Add connection** form:
    1. Enter the **Name of your GitHub Organization**.
    2. Paste the PAT you created in **Access token**.

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -153,6 +153,11 @@ azuredevops:
 &nbsp;&nbsp;token: <span className="placeholder">ADO_PAT</span>
 </code></pre>
 
+Semgrep recommends setting up and configuring Semgrep with an Azure DevOps service account, not a personal account. Regardless, the account must be assigned the **Owner** or **Project Collection Administrator** role for the organization, and the scopes you must assign to the personal access token include:
+
+- `Code: Read`
+- `Pull Request Threads: Read & write`
+
 </TabItem>
 
 <TabItem value='bb'>
@@ -173,6 +178,9 @@ github:
 &nbsp;&nbsp;baseURL: https://<span className="placeholder">GITHUB_BASE_URL</span>/api/v3
 &nbsp;&nbsp;token: <span className="placeholder">GITHUB_PAT</span>
 </code></pre>
+
+- **Bitbucket Cloud**: The Bitbucket token must be a [workspace access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/) with [**Read** and **Write** permissions for the **Pull requests** scope](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-token-permissions/#Pull-requests).
+- **Bitbucket Data Center**: The Bitbucket token must be an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html). Ensure that the HTTP access token that you create has been granted **Project write** permission. 
 
 </TabItem>
 <TabItem value='gl'>

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -327,10 +327,6 @@ gitlab:
 &nbsp;&nbsp;allowCodeAccess: true
 </code></pre>
 
-:::info Access token
-The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of role of **Maintainer** or **Owner**](https://docs.gitlab.com/user/permissions/#roles).
-:::
-
 :::info Access tokens
 See [Prerequisites and permissions](/deployment/managed-scanning/gitlab#prerequisites-and-permissions) for access token requirements.
 :::

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -154,7 +154,7 @@ azuredevops:
 </code></pre>
 
 :::info Access tokens
-See [Prerequisites](/semgrep-appsec-platform/azure-pr-comments#prerequisites) for access token requirements.
+Semgrep recommends providing the access token when you [connect the source code manager](/deployment/connect-scm#connect-to-cloud-hosted-orgs) instead of in the Network Broker configuration. However, if you must provide the token in the network broker configuration, see [Prerequisites](/semgrep-appsec-platform/azure-pr-comments#prerequisites) for access token requirements.
 :::
 </TabItem>
 
@@ -169,7 +169,7 @@ bitbucket:
 </code></pre>
 
 :::info Access tokens
-See Prerequisites for access token requirements:
+Semgrep recommends providing the access token when you [connect the source code manager](/deployment/connect-scm) instead of in the Network Broker configuration. However, if you must provide the token in the network broker configuration, see Prerequisites for access token requirements:
 - [Bitbucket Cloud](/semgrep-appsec-platform/bitbucket-cloud-pr-comments#create-and-add-a-workspace-access-token)
 - [Bitbucket Data Center](/semgrep-appsec-platform/bitbucket-data-center-pr-comments#prerequisites)
 :::
@@ -193,7 +193,7 @@ gitlab:
 </code></pre>
 
 :::info Access token
-See [Prerequisites](/semgrep-appsec-platform/gitlab-mr-comments#prerequisites) for access token requirements.
+Semgrep recommends providing the access token when you [connect the source code manager](/deployment/connect-scm#connect-to-cloud-hosted-orgs) instead of in the Network Broker configuration. However, if you must provide the token in the network broker configuration, see [Prerequisites](/semgrep-appsec-platform/gitlab-mr-comments#prerequisites) for access token requirements.
 :::
 
 </TabItem>
@@ -289,7 +289,7 @@ azuredevops:
 </code></pre>
 
 :::info Access tokens
-See [Prerequisites and permissions](/deployment/managed-scanning/azure#prerequisites-and-permissions) for access token requirements.
+Semgrep recommends providing the access token when you [connect the source code manager](/deployment/connect-scm#connect-to-cloud-hosted-orgs) instead of in the Network Broker configuration. However, if you must provide the token in the network broker configuration, see [Prerequisites and permissions](/deployment/managed-scanning/azure#prerequisites-and-permissions) for access token requirements.
 :::
 
 </TabItem>
@@ -304,7 +304,7 @@ bitbucket:
 </code></pre>
 
 :::info Access tokens
-See [Prerequisites and permissions](/deployment/managed-scanning/bitbucket#prerequisites-and-permissions) for access token requirements.
+Semgrep recommends providing the access token when you [connect the source code manager](/deployment/connect-scm#connect-to-cloud-hosted-orgs) instead of in the Network Broker configuration. However, if you must provide the token in the network broker configuration, see [Prerequisites and permissions](/deployment/managed-scanning/bitbucket#prerequisites-and-permissions) for access token requirements.
 :::
 
 </TabItem>
@@ -328,7 +328,7 @@ gitlab:
 </code></pre>
 
 :::info Access tokens
-See [Prerequisites and permissions](/deployment/managed-scanning/gitlab#prerequisites-and-permissions) for access token requirements.
+Semgrep recommends providing the access token when you [connect the source code manager](/deployment/connect-scm#connect-to-cloud-hosted-orgs) instead of in the Network Broker configuration. However, if you must provide the token in the network broker configuration, see [Prerequisites and permissions](/deployment/managed-scanning/gitlab#prerequisites-and-permissions) for access token requirements.
 :::
 
 </TabItem>

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -48,7 +48,7 @@ Ensure that you are logged in to the server where you want to run Semgrep Networ
 
 <TabItem value='current'>
 
-Create a `config.yaml` file similar to the following snippet, or copy a starting config from the Semgrep AppSec Platform at  **Settings > Broker**. The steps required to generate values for the placeholders `SEMGREP_LOCAL_ADDRESS`, `YOUR_PRIVATE_KEY`, and `YOUR_BASE_URL` are provided in subsequent steps of this guide.
+Create a `config.yaml` file similar to the following snippet, or copy a starting config from the Semgrep AppSec Platform at  **Settings > Broker**. The steps required to generate values for the placeholders `SEMGREP_LOCAL_ADDRESS`, `YOUR_PRIVATE_KEY`, and `YOUR_BASE_URL`, as well as the scopes required for the access tokens, are provided in subsequent steps of this guide.
 
 ```yaml
   inbound:
@@ -181,6 +181,9 @@ github:
 gitlab:
 &nbsp;&nbsp;baseURL: https://<span className="placeholder">GITLAB_BASE_URL</span>/api/v4
 &nbsp;&nbsp;token: <span className="placeholder">GITLAB_PAT</span>
+
+The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of `Developer` or higher](https://docs.gitlab.com/user/permissions/#roles).
+
 </code></pre>
 
 </TabItem>
@@ -305,6 +308,8 @@ gitlab:
 &nbsp;&nbsp;token: <span className="placeholder">GITLAB_PAT</span>
 &nbsp;&nbsp;allowCodeAccess: true
 </code></pre>
+
+The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of role of **Maintainer** or **Owner**](https://docs.gitlab.com/user/permissions/#roles).
 
 </TabItem>
 </Tabs>

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -153,11 +153,8 @@ azuredevops:
 &nbsp;&nbsp;token: <span className="placeholder">ADO_PAT</span>
 </code></pre>
 
-:::info Access token
-Semgrep recommends setting up and configuring Semgrep with an Azure DevOps service account, not a personal account. Regardless, the account must be assigned the **Owner** or **Project Collection Administrator** role for the organization, and the scopes you must assign to the personal access token include:
-
-- `Code: Read`
-- `Pull Request Threads: Read & write`
+:::info Access tokens
+See [Prerequisites](/semgrep-appsec-platform/azure-pr-comments#prerequisites) for access token requirements.
 :::
 </TabItem>
 
@@ -171,9 +168,10 @@ bitbucket:
 &nbsp;&nbsp;token: <span className="placeholder">BITBUCKET_ACCESS_TOKEN</span>
 </code></pre>
 
-:::info Access token
-- **Bitbucket Cloud**: The Bitbucket token must be a [workspace access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/) with [**Read** and **Write** permissions for the **Pull requests** scope](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-token-permissions/#Pull-requests).
-- **Bitbucket Data Center**: The Bitbucket token must be an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html). Ensure that the HTTP access token that you create has been granted **Project write** permission. 
+:::info Access tokens
+See Prerequisites for access token requirements:
+- [Bitbucket Cloud](/semgrep-appsec-platform/bitbucket-cloud-pr-comments#create-and-add-a-workspace-access-token)
+- [Bitbucket Data Center](/semgrep-appsec-platform/bitbucket-data-center-pr-comments#prerequisites)
 :::
 
 </TabItem>
@@ -195,7 +193,7 @@ gitlab:
 </code></pre>
 
 :::info Access token
-The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of `Developer` or higher](https://docs.gitlab.com/user/permissions/#roles).
+See [Prerequisites](/semgrep-appsec-platform/gitlab-mr-comments#prerequisites) for access token requirements.
 :::
 
 </TabItem>
@@ -290,14 +288,8 @@ azuredevops:
 &nbsp;&nbsp;allowCodeAccess: true
 </code></pre>
 
-:::info Access token
-Semgrep recommends setting up and configuring Semgrep with an Azure DevOps service account, not a personal account. Regardless, the account must be assigned the **Owner** or **Project Collection Administrator** role for the organization, and the scopes you must assign to the personal access token include:
-
-- `Code: Read`
-- `Code: Status`
-- `Member Entitlement Management: Read`
-- `Project and Team: Read & write`
-- `Pull Request Threads: Read & write`
+:::info Access tokens
+See [Prerequisites and permissions](/deployment/managed-scanning/azure#prerequisites-and-permissions) for access token requirements.
 :::
 
 </TabItem>
@@ -311,14 +303,8 @@ bitbucket:
 &nbsp;&nbsp;allowCodeAccess: true
 </code></pre>
 
-:::info Access token
-- **Bitbucket Cloud**: The user generating the workspace token must be a **Product Admin** for the workspace. The token must be a [workspace access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/) with the following [scopes assigned](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-token-permissions/):
-  - `webhook (read and write)`
-  - `repository (read and write)`
-  - `pullrequest (read and write)`
-  - `project (admin)`
-  - `account (read)`
-- **Bitbucket Data Center**: The user generating the workspace token must be a **Product Admin** for the workspace. The token must be an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) with `PROJECT_ADMIN` permissions.
+:::info Access tokens
+See [Prerequisites and permissions](/deployment/managed-scanning/bitbucket#prerequisites-and-permissions) for access token requirements.
 :::
 
 </TabItem>
@@ -343,6 +329,10 @@ gitlab:
 
 :::info Access token
 The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of role of **Maintainer** or **Owner**](https://docs.gitlab.com/user/permissions/#roles).
+:::
+
+:::info Access tokens
+See [Prerequisites and permissions](/deployment/managed-scanning/gitlab#prerequisites-and-permissions) for access token requirements.
 :::
 
 </TabItem>

--- a/docs/semgrep-ci/network-broker.md
+++ b/docs/semgrep-ci/network-broker.md
@@ -153,11 +153,12 @@ azuredevops:
 &nbsp;&nbsp;token: <span className="placeholder">ADO_PAT</span>
 </code></pre>
 
+:::info Access token
 Semgrep recommends setting up and configuring Semgrep with an Azure DevOps service account, not a personal account. Regardless, the account must be assigned the **Owner** or **Project Collection Administrator** role for the organization, and the scopes you must assign to the personal access token include:
 
 - `Code: Read`
 - `Pull Request Threads: Read & write`
-
+:::
 </TabItem>
 
 <TabItem value='bb'>
@@ -170,6 +171,11 @@ bitbucket:
 &nbsp;&nbsp;token: <span className="placeholder">BITBUCKET_ACCESS_TOKEN</span>
 </code></pre>
 
+:::info Access token
+- **Bitbucket Cloud**: The Bitbucket token must be a [workspace access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/) with [**Read** and **Write** permissions for the **Pull requests** scope](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-token-permissions/#Pull-requests).
+- **Bitbucket Data Center**: The Bitbucket token must be an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html). Ensure that the HTTP access token that you create has been granted **Project write** permission. 
+:::
+
 </TabItem>
 <TabItem value='gh'>
 
@@ -179,9 +185,6 @@ github:
 &nbsp;&nbsp;token: <span className="placeholder">GITHUB_PAT</span>
 </code></pre>
 
-- **Bitbucket Cloud**: The Bitbucket token must be a [workspace access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/) with [**Read** and **Write** permissions for the **Pull requests** scope](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-token-permissions/#Pull-requests).
-- **Bitbucket Data Center**: The Bitbucket token must be an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html). Ensure that the HTTP access token that you create has been granted **Project write** permission. 
-
 </TabItem>
 <TabItem value='gl'>
 
@@ -189,10 +192,11 @@ github:
 gitlab:
 &nbsp;&nbsp;baseURL: https://<span className="placeholder">GITLAB_BASE_URL</span>/api/v4
 &nbsp;&nbsp;token: <span className="placeholder">GITLAB_PAT</span>
-
-The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of `Developer` or higher](https://docs.gitlab.com/user/permissions/#roles).
-
 </code></pre>
+
+:::info Access token
+The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of `Developer` or higher](https://docs.gitlab.com/user/permissions/#roles).
+:::
 
 </TabItem>
 </Tabs>
@@ -286,6 +290,16 @@ azuredevops:
 &nbsp;&nbsp;allowCodeAccess: true
 </code></pre>
 
+:::info Access token
+Semgrep recommends setting up and configuring Semgrep with an Azure DevOps service account, not a personal account. Regardless, the account must be assigned the **Owner** or **Project Collection Administrator** role for the organization, and the scopes you must assign to the personal access token include:
+
+- `Code: Read`
+- `Code: Status`
+- `Member Entitlement Management: Read`
+- `Project and Team: Read & write`
+- `Pull Request Threads: Read & write`
+:::
+
 </TabItem>
 
 <TabItem value='bb'>
@@ -296,6 +310,16 @@ bitbucket:
 &nbsp;&nbsp;token: <span className="placeholder">BITBUCKET_ACCESS_TOKEN</span>
 &nbsp;&nbsp;allowCodeAccess: true
 </code></pre>
+
+:::info Access token
+- **Bitbucket Cloud**: The user generating the workspace token must be a **Product Admin** for the workspace. The token must be a [workspace access token](https://support.atlassian.com/bitbucket-cloud/docs/create-a-workspace-access-token/) with the following [scopes assigned](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-token-permissions/):
+  - `webhook (read and write)`
+  - `repository (read and write)`
+  - `pullrequest (read and write)`
+  - `project (admin)`
+  - `account (read)`
+- **Bitbucket Data Center**: The user generating the workspace token must be a **Product Admin** for the workspace. The token must be an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) with `PROJECT_ADMIN` permissions.
+:::
 
 </TabItem>
 <TabItem value='gh'>
@@ -317,7 +341,9 @@ gitlab:
 &nbsp;&nbsp;allowCodeAccess: true
 </code></pre>
 
+:::info Access token
 The GitLab [personal access token (PAT) must have the `api` scope](https://docs.gitlab.com/user/profile/personal_access_tokens/#personal-access-token-scopes) and be created using an account [assigned a role of role of **Maintainer** or **Owner**](https://docs.gitlab.com/user/permissions/#roles).
+:::
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
This PR:
- updates GitLab docs to include roles and token scopes information
- updates the Network Broker doc to link out to tokens info (except for GitHub, since most use the app)

### Please ensure

- [x] A subject matter expert (SME) reviews the content