### PR TITLE
remove use of synonym in algolia config

### DIFF
--- a/algolia-config.json
+++ b/algolia-config.json
@@ -72,7 +72,6 @@
       "url_without_anchor",
       "type"
     ],
-    "type": "synonym",
     "synonyms": [
       [
         "taint mode",


### PR DESCRIPTION
It appears the config doesn't like the use of the synonym key

### Please ensure

- [ ] A technical writer reviews the content or PR
