### PR TITLE
Explicitly use `semgrep` switch in `opam env` commands

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -30,7 +30,7 @@ git submodule update --init --recursive
 brew install opam
 opam init
 opam switch create semgrep 5.3.0
-eval $(opam env)
+eval $(opam env --switch=semgrep)
 ```
 
 Next, install some base packages required for setup and compilation.
@@ -175,7 +175,7 @@ Note that dune and ocamlmerlin must be in your PATH for vscode to correctly buil
 
 ```bash
 cd /path/to/semgrep
-eval $(opam env)
+eval $(opam env --switch=semgrep)
 dune        --version # just checking dune is in your PATH
 ocamlmerlin -version  # just checking ocamlmerlin is in your PATH
 code .


### PR DESCRIPTION
The `opam switch create` command in the instructions for contributing creates an opam switch named `semgrep`, but later commands don't explicitly refer to a switch when setting up the environment in order to use it, which may cause unintended behaviour if more than one switch exists. Explicitly refer to the `semgrep` switch in invocations of `opam env`.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
