### PR TITLE
Update quickstart-sms.md

### DIFF
--- a/docs/getting-started/quickstart-sms.md
+++ b/docs/getting-started/quickstart-sms.md
@@ -128,8 +128,8 @@ You must have admin access to your Bitbucket organization.
 
 #### Bitbucket Data Center
 
-- Server/Data Center 8.8+: Project-level webhooks available
-- Server/Data Center less than 8.8: Repository-level webhook support is in BETA
+- Server/Data Center 8.8+: Project-level webhooks available to support Diff-aware scanning in Semgrep Managed Scans
+- For Server/Data Center less than 8.8 please contact your Semgrep Account Manager or [Semgrep Support](https://semgrep.dev/docs/support)
 
 For Bitbucket Server/Data Center less than 7.18, you must provide a [Personal Access Token](https://confluence.atlassian.com/bitbucketserver0717/personal-access-tokens-1087535496.html) to Semgrep, with 'PROJECT_ADMIN' permissions.
 

--- a/docs/getting-started/quickstart-sms.md
+++ b/docs/getting-started/quickstart-sms.md
@@ -129,9 +129,9 @@ You must have admin access to your Bitbucket organization.
 #### Bitbucket Data Center
 
 - Server/Data Center 8.8+: Project-level webhooks available
-- Server/Data Center <8.8: Repository-level webhook support is in BETA
+- Server/Data Center less than 8.8: Repository-level webhook support is in BETA
 
-For Bitbucket Server/Data Center <7.18, you must provide a [Personal Access Token](https://confluence.atlassian.com/bitbucketserver0717/personal-access-tokens-1087535496.html) to Semgrep, with 'PROJECT_ADMIN' permissions.
+For Bitbucket Server/Data Center less than 7.18, you must provide a [Personal Access Token](https://confluence.atlassian.com/bitbucketserver0717/personal-access-tokens-1087535496.html) to Semgrep, with 'PROJECT_ADMIN' permissions.
 
 For Bitbucket Server/Data Center 7.18+, you must provide a Bitbucket [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) to Semgrep, which can be created by a user with the `Product Admin` role. This access token must be created with with `PROJECT_ADMIN` permissions.
 

--- a/docs/getting-started/quickstart-sms.md
+++ b/docs/getting-started/quickstart-sms.md
@@ -128,9 +128,12 @@ You must have admin access to your Bitbucket organization.
 
 #### Bitbucket Data Center
 
-- V8.8 or above for diff-aware scans.
-- Read access is granted through an [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) you generate on Bitbucket. You can provide this token by [adding Bitbucket as a source code manager](/deployment/connect-scm#connect-to-on-premise-orgs-and-projects).
-- The user generating the workspace token must be a **Product Admin** for the workspace. The token must be created with `PROJECT_ADMIN` permissions.
+- Server/Data Center 8.8+: Project-level webhooks available
+- Server/Data Center <8.8: Repository-level webhook support is in BETA
+
+For Bitbucket Server/Data Center <7.18, you must provide a [Personal Access Token](https://confluence.atlassian.com/bitbucketserver0717/personal-access-tokens-1087535496.html) to Semgrep, with 'PROJECT_ADMIN' permissions.
+
+For Bitbucket Server/Data Center 7.18+, you must provide a Bitbucket [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) to Semgrep, which can be created by a user with the `Product Admin` role. This access token must be created with with `PROJECT_ADMIN` permissions.
 
 ### Add a project
 


### PR DESCRIPTION
Updated with new BitBucket Server/Data Center info:

- Version 7.17+ Supported
- Server/Data Center 8.8+: Project-level webhooks available
- Server/Data Center <8.8: Repository-level webhook support is in BETA

For Bitbucket Server/Data Center <7.18, you must provide a [Personal Access Token](https://confluence.atlassian.com/bitbucketserver0717/personal-access-tokens-1087535496.html) to Semgrep, with 'PROJECT_ADMIN' permissions.

For Bitbucket Server/Data Center 7.18+, you must provide a Bitbucket [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) to Semgrep, which can be created by a user with the `Product Admin` role. This access token must be created with with `PROJECT_ADMIN` permissions.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
