### PR TITLE
Add how advisories are generated and matched to dependencies

### DIFF
--- a/docs/semgrep-supply-chain/malicious-dependencies.md
+++ b/docs/semgrep-supply-chain/malicious-dependencies.md
@@ -77,7 +77,7 @@ If you have configured your policies to display malicious dependency findings to
 
 You can view all the malicious dependencies that Semgrep can detect by navigating to [**Supply Chain > Advisories**](https://semgrep.dev/orgs/-/supply-chain/advisories) and clicking on the **<i class="fa-solid fa-square-check"></i> Malicious package** filter.
 
-Currently, advsories for malicious dependencies are generated automatically and use the package name and version to identify the dependency. In some cases, the advisory may indicate that only certain sources of the dependency may have been affected by the compromise. If you do not use those sources, and never have, then it may be appropriate to mark findings for that advisory as ignored.
+Currently, advisories for malicious dependencies are generated automatically and use the package name and version to identify the dependency. In some cases, the advisory indicates that only specific sources of the dependency have been compromised. If you do not use those sources and have never done so, then it may be appropriate to mark the findings for that advisory as ignored.
 
 ## Disable malicious dependency detection
 

--- a/docs/semgrep-supply-chain/malicious-dependencies.md
+++ b/docs/semgrep-supply-chain/malicious-dependencies.md
@@ -77,6 +77,8 @@ If you have configured your policies to display malicious dependency findings to
 
 You can view all the malicious dependencies that Semgrep can detect by navigating to [**Supply Chain > Advisories**](https://semgrep.dev/orgs/-/supply-chain/advisories) and clicking on the **<i class="fa-solid fa-square-check"></i> Malicious package** filter.
 
+Currently, advsories for malicious dependencies are generated automatically and use the package name and version to identify the dependency. In some cases, the advisory may indicate that only certain sources of the dependency may have been affected by the compromise. If you do not use those sources, and never have, then it may be appropriate to mark findings for that advisory as ignored.
+
 ## Disable malicious dependency detection
 
 Reach out to [support](/support) to disable this feature.


### PR DESCRIPTION
Some customers have had questions about how we generate the malicious dependency advisories, so this addition attempts to provide clarification on related points.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
