### PR TITLE
Direct to support info rather than email

### DIFF
--- a/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.md
+++ b/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.md
@@ -48,7 +48,7 @@ PR comments appear for the following types of scans under these conditions:
 
 In addition to finishing the previous steps in your deployment journey, it is recommended that you complete a **full scan** on your **default branch** for the repository in which you want to receive comments.
 - You must have a Bitbucket Data Center HTTP access token. Ensure that the [HTTP access token that you create](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) has been granted **Project write** permissions. You'll provide this token to your CI provider during the setup process.
-- Semgrep has been tested with Bitbucket Data Center v8.19. If you are using a different version of BBDC and there are issues, please contact [<i class="fa-regular fa-envelope"></i> support@semgrep.com](mailto:support@semgrep.com).
+- Semgrep has been tested with Bitbucket Data Center v8.19. If you are using a different version of BBDC and there are issues, please [reach out to support](/docs/support).
 
 ### Confirm your Semgrep account's connection
 


### PR DESCRIPTION
In general it's preferred to send people to info about how to get support for their setup over directly including the mailto.

### Please ensure

~- [ ] A subject matter expert (SME) reviews the content~ xs PR
- [ ] A technical writer reviews the content or PR
