### PR TITLE
Update _ide-limitations.md

### DIFF
--- a/src/components/reference/_ide-limitations.md
+++ b/src/components/reference/_ide-limitations.md
@@ -1,1 +1,1 @@
-IDE scans use Semgrep Community Edition (CE) for its speed. Scans are thus limited to single-file analysis. You may encounter a higher rate of false positives.
+Semgrep's VS Code extension supports the Pro Engine and cross-file analysis. Other IDE scans use Semgrep Community Edition (CE) for its speed with those scans limited to single-file analysis. As a result, you may encounter a higher rate of false positives.

--- a/src/components/reference/_ide-limitations.md
+++ b/src/components/reference/_ide-limitations.md
@@ -1,1 +1,1 @@
-Semgrep's VS Code extension supports the Pro Engine and cross-file analysis. Other IDE scans use Semgrep Community Edition (CE) for its speed with those scans limited to single-file analysis. As a result, you may encounter a higher rate of false positives.
+Semgrep's VS Code extension supports the use of Pro rules and cross-file analysis. Other IDE scans use Semgrep Community Edition (CE) for its speed, and these scans are limited to single-file analysis. As a result, you may encounter a higher rate of false positives.


### PR DESCRIPTION
Updating this to reflect that VS Code is not limited by CE or single file analysis as declared elsewhere in docs.

https://semgrep.dev/docs/extensions/semgrep-vs-code#:~:text=You%20can%20use%20the%20extension%20without%20signing%20in%2C%20but%20doing%20so%20enables%20better%20results%20since%20you%20benefit%20from%20Semgrep%20Code%20and%20its%20Pro%20rules

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
