### PR TITLE
Remove `make dev-setup` instruction

### DIFF
--- a/docs/contributing/semgrep-core-contributing.md
+++ b/docs/contributing/semgrep-core-contributing.md
@@ -59,7 +59,6 @@ up-to-date.
 To install all necessary dependencies, run
 
 ```bash
-make dev-setup
 make setup
 ```
 


### PR DESCRIPTION
`make setup` is enough to build `semgrep-core`. `make dev-setup` installs a variety of other OCaml packages that can improve the developer experience, but they are strictly optional.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
