### PR TITLE
Update Windows installation docs

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -103,11 +103,19 @@ You must have Python 3.9 or later installed on the machine where the Semgrep CLI
 
     <TabItem value='Windows'>
 
-    1. Install the Semgrep CLI and confirm the installation:
+    1. [Download](https://www.python.org/downloads/) and install Python. Make sure to check the box to add python.exe to the PATH, otherwise you will have difficulty running Pip and Semgrep.
+
+    2. Configure your system to run Python with UTF-8 text encodings by default. In PowerShell, run:
+
+        ```console
+        [System.Environment]::SetEnvironmentVariable('PYTHONUTF8', '1', 'User')
+        ```
+
+    3. Install the Semgrep CLI and confirm the installation. In PowerShell, run:
 
         ```console
         # install through pip
-        python3 -m pip install semgrep
+        pip install –upgrade semgrep
 
         # if you get the following error "error: externally-managed-environment",
         # see semgrep.dev/docs/kb/semgrep-appsec-platform/error-externally-managed-environment 
@@ -116,15 +124,15 @@ You must have Python 3.9 or later installed on the machine where the Semgrep CLI
         semgrep --version
         ```
 
-    2. Log in to your Semgrep account. Running this command launches a browser window, but you can also use the link that's returned in the CLI to proceed:
+    4. Log in to your Semgrep account. Running this command launches a browser window, but you can also use the link that's returned in the CLI to proceed:
 
         ```console
         semgrep login
         ```
 
-    3. In the **Semgrep CLI login**, click **Activate** to proceed.
+    5. In the **Semgrep CLI login**, click **Activate** to proceed.
 
-    4. Return to the CLI, navigate to the root of your project, and run your first scan:
+    6. Return to the CLI, navigate to the root of your project, and run your first scan:
 
         ```console
         semgrep ci


### PR DESCRIPTION
These instructions are slightly different from what we had before. Notably, we previously did not include the instruction to set the PYTHONUTF8 environment variable, which tripped up one customer that I know of. I also got a report from a Semgrep employee that `semgrep` was not made available by default when installed via `python3 -m pip install semgrep`.

So, I'm updating the instructions here with ones that I have personally run through. I know that this works, at least on Windows 11.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
