### PR TITLE
remove unhelpful permissions links only

### DIFF
--- a/docs/deployment/managed-scanning/bitbucket.md
+++ b/docs/deployment/managed-scanning/bitbucket.md
@@ -35,15 +35,11 @@ You must provide a Bitbucket [workspace access token](https://support.atlassian.
 - `project (admin)`
 - `account (read)`
 
-See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
-
 ### Bitbucket Data Center
 
 You must provide a Bitbucket [HTTP access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html) to Semgrep, which can be created by a user with the `Product Admin` role. This access token must be created with with `PROJECT_ADMIN` permissions.
 
 Project-level webhooks are required to support diff-aware scans.
-
-See [Pre-deployment checklist > Permissions](/deployment/checklist#permissions) for more information about the permissions used by Semgrep.
 
 ## Enable Managed Scanning and scan your first repository
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -19,7 +19,7 @@ Learn how to set up Semgrep, scan your first project for security issues, and vi
 You must have Python 3.9 or later installed on the machine where the Semgrep CLI is running.
 :::
 
-1. Navigate to [Semgrep AppSec Platform](https://semgrep.dev/login), and sign up by clicking on **Continue with GitHub** or **Continue with GitLab**. Follow the on-screen prompts to [grant Semgrep the necessary permissions](/deployment/checklist/#permissions) and proceed.
+1. Navigate to [Semgrep AppSec Platform](https://semgrep.dev/login), and sign up by clicking on **Continue with GitHub** or **Continue with GitLab**. Follow the on-screen prompts to grant Semgrep the necessary permissions.
 1. Provide the **Organization display name** you'd like to use, then click **Create new organization**.
 1. When asked **Where do you want to scan?** click **Run on CLI**.
 1. Launch your CLI, and follow the instructions on the [**Scan a project on your machine**](https://semgrep.dev/onboarding/scan) page. For your convenience, the same information is presented below, along with instructions for Windows users.

--- a/docs/run-a-successful-pov.md
+++ b/docs/run-a-successful-pov.md
@@ -24,7 +24,7 @@ To run a successful POV, the Semgrep team needs your organization's decisions re
     - Who among your organization will be evaluating Semgrep? Semgrep creates accounts for everyone on the team who is involved in the POV.
 - **The method to scan the repositories used in the POV**
     - **Recommended: Semgrep Managed Scans (SMS)**
-        - This is the fastest way to deploy Semgrep to the repositories you want to scan. It requires code access, which can be limited to only certain repositories. See [Permissions](/deployment/checklist#permissions) to review SMS requirements.
+        - This is the fastest way to deploy Semgrep to the repositories you want to scan. It requires access to your code, which can be limited to only certain repositories.
     - **CI/CD**
         - This method relies on a CI configuration file, such as a GitHub Actions workflow file. A CI/CD job must be created for each repository you want to scan.
 - **The technical resources**
@@ -32,7 +32,7 @@ To run a successful POV, the Semgrep team needs your organization's decisions re
     - You must decide on and communicate to Semgrep your account management, infra, and tech needs.
 
 :::tip Benefits of Semgrep Managed Scans
-SMS is the **fastest** and **most scalable** deployment method, since it enables you to add repositories for scanning without the need for CI integrations. However, SMS requires code access. [Review the required permissions](/deployment/checklist#permissions).
+SMS is the **fastest** and **most scalable** deployment method, since it enables you to add repositories for scanning without the need for CI integrations. However, SMS requires access to your code.
 :::
 
 ## Summary

--- a/docs/semgrep-assistant/getting-started.md
+++ b/docs/semgrep-assistant/getting-started.md
@@ -92,10 +92,7 @@ Semgrep Assistant requires [read access to your code in GitHub](https://docs.git
 
 <TabItem value='gitlab'>
 
-Semgrep Assistant extends normal Semgrep capabilities by providing contextually aware AI-generated suggestions. In order to build that context, it requires GitLab permissions in addition to the
-[<i class="fa-regular fa-file-lines"></i> standard permissions required for Semgrep](/deployment/checklist/#permissions).
-
-Semgrep Assistant requires the **API scope** to run in both GitLab SaaS and GitLab self-managed instances. This can be specified at either the [project access token level](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) or [personal access token level](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
+Semgrep Assistant extends normal Semgrep capabilities by providing contextually aware AI-generated suggestions. In order to build that context, Semgrep Assistant requires the **API scope** to run in both GitLab SaaS and GitLab self-managed instances. This can be specified at either the [project access token level](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) or [personal access token level](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 
 * You can revoke [project access tokens](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html#revoke-a-project-access-token) or [personal access tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#revoke-a-personal-access-token) at any time.
 * Semgrep Assistant only accesses source code repositories (projects) on a file-by-file basis; it does not need or request org-level access to your codebase.

--- a/src/components/procedure/_join-an-org.md
+++ b/src/components/procedure/_join-an-org.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 To join an existing org in GitHub or GitLab:
 
 1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) with the account credentials specified by your admin.
-1. Follow the on-screen prompts to [grant Semgrep the needed permissions](/deployment/checklist/#permissions) and proceed. This creates your **personal** Semgrep account.
+1. Follow the on-screen prompts to grant Semgrep the needed permissions and proceed. This creates your **personal** Semgrep account.
 1. Click **Join an existing organization**.
 1. Click your organization's name. The web app signs you in to your organization's Semgrep account. You can verify this by viewing the account name in the navigation menu.
 

--- a/src/components/procedure/_platform-signin-gitlab.md
+++ b/src/components/procedure/_platform-signin-gitlab.md
@@ -1,7 +1,7 @@
 To sign in using your GitLab account:
 
 1. Navigate to the [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform login page](https://semgrep.dev/login/) and click **Sign in with GitLab**.
-1. Click **Authorize** to [grant Semgrep the needed permissions](/deployment/checklist#permissions) and proceed.
+1. Click **Authorize** to grant Semgrep the needed permissions and proceed.
 1. Enter an **organization name** when prompted then click **Create new organization**. This organization name is typically the name of the org in GitLab that you want to connect Semgrep to. For individual users, this can also be a personal account.
 1. Either select a **scan environment** or click **Don't want to connect to anything yet?**
 ![Select a scan environment](/img/onboarding-scan-location.png#md-width)


### PR DESCRIPTION
This removes all links to the deployment checklist's permissions section if it's not relevant (currently, it is mostly relevant for GitHub users). In the future, I'll move this info to GitHub-specific pages like we do for all the other SCMs.

### Please ensure

- [ ] A technical writer reviews the content or PR