### PR TITLE
docs: add Semaphore as a CI option

### DIFF
--- a/docs/deployment/add-semgrep-other-ci.md
+++ b/docs/deployment/add-semgrep-other-ci.md
@@ -13,6 +13,7 @@ import NextStepsComments from "/src/components/concept/_next-steps-comments.mdx"
 # Add Semgrep manually to CI providers
 
 :::note Your deployment journey
+
 - You have gained the necessary [resource access and permissions](/deployment/checklist) required for deployment.
 - You have [created a Semgrep account and organization](/deployment/create-account-and-orgs).
 - For GitHub and GitLab users: You have [connected your source code manager](/deployment/connect-scm).
@@ -27,16 +28,17 @@ Skip this guide if you have already configured a CI job.
 
 The steps provided here are known to work with the following CI providers:
 
-* AppVeyor
-* Bamboo
-* Bitrise
-* Buildbot
-* Codeship
-* Codefresh
-* Drone CI
-* Nomad
-* TeamCity CI
-* Travis CI
+- AppVeyor
+- Bamboo
+- Bitrise
+- Buildbot
+- Codeship
+- Codefresh
+- Drone CI
+- Nomad
+- TeamCity CI
+- Travis CI
+- Semaphore
 
 ## General steps
 

--- a/docs/deployment/add-semgrep-to-ci.md
+++ b/docs/deployment/add-semgrep-to-ci.md
@@ -19,6 +19,7 @@ import DeleteAProject from "/src/components/procedure/_delete-a-project.md"
 # Add Semgrep to CI
 
 :::note Your deployment journey
+
 - You have gained the necessary [resource access and permissions](/deployment/checklist) required for deployment.
 - You have [created a Semgrep account and organization](/deployment/create-account-and-orgs).
 - For GitHub and GitLab users: You have [connected your source code manager](/deployment/connect-scm).
@@ -44,6 +45,7 @@ This guide walks you through creating a Semgrep job in the following CI provider
 - CircleCI
 - Buildkite
 - Azure Pipelines
+- Semaphore
 
 ![CI providers explicitly supported in Semgrep AppSec Platform.](/img/in-app-providers.png#md-width)
 _**Figure**. Semgrep AppSec Platform provides steps and configuration files to easily set up a Semgrep job for popular CI providers._
@@ -98,8 +100,10 @@ You have now added a Semgrep job to GitHub Actions. A **full scan** begins autom
 
 :::tip
 You can edit your configuration files to send findings to **GitHub Advanced Security Dashboard (GHAS)** and **GitLab SAST Dashboard**. Refer to the following samples:
+
 - [GitHub Advanced Security Dashboard](/semgrep-ci/sample-ci-configs/#upload-findings-to-github-advanced-security-dashboard)
 - [GitLab SAST Dashboard](/semgrep-ci/sample-ci-configs/#upload-findings-to-gitlab-security-dashboard)
+
 :::
 
 ### Sample CI configuration snippets
@@ -115,6 +119,7 @@ Refer to the following table for links to sample CI configuration snippets:
 | CircleCI             | [`config.yml`](/semgrep-ci/sample-ci-configs/#circleci) |
 | Buildkite            | [`pipelines.yml`](/semgrep-ci/sample-ci-configs/#buildkite) |
 | Azure Pipelines      | [`azure-pipelines.yml`](/semgrep-ci/sample-ci-configs/#azure-pipelines) |
+| Semaphore            | [`semaphore.yml`](/semgrep-ci/sample-ci-configs/#semaphore) |
 
 ### Data collected by Semgrep
 

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -48,6 +48,9 @@ import AzureSemgrepAppSast from "/src/components/code_snippets/_azure-semgrep-ap
 import AzureSemgrepOssSast from "/src/components/code_snippets/_azure-semgrep-oss-sast.mdx"
 import AzureVariables from "/src/components/procedure/_set-env-vars-azure.mdx"
 
+<!-- Semaphore -->
+import SemaphoreSemgrepAppSast from "/src/components/code_snippets/_semaphore-semgrep-app-sast.mdx"
+import SemaphoreSemgrepOssSast from "/src/components/code_snippets/_semaphore-semgrep-oss-sast.mdx"
 
 import ScmFeatureReference from "/src/components/reference/_scm-feature-reference.md"
 
@@ -122,6 +125,7 @@ push:
   paths:
     - .github/workflows/semgrep.yml
 ```
+
 :::
 
 #### Upload findings to GitHub Advanced Security Dashboard
@@ -303,6 +307,7 @@ pipelines:
         script:
           - echo "This step gets double the memory!"
 ```
+
 :::
 
 ## Buildkite
@@ -344,10 +349,10 @@ In order for this configuration to run the correct type of scan for each conditi
 
 1. In the Buildkite UI, go to the pipeline **Settings** and select the connected source code manager in the left sidebar.
     ![Pipeline settings with example GitHub SCM](/img/buildkite-pipeline-settings.png#md-width)
-    _**Figure.**_ Buildkite pipeline settings with using GitHub as the SCM.
+    ***Figure.*** Buildkite pipeline settings with using GitHub as the SCM.
 2. Under **Branch Limiting**, enter your default branch name in the **Branch Filter Pattern** box. You can include any other branch names that require full scans as well, such as `release-*`.
     ![Branch limiting settings with example main branch](/img/buildkite-branch-settings.png#md-width)
-    _**Figure.**_ Branch limiting settings with main as the example branch.
+    ***Figure.*** Branch limiting settings with main as the example branch.
 3. Click **Save Branch Limiting**.
 
 #### Build on pull requests
@@ -467,6 +472,55 @@ You can **run specific product scans** by passing an argument, such as `--supply
 The following configuration creates a CI job that runs Semgrep CE scans using rules configured for your programming language.
 
 <AzureSemgrepOssSast />
+
+You can customize the scan by entering custom rules or other rulesets to scan with. See [Scan your codebase with a specific ruleset](/getting-started/cli-oss/#scan-your-codebase-with-a-specific-ruleset).
+
+</TabItem>
+</Tabs>
+
+## Semaphore
+
+To add Semgrep into Semaphore:
+
+1. [Create a secret](https://docs.semaphore.io/using-semaphore/secrets) with your `SEMGREP_APP_TOKEN`
+2. Open the YAML pipeline using the [Visual Editor](https://docs.semaphore.io/using-semaphore/workflows#workflow-editor)
+3. Press **+Add Block**
+4. Enable the secret created on Step 1
+5. Add the following commands to perform a full scan
+
+   ```shell
+   checkout
+   sudo pip install semgrep
+   semgrep ci
+   ```
+
+6. Press **Run the workflow** to save changes and run the pipeline
+
+### Sample Semaphore configuration snippet
+
+<Tabs
+    defaultValue="semaphore-semgrep"
+    values={[
+    {label: 'Default', value: 'semaphore-semgrep'},
+    {label: 'Semgrep CE', value: 'semaphore-oss'},
+    ]}
+>
+
+<TabItem value='semaphore-semgrep'>
+
+The following configuration creates a CI job that runs scans using the products and options you have enabled in Semgrep AppSec Platform.
+
+<SemaphoreSemgrepAppSast />
+
+You can **run specific product scans** by passing an argument, such as `--supply-chain`. View the [list of arguments](/getting-started/cli/#scan-using-specific-semgrep-products).
+
+</TabItem>
+
+<TabItem value='semaphore-oss'>
+
+The following configuration creates a CI job that runs Semgrep CE scans using rules configured for your programming language.
+
+<SemaphoreSemgrepOssSast />
 
 You can customize the scan by entering custom rules or other rulesets to scan with. See [Scan your codebase with a specific ruleset](/getting-started/cli-oss/#scan-your-codebase-with-a-specific-ruleset).
 

--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -482,11 +482,11 @@ You can customize the scan by entering custom rules or other rulesets to scan wi
 
 To add Semgrep into Semaphore:
 
-1. [Create a secret](https://docs.semaphore.io/using-semaphore/secrets) with your `SEMGREP_APP_TOKEN`
-2. Open the YAML pipeline using the [Visual Editor](https://docs.semaphore.io/using-semaphore/workflows#workflow-editor)
-3. Press **+Add Block**
-4. Enable the secret created on Step 1
-5. Add the following commands to perform a full scan
+1. [Create a secret](https://docs.semaphore.io/using-semaphore/secrets) with your `SEMGREP_APP_TOKEN`.
+2. Open the YAML pipeline using the [Visual Editor](https://docs.semaphore.io/using-semaphore/workflows#workflow-editor).
+3. Clock **+Add Block**.
+4. Enable the secret created in **Step 1**.
+5. Add the following commands to perform a full scan:
 
    ```shell
    checkout
@@ -494,7 +494,7 @@ To add Semgrep into Semaphore:
    semgrep ci
    ```
 
-6. Press **Run the workflow** to save changes and run the pipeline
+6. Click **Run the workflow** to save your changes and run the pipeline job.
 
 ### Sample Semaphore configuration snippet
 

--- a/src/components/code_snippets/_semaphore-semgrep-app-sast.mdx
+++ b/src/components/code_snippets/_semaphore-semgrep-app-sast.mdx
@@ -16,7 +16,7 @@ blocks:
             - sudo pip install semgrep
             - semgrep ci
         # Job performing a diff scan for PR/branches
-        - name: Semgrep Diff Scan
+        - name: Semgrep Diff-aware Scan
           commands:
             - checkout
             - export SEMGREP_BRANCH=$SEMAPHORE_GIT_BRANCH

--- a/src/components/code_snippets/_semaphore-semgrep-app-sast.mdx
+++ b/src/components/code_snippets/_semaphore-semgrep-app-sast.mdx
@@ -1,0 +1,29 @@
+```yaml
+version: v1.0
+name: Semaphore Semgrep Example
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+blocks:
+  - name: Semgrep
+    task:
+      jobs:
+        # Job performing a full scan
+        - name: Semgrep Full Scan
+          commands:
+            - checkout
+            - sudo pip install semgrep
+            - semgrep ci
+        # Job performing a diff scan for PR/branches
+        - name: Semgrep Diff Scan
+          commands:
+            - checkout
+            - export SEMGREP_BRANCH=$SEMAPHORE_GIT_BRANCH
+            - export SEMGREP_BASELINE_COMMIT=$SEMAPHORE_GIT_SHA
+            - sudo pip install semgrep
+            - semgrep ci
+      # import a secret named 'semgrep' with the SEMGREP_APP_TOKEN
+      secrets:
+        - name: semgrep
+```

--- a/src/components/code_snippets/_semaphore-semgrep-oss-sast.mdx
+++ b/src/components/code_snippets/_semaphore-semgrep-oss-sast.mdx
@@ -1,0 +1,26 @@
+```yaml
+version: v1.0
+name: Semaphore Semgrep CE Example
+agent:
+  machine:
+    type: f1-standard-2
+    os_image: ubuntu2204
+blocks:
+  - name: Semgrep
+    task:
+      jobs:
+        # Job performing a full scan using Semgrep CE
+        - name: Semgrep CE Scan
+          commands:
+            - checkout
+            - sudo pip install semgrep
+            # Save report using JUnit to present results in the test dashboard
+            - semgrep scan --junit-xml --output=report.xml
+            - '[[ -f report.xml ]] && test-results publish report.xml'
+after_pipeline:
+  task:
+    jobs:
+      - name: Publish Results
+        commands:
+          - test-results gen-pipeline-report
+```

--- a/src/components/reference/_ci-scheduling.mdx
+++ b/src/components/reference/_ci-scheduling.mdx
@@ -9,3 +9,4 @@ The following table is a summary of methods and resources to set up schedules fo
 | CircleCI | Refer to [CircleCI documentation](https://circleci.com/docs/scheduled-pipelines#get-started-with-scheduled-pipelines-in-circleci) |
 | Buildkite | Refer to [Buildkite documentation](https://buildkite.com/docs/pipelines/scheduled-builds) |
 | Azure Pipelines | Refer to [Azure documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml)
+| Semaphore | Refer to [Semaphore documentation](https://docs.semaphore.io/using-semaphore/tasks)


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

This PR adds [Semaphore](https://github.com/semaphoreio/semaphore) to the CI parts of the docs. The provided docs work for the cloud and open-source+self-hosted versions Semaphore.

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
