### PR TITLE
fix from 90 to 30 days the usage computation

### DIFF
--- a/docs/usage-and-billing.mdx
+++ b/docs/usage-and-billing.mdx
@@ -47,7 +47,7 @@ If you are a small team, such as an **11-person team**, you may be eligible for 
 
 ### Usage computation
 
-Contributors are calculated using `git log` over the **past 90 days** (a rolling interval), not the beginning of each month. The start date is either:
+Contributors are calculated using `git log` over the **past 30 days** (a rolling interval), not the beginning of each month. The start date is either:
 
 - The date of your license purchase.
 - The date of account creation, if you and your team are within usage limits.


### PR DESCRIPTION
The goal is to align doc and the UI.
The doc says last 90 days.
The UI says last 30 days.

<img width="906" height="181" alt="Screenshot 2025-09-03 at 17 10 49" src="https://github.com/user-attachments/assets/0a28b13b-ce98-42ef-81a5-5f83132b8dd4" />

<img width="984" height="249" alt="Screenshot 2025-09-03 at 17 03 47" src="https://github.com/user-attachments/assets/49bc221b-b8f0-4fe3-9151-189491d1e69d" />
