### PR TITLE
[TEC-420] Python SCA now finds all high and critical severity CVEs > 2017

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -382,10 +382,12 @@ _<strong>†</strong>License detection for new packages is asynchronous and proc
 
 #### CVE coverage
 
-Semgrep's reachability analysis covers the following:
+For customers with an active, paid subscription, Semgrep’s reachability analysis covers:
 
-- All **critical severity** CVEs from [supported sources](#supported-sources) starting 2017 onwards, for packages used by customers with an active, paid subscription.
-- All **high and critical severity** CVEs from supported sources starting May 2022 onwards, for packages used by customers with an active, paid subscription.
+- All **critical severity** CVEs from [supported sources](#supported-sources) starting in 2017.
+- All **high and critical severity** CVEs from supported sources starting:
+   - May 2022 for all packages
+   - 2017 for Python packages
 
 ##### Supported sources
 


### PR DESCRIPTION
# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
