### PR TITLE
Fix typo in dependency search documentation

### DIFF
--- a/docs/semgrep-supply-chain/dependency-search.md
+++ b/docs/semgrep-supply-chain/dependency-search.md
@@ -136,4 +136,4 @@ If you don't see any results on the Dependencies page, ensure that:
 * Semgrep Supply Chain supports your manifest file or lockfile. Refer to [Supported languages](/supported-languages) for a list of supported languages, manifest files, and lockfiles.
 * You've scanned the repository at least once. If you're having trouble seeing dependencies after a scan, see [Why aren't Supply Chain findings showing?](https://semgrep.dev/docs/kb/semgrep-supply-chain/why-no-findings) for additional troubleshooting tips.
 * Your filters and search syntax are correct.
-* The scan you're searching isn't a diff-aware scan. Only dependencies detected during full scans are shown on the **Dependencies** page. 
+* The scan you're searching is a diff-aware scan. Only dependencies detected during full scans are shown on the **Dependencies** page. 


### PR DESCRIPTION
Quick fix to what looks like a typo when describing why dependencies might now show up on the Dependencies page.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Redirects are added if the PR changes page URLs
- [ ] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
