### PR TITLE
This sample works only for SAST

### DIFF
--- a/docs/semgrep-ci/sample-ci-configs.md
+++ b/docs/semgrep-ci/sample-ci-configs.md
@@ -182,7 +182,7 @@ You can customize the scan by entering custom rules or other rulesets to scan wi
 #### Upload findings to GitLab Security Dashboard
 
 <details>
- <summary>Alternate job that uploads findings to GitLab Security Dashboard</summary>
+ <summary>Alternate job that uploads SAST findings to GitLab Security Dashboard</summary>
 
  <GlcicdSemgrepAppSastDash />
 

--- a/src/components/code_snippets/_glcicd-semgrep-app-sast-dash.mdx
+++ b/src/components/code_snippets/_glcicd-semgrep-app-sast-dash.mdx
@@ -21,7 +21,7 @@ semgrep:
 
   # Run the "semgrep ci" command on the command line of the docker image and send findings
   # to GitLab SAST.
-  script: semgrep ci --gitlab-sast > gl-sast-report.json || true
+  script: semgrep ci --code --gitlab-sast > gl-sast-report.json || true
   artifacts:
     reports:
       sast: gl-sast-report.json


### PR DESCRIPTION
If you execute the current example, it fails with an Engine Error -14

<img width="782" height="352" alt="Screenshot 2025-09-05 at 11 26 00" src="https://github.com/user-attachments/assets/30f30e41-ef31-43b6-b34d-bc80a2cada98" />

The reason behind this is that we upload SAST findings, so we need to specify that it is a Code scan.
