### PR TITLE
fix(sca): remove podfile, which we don't support

### DIFF
--- a/docs/supported-languages.md
+++ b/docs/supported-languages.md
@@ -226,15 +226,11 @@ The following table lists all Semgrep-supported package managers for each langua
    <td>Maven</td>
    <td>Maven-generated dependency tree (See <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions.)</td>
 </tr>
-<tr rowspan="2">
-   <td rowspan="2">Swift</td>
+<tr>
+   <td>Swift</td>
    <td>SwiftPM</td>
    <td><code>Package.swift</code> file and Swift-generated <code>Package.resolved</code> file. (See <a href="https://www.swift.org/documentation/package-manager/">Swift documentation </a> for instructions.)</td>
 </tr>
-<tr>
-   <td>CocoaPods</td>
-   <td><code>Podfile.lock</code></td>
-</tr>  
   <tr>
    <td>Rust</td>
    <td>Cargo*</td>


### PR DESCRIPTION
We don't support Cocoapods, but it was in the docs as a supported package
manager

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Redirects are added if the PR changes page URLs
- [x] If you have changed any header tag links (doc/#this-kind-of-anchor), update all instances of that link
