### PR TITLE
Update MCP setup link to reflect the correction location

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -21,4 +21,4 @@ Semgrep's open source MCP works with any IDE-based MCP client, enabling LLMs to 
 Semgrep MCP Server is a beta project in active development. Join the `#mcp` [Slack community](https://go.semgrep.dev/slack) channel to provide your feedback, bug reports, feature requests, and code contributions.
 :::
 
-To learn more and get started, see the [Semgrep MCP server repo on GitHub](https://github.com/semgrep/mcp).
+To learn more and get started, see the [Semgrep MCP server repo on GitHub](https://github.com/semgrep/semgrep/tree/develop/cli/src/semgrep/mcp).


### PR DESCRIPTION
Since the Semgrep MCP server has been moved from a standalone repository into the main Semgrep repo, the previous setup instructions are no longer accurate. This PR updates the link to point to the correct and current setup instructions.

# Thanks for improving Semgrep Docs 😀

### Please ensure

- [ ] A subject matter expert (SME) reviews the content
- [ ] A technical writer reviews the content or PR
