### PR TITLE
Improve docs LLM discovery

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,12 +19,6 @@ to = "/docs"
 status = 302
 
 [[redirects]]
-from = "/docs/llms.txt"
-to = "/llms.txt"
-status = 301
-
-[[redirects]]
 from = "/*"
 to = "/docs/404.html"
 status = 404
-

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "verify:llms": "node scripts/verify-llms-txt.js",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/plugins/llms-txt/index.js
+++ b/plugins/llms-txt/index.js
@@ -1,6 +1,54 @@
 const fs = require('node:fs');
 const path = require('node:path');
 
+const FEATURED_DOCS = [
+  {
+    docId: 'index',
+    title: 'Docs home',
+    description: 'Start page for Semgrep documentation.',
+  },
+  {
+    docId: 'getting-started/introduction',
+    title: 'Introduction to Semgrep',
+    description: 'Overview of Semgrep products and scan workflows.',
+  },
+  {
+    docId: 'getting-started/quickstart',
+    title: 'Quickstart',
+    description: 'Set up Semgrep and scan a project.',
+  },
+  {
+    docId: 'cli-reference',
+    title: 'CLI reference',
+    description: 'Command-line options and exit code behavior.',
+  },
+  {
+    docId: 'writing-rules/overview',
+    title: 'Write Semgrep rules',
+    description: 'Starting point for Semgrep rule writing.',
+  },
+  {
+    docId: 'writing-rules/rule-syntax',
+    title: 'Rule syntax',
+    description: 'YAML rule syntax reference.',
+  },
+  {
+    docId: 'semgrep-ci/sample-ci-configs',
+    title: 'Sample CI configurations',
+    description: 'Example CI/CD configurations for Semgrep scans.',
+  },
+  {
+    docId: 'semgrep-appsec-platform/semgrep-api',
+    title: 'Semgrep API',
+    description: 'Semgrep API overview and usage guidance.',
+  },
+  {
+    docId: 'mcp',
+    title: 'Semgrep Plugin',
+    description: 'MCP server setup for AI coding tools.',
+  },
+];
+
 function walk(dir, extFilter = ['.md', '.mdx']) {
   const results = [];
 
@@ -47,10 +95,6 @@ function normalizeBasePath(baseUrl) {
     : `/${basePath.replace(/^\/|\/$/g, '')}/`;
 }
 
-function getOutputDir(outDir) {
-  return path.dirname(outDir);
-}
-
 function toAbsoluteUrl(siteUrl, pathUrl) {
   if (!siteUrl) {
     return pathUrl;
@@ -58,32 +102,51 @@ function toAbsoluteUrl(siteUrl, pathUrl) {
   return new URL(pathUrl, siteUrl).toString();
 }
 
-function buildLlmsTxt({
-  siteUrl,
-  basePath,
-  htmlRelativeUrls,
-  markdownRelativeUrls,
-}) {
+function getMarkdownUrl({siteUrl, basePath, docId}) {
+  return toAbsoluteUrl(siteUrl, `${basePath}markdown/${docId}.md`);
+}
+
+function getDocIds(docsDir) {
+  return walk(docsDir)
+    .map((file) => getDocId(path.relative(docsDir, file)))
+    .filter(Boolean)
+    .sort();
+}
+
+function renderFeaturedDocs({docIds, siteUrl, basePath}) {
+  const availableDocIds = new Set(docIds);
+
+  return FEATURED_DOCS.filter(({docId}) => availableDocIds.has(docId)).map(
+    ({docId, title, description}) =>
+      `- [${title}](${getMarkdownUrl({siteUrl, basePath, docId})}): ${description}`,
+  );
+}
+
+function renderAllDocs({docIds, siteUrl, basePath}) {
+  return docIds.map(
+    (docId) =>
+      `- [${docId}](${getMarkdownUrl({siteUrl, basePath, docId})})`,
+  );
+}
+
+function buildLlmsTxt({siteUrl, basePath, docIds}) {
   const baseUrl = toAbsoluteUrl(siteUrl, basePath);
-  const htmlAbsoluteUrls = htmlRelativeUrls.map((url) =>
-    toAbsoluteUrl(siteUrl, url),
-  );
-  const markdownAbsoluteUrls = markdownRelativeUrls.map((url) =>
-    toAbsoluteUrl(siteUrl, url),
-  );
 
   return [
     '# Semgrep Docs',
-    '# This file lists documentation pages for AI tooling.',
-    `# Base URL: ${baseUrl}`,
-    '# Absolute HTML routes:',
-    ...htmlAbsoluteUrls.map((url) => `- ${url}`),
-    '# Absolute Markdown mirror:',
-    ...markdownAbsoluteUrls.map((url) => `- ${url}`),
-    '# Relative HTML routes:',
-    ...htmlRelativeUrls.map((url) => `- ${url}`),
-    '# Relative Markdown mirror:',
-    ...markdownRelativeUrls.map((url) => `- ${url}`),
+    '',
+    '> Documentation for using Semgrep AppSec Platform, Semgrep Code, Semgrep Supply Chain, Semgrep Secrets, CI, rule writing, and related references.',
+    '',
+    `Base URL: ${baseUrl}`,
+    `Markdown mirror pages: ${docIds.length}`,
+    '',
+    'Use the Markdown mirror links below when possible. They are generated from the docs source and avoid the navigation, script, and layout noise in rendered HTML pages.',
+    '',
+    '## Start Here',
+    ...renderFeaturedDocs({docIds, siteUrl, basePath}),
+    '',
+    '## All Markdown Docs',
+    ...renderAllDocs({docIds, siteUrl, basePath}),
     '',
   ].join('\n');
 }
@@ -93,29 +156,16 @@ module.exports = function llmsTxtPlugin(context, options) {
     name: 'llms-txt',
     async postBuild({outDir}) {
       const docsDir = path.resolve(context.siteDir, 'docs');
-      const markdownFiles = walk(docsDir);
       const basePath = normalizeBasePath(context.siteConfig.baseUrl);
-      const docIds = markdownFiles
-        .map((file) => getDocId(path.relative(docsDir, file)))
-        .filter(Boolean)
-        .sort();
+      const siteUrl = context.siteConfig.url;
+      const docIds = getDocIds(docsDir);
 
-      const htmlRelativeUrls = docIds.map((docId) =>
-        docId === 'index' ? basePath : `${basePath}${docId}`,
+      fs.mkdirSync(outDir, {recursive: true});
+      fs.writeFileSync(
+        path.join(outDir, 'llms.txt'),
+        buildLlmsTxt({siteUrl, basePath, docIds}),
+        'utf-8',
       );
-      const markdownRelativeUrls = docIds.map(
-        (docId) => `${basePath}markdown/${docId}.md`,
-      );
-
-      const llmsTxt = buildLlmsTxt({
-        siteUrl: context.siteConfig.url,
-        basePath,
-        htmlRelativeUrls,
-        markdownRelativeUrls,
-      });
-      const outputDir = getOutputDir(outDir);
-      fs.mkdirSync(outputDir, {recursive: true});
-      fs.writeFileSync(path.join(outputDir, 'llms.txt'), llmsTxt, 'utf-8');
     },
   };
 };

--- a/scripts/verify-llms-txt.js
+++ b/scripts/verify-llms-txt.js
@@ -1,0 +1,135 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const siteDir = path.resolve(__dirname, '..');
+const docsDir = path.join(siteDir, 'docs');
+const buildDir = path.join(siteDir, 'build');
+const llmsPath = path.join(buildDir, 'llms.txt');
+const netlifyPath = path.join(siteDir, 'netlify.toml');
+
+function walk(dir, extFilter = ['.md', '.mdx']) {
+  const results = [];
+
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...walk(fullPath, extFilter));
+    } else if (
+      !entry.name.startsWith('_') &&
+      extFilter.includes(path.extname(entry.name))
+    ) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+function getDocId(relPath) {
+  let docId = relPath.replace(/\.(md|mdx)$/, '');
+
+  if (path.basename(docId) === 'index') {
+    docId = path.dirname(docId);
+    if (docId === '.' || docId === '') {
+      docId = 'index';
+    }
+  }
+
+  return docId.replace(/\\/g, '/');
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function read(filePath) {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function main() {
+  assert(fs.existsSync(llmsPath), 'build/llms.txt was not generated');
+
+  const llmsTxt = read(llmsPath);
+  const netlifyToml = read(netlifyPath);
+  const sourceDocIds = walk(docsDir)
+    .map((file) => getDocId(path.relative(docsDir, file)))
+    .sort();
+
+  const markdownUrlRegex =
+    /https:\/\/semgrep\.dev\/docs\/markdown\/([A-Za-z0-9./_-]+\.md)/g;
+  const markdownPaths = new Set();
+  let match;
+
+  while ((match = markdownUrlRegex.exec(llmsTxt)) !== null) {
+    markdownPaths.add(match[1]);
+  }
+
+  assert(
+    llmsTxt.startsWith('# Semgrep Docs\n'),
+    'llms.txt must start with the Semgrep Docs H1',
+  );
+  assert(
+    (llmsTxt.match(/^# /gm) || []).length === 1,
+    'llms.txt should contain one top-level H1',
+  );
+  assert(
+    llmsTxt.includes('> Documentation for using Semgrep AppSec Platform'),
+    'llms.txt is missing the summary blockquote',
+  );
+  assert(
+    llmsTxt.includes('## Start Here'),
+    'llms.txt is missing the curated Start Here section',
+  );
+  assert(
+    llmsTxt.includes('## All Markdown Docs'),
+    'llms.txt is missing the all-docs section',
+  );
+  assert(
+    llmsTxt.includes(`Markdown mirror pages: ${sourceDocIds.length}`),
+    'llms.txt markdown mirror count does not match docs source count',
+  );
+  assert(
+    !llmsTxt.includes('# Absolute HTML routes:'),
+    'llms.txt still contains the old raw HTML route list',
+  );
+  assert(
+    !netlifyToml.includes('from = "/docs/llms.txt"'),
+    'netlify.toml still redirects /docs/llms.txt away from the generated file',
+  );
+
+  for (const docId of sourceDocIds) {
+    const markdownPath = `${docId}.md`;
+    assert(
+      markdownPaths.has(markdownPath),
+      `llms.txt is missing https://semgrep.dev/docs/markdown/${markdownPath}`,
+    );
+    assert(
+      fs.existsSync(path.join(buildDir, 'markdown', markdownPath)),
+      `build/markdown/${markdownPath} was not generated`,
+    );
+  }
+
+  const expectedExamples = [
+    'index.md',
+    'getting-started/introduction.md',
+    'getting-started/quickstart.md',
+    'semgrep-supply-chain/feature-support.md',
+    'writing-rules/rule-syntax.md',
+  ];
+
+  for (const markdownPath of expectedExamples) {
+    assert(
+      markdownPaths.has(markdownPath),
+      `representative Markdown URL missing from llms.txt: ${markdownPath}`,
+    );
+  }
+
+  console.log(
+    `Verified ${sourceDocIds.length} docs Markdown mirror entries in build/llms.txt`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

This fixes docs-specific LLM discovery for `https://semgrep.dev/docs/`.

Today, `https://semgrep.dev/docs/llms.txt` is redirected to the root `https://semgrep.dev/llms.txt`. The root file is useful as a company-level pointer, but it is very small and does not expose the existing docs Markdown mirror under `https://semgrep.dev/docs/markdown/...`.

This PR makes `/docs/llms.txt` serve a docs-specific index that points LLMs and coding agents directly at the Markdown mirror pages.

## What changed

- Generate `llms.txt` into the Docusaurus build output so it is served at `/docs/llms.txt`.
- Remove the Netlify redirect that sent `/docs/llms.txt` to `/llms.txt`.
- Keep the generated file intentionally simple:
  - one `# Semgrep Docs` heading
  - a short summary
  - a small hand-curated `Start Here` section
  - a flat inventory of every generated `/docs/markdown/*.md` mirror page
- Add `yarn verify:llms` to check that the source docs, generated Markdown mirrors, and generated `llms.txt` links stay in sync.

## Why this approach

The docs site already publishes Markdown mirrors, for example:

- `https://semgrep.dev/docs/markdown/index.md`
- `https://semgrep.dev/docs/markdown/getting-started/quickstart.md`
- `https://semgrep.dev/docs/markdown/writing-rules/rule-syntax.md`

The missing piece was discovery. LLMs could use those Markdown pages if they knew the URL pattern, but `/docs/llms.txt` did not advertise them because it was redirected to the root `llms.txt`.

This keeps the implementation reviewable and avoids adding frontmatter parsing, category inference, or heavy formatting logic in this PR.

## What this does not change

- It does not rewrite or clean the Markdown mirror contents.
- It does not expand imported MDX components or tabs.
- It does not add API-doc-specific `llms.txt` support.
- It does not include release notes in the Markdown mirror inventory, because the current mirror generator only covers `docs/`.

Those could be follow-up improvements if we want richer LLM ingestion later.

## Commit structure

1. `Generate docs llms markdown index`
   - Updates the generator to write a docs-specific Markdown mirror index.
   - Removes the `/docs/llms.txt` redirect.
2. `Add llms index verification`
   - Adds the verification script and `yarn verify:llms` entrypoint.

## Verification

- `yarn build`
  - Passes and copies 331 Markdown mirror files to `build/markdown`.
  - Existing unrelated warnings remain for deprecated Docusaurus config, one untruncated release note, duplicate routes for `/docs/metrics` and `/docs/semgrep-appsec-platform/dashboard`, and pre-existing broken anchors.
- `yarn verify:llms`
  - Verifies 331 docs Markdown mirror entries in `build/llms.txt`.
- Local serve check with `yarn serve --host 127.0.0.1 --port 3303`
  - `GET /docs/llms.txt` returned 200.
  - `GET /docs/markdown/index.md` returned 200.
  - `GET /docs/markdown/getting-started/quickstart.md` returned 200.

## Linear

GROW-1037
