### PR TITLE
Redirects to fix diff in number of pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1173,6 +1173,7 @@
       "source": "/rule-updates/",
       "destination": "/release-notes/rule-updates"
     },
+
     {
       "source": "/experiments/overview/",
       "destination": "/writing-rules/experiments/introduction"
@@ -1552,6 +1553,10 @@
     {
       "source": "/semgrep-appsec-platform/dashboard-beta/",
       "destination": "/semgrep-appsec-platform/dashboard"
+    },
+    {
+      "source": "/semgrep-appsec-platform/details-page",
+      "destination": "/semgrep-appsec-platform/findings-details"
     },
     {
       "source": "/deployment/managed-scanning",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1173,7 +1173,6 @@
       "source": "/rule-updates/",
       "destination": "/release-notes/rule-updates"
     },
-
     {
       "source": "/experiments/overview/",
       "destination": "/writing-rules/experiments/introduction"


### PR DESCRIPTION
### Thanks for improving Semgrep Docs

Please ensure:

- [ ] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
