### PR TITLE
docs: rebrand Guardian Windsurf instructions to Devin

### DIFF
--- a/docs/extensions/pre-commit.mdx
+++ b/docs/extensions/pre-commit.mdx
@@ -18,7 +18,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.166.0'
+  rev: 'v1.168.0'
   hooks:
     - id: semgrep
       entry: semgrep
@@ -51,7 +51,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.166.0'
+  rev: 'v1.168.0'
   hooks:
     - id: semgrep-ci
 ```

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -13,7 +13,7 @@ The plugin uses each IDE's native hook or MCP system:
 * **GitHub Copilot** (Visual Studio, JetBrains, Xcode, Eclipse): [MCP](https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp-in-your-ide/extend-copilot-chat-with-mcp)
 * **Kiro**: [MCP](https://kiro.dev/docs/mcp/)
 * **VS Code**: [MCP](https://code.visualstudio.com/docs/copilot/customization/mcp-servers)
-* **Windsurf**: [Cascade hooks](https://docs.windsurf.com/windsurf/cascade/hooks)
+* **Devin** (Windsurf): [Cascade hooks](https://docs.windsurf.com/windsurf/cascade/hooks)
 
 This guide covers setup for each of the preceding products listed, but the plugin works with any MCP client.
 
@@ -196,7 +196,7 @@ This guide covers setup for each of the preceding products listed, but the plugi
     VS Code does not expose a post-write hook today, so Semgrep tools are invoked when the agent calls them through MCP. Learn more about [adding and managing MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
   </Tab>
 
-  <Tab title="Windsurf">
+  <Tab title="Devin (Windsurf)">
     <Steps>
       <Step>
         [Install the Semgrep CLI](#install-the-semgrep-cli).


### PR DESCRIPTION
## Summary

Windsurf recently rebranded to **Devin**. This updates the Guardian docs so the IDE setup instructions reflect the new name while keeping the former name in parentheses so existing users can still find it.

Changes to `docs/guardian.mdx`:
- Support list entry: `**Windsurf**` → `**Devin** (Windsurf)`
- IDE setup tab title: `Windsurf` → `Devin (Windsurf)`

The configuration details (`~/.codeium/windsurf/hooks.json`, the `windsurf` `-a` flag, Cascade hooks) are unchanged since the underlying paths and product mechanics are the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)