### PR TITLE
Update missed references to "scan without lockfiles"

### DIFF
--- a/docs/extensions/pre-commit.mdx
+++ b/docs/extensions/pre-commit.mdx
@@ -18,7 +18,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.166.0'
+  rev: 'v1.168.0'
   hooks:
     - id: semgrep
       entry: semgrep
@@ -51,7 +51,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.166.0'
+  rev: 'v1.168.0'
   hooks:
     - id: semgrep-ci
 ```

--- a/docs/semgrep-supply-chain/requirements-and-feature-support.mdx
+++ b/docs/semgrep-supply-chain/requirements-and-feature-support.mdx
@@ -160,7 +160,7 @@ The following table lists all Supply Chain features for each language. Languages
 <tr>
 <th>Language</th>
 <th align="center">Reachability<br />(see <a href="#cve-coverage">CVE coverage</a>)</th>
-<th><a href="/docs/semgrep-supply-chain/set-up-and-configure##dynamic-dependency-resolution-beta">Dynamic dependency resolution (beta)</a></th>
+<th><a href="/docs/semgrep-supply-chain/set-up-and-configure#dynamic-dependency-resolution-beta">Dynamic dependency resolution (beta)</a></th>
 <th>License detection</th>
 <th>Malicious dependency<br />detection</th>
 </tr>

--- a/docs/semgrep-supply-chain/requirements-and-feature-support.mdx
+++ b/docs/semgrep-supply-chain/requirements-and-feature-support.mdx
@@ -38,13 +38,13 @@ The following table lists all Semgrep-supported package managers for each langua
    <td>Gradle</td>
    <td><code>gradle.lockfile</code> <b>or</b> <br /><code>build.gradle</code> or
    <code>build.gradle.kts</code> through <a
-   href="/docs/semgrep-supply-chain/set-up-and-configure#scan-a-project-without-lockfiles-beta">Dynamic
+   href="/docs/semgrep-supply-chain/set-up-and-configure#dynamic-dependency-resolution-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>
   <tr>
    <td>Maven</td>
    <td>Maven-generated dependency tree (see <a href="/docs/semgrep-supply-chain/setup-maven/">Setting up SSC scans for Apache Maven</a> for instructions) <b>or</b> <br /><code>pom.xml</code> through <a
-   href="/docs/semgrep-supply-chain/set-up-and-configure#scan-a-project-without-lockfiles-beta">Dynamic
+   href="/docs/semgrep-supply-chain/set-up-and-configure#dynamic-dependency-resolution-beta">Dynamic
    Dependency Resolution</a>.</td>
   </tr>
   <tr>
@@ -73,7 +73,7 @@ The following table lists all Semgrep-supported package managers for each langua
    <td rowspan="5">Python</td>
    <td>pip</td>
    <td rowspan="2"><ul><li>A `*requirement*.txt`, `*requirement*.pip`, `**/requirements/*.txt`, or `**/requirements/*.pip` with dependencies pinned†</li><li>`setup.py` with <a
-   href="/docs/semgrep-supply-chain/set-up-and-configure#scan-a-project-without-lockfiles-beta">Dynamic
+   href="/docs/semgrep-supply-chain/set-up-and-configure#dynamic-dependency-resolution-beta">Dynamic
    Dependency Resolution.</a></li></ul></td>
   </tr>
   <tr>
@@ -130,7 +130,7 @@ The following table lists all Semgrep-supported package managers for each langua
 </table>
 </div>
 
-_<strong>†</strong>Supply Chain can treat `requirements.txt` as a lockfile with Pip-compiled output and fully pinned dependencies or as a manifest file with more flexible specifiers. If your `requirements.txt` file doesn't use pinned dependencies exclusively, use the [`--allow-local-builds` flag](/semgrep-supply-chain/set-up-and-configure#scan-a-project-without-lockfiles-beta) when invoking your scan. This ensures that the dependencies using non-exact version specifiers, such as `>=`, `>`, `~=`, are included in the dependency graph. Otherwise, Semgrep ingests only pinned (`==`) dependencies._<br /><br />
+_<strong>†</strong>Supply Chain can treat `requirements.txt` as a lockfile with Pip-compiled output and fully pinned dependencies or as a manifest file with more flexible specifiers. If your `requirements.txt` file doesn't use pinned dependencies exclusively, use the [`--allow-local-builds` flag](/semgrep-supply-chain/set-up-and-configure#dynamic-dependency-resolution-beta) when invoking your scan. This ensures that the dependencies using non-exact version specifiers, such as `>=`, `>`, `~=`, are included in the dependency graph. Otherwise, Semgrep ingests only pinned (`==`) dependencies._<br /><br />
 _<strong>‡</strong>Supply Chain does not analyze the transitivity of packages for these language and manifest file or lockfile combinations. All dependencies are listed as **No <Tooltip tip="Whether a vulnerable code pattern from a dependency is used in the codebase that imports it. Semgrep Supply Chain requires both a vulnerable version and a matching pattern for reachability." cta="See full definition." href="/semgrep-supply-chain/glossary#reachability">reachability</Tooltip> Analysis.**_<br />
 
 ## Feature availability
@@ -160,7 +160,7 @@ The following table lists all Supply Chain features for each language. Languages
 <tr>
 <th>Language</th>
 <th align="center">Reachability<br />(see <a href="#cve-coverage">CVE coverage</a>)</th>
-<th><a href="/docs/semgrep-supply-chain/set-up-and-configure#scan-a-project-without-lockfiles-beta">Scan without lockfiles (beta)</a></th>
+<th><a href="/docs/semgrep-supply-chain/set-up-and-configure##dynamic-dependency-resolution-beta">Dynamic dependency resolution (beta)</a></th>
 <th>License detection</th>
 <th>Malicious dependency<br />detection</th>
 </tr>


### PR DESCRIPTION
We missed some of the "scan without lockfiles" terminology and links in this doc. This PR updates them to the current term "Dynamic dependency resolution".

I updated the anchor links & the related text. I don't know if that's something that ought to have been in docs.json; the target section had been updated and the anchor links weren't already working so I just went with updating them.

Please ensure:

- [ ] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
