### PR TITLE
Remove outdated references to the project details icon

### DIFF
--- a/docs/deployment/manage-projects.mdx
+++ b/docs/deployment/manage-projects.mdx
@@ -134,7 +134,7 @@ Select the checkbox to **Show archived** projects.
 Search for the archived repository's name.
 </Step>
 <Step>
-Click the project name of interest for **Project details**.
+Click the project name or **Project details**.
 </Step>
 <Step>
 Click the dropdown at the header and click **Delete project**.

--- a/docs/deployment/manage-projects.mdx
+++ b/docs/deployment/manage-projects.mdx
@@ -79,11 +79,12 @@ You can link to a specific scan's details to share with collaborators or for tro
 
 ## Project details page
 
-Each project listed on the **Projects** page has its own **Project detail** page, which you can access by clicking the **<Icon icon="window-restore" iconType="regular"/> window icon** under the **Details** column. The **Project detail** page is where you can filter scans, configure settings, and view detailed logs for each scan that has been run. Use the **Project detail** page to:
+Each project listed on the **Projects** page has its own **Project detail** page, which you can access by clicking the project's name. The **Project detail** page is where you can filter scans, configure settings, and view detailed logs for each scan that has been run. Use the **Project detail** page to:
 
 - View trends over time, such as longer or shorter scan durations.
 - Share information when troubleshooting scans through the **Scans** tab.
 - Update a project's tags, primary branch, and path ignores through the **Settings** tab.
+- Rename or delete the project.
 
 Additionally, the Semgrep API allows you to filter tags for use in additional workflows and integrations within your own systems. Create tags based on engineering or department teams, external-facing or internal codebases, and so on. See [Tags](/semgrep-appsec-platform/tags) for more information.
 
@@ -110,7 +111,7 @@ In Semgrep AppSec Platform, click <Icon icon="folder-open" iconType="solid"/> **
 Search for your repository's name.
 </Step>
 <Step>
-Click the <Icon icon="window-restore"/> **windows icon** to access the settings page for that project.
+Click the project name for **Project details**.
 </Step>
 <Step>
 Click the **three-dot (...) button** at the header and click **Delete project**.
@@ -133,7 +134,7 @@ Select the checkbox to **Show archived** projects.
 Search for the archived repository's name.
 </Step>
 <Step>
-Click the <Icon icon="window-restore"/> **window icon** under **Details** to access the settings page for that repository.
+Click the project name of interest for **Project details**.
 </Step>
 <Step>
 Click the dropdown at the header and click **Delete project**.

--- a/docs/deployment/manage-projects.mdx
+++ b/docs/deployment/manage-projects.mdx
@@ -108,7 +108,7 @@ Deleting a project removes all of its findings, metadata, and other records from
 In Semgrep AppSec Platform, click <Icon icon="folder-open" iconType="solid"/> **Projects**.
 </Step>
 <Step>
-Search for your repository's name.
+Search for your project's name.
 </Step>
 <Step>
 Click the project name for **Project details**.
@@ -131,7 +131,7 @@ Switch to the **Not Scanning** tab of the **Projects** page.
 Select the checkbox to **Show archived** projects.
 </Step>
 <Step>
-Search for the archived repository's name.
+Search for the archived project's name.
 </Step>
 <Step>
 Click the project name or **Project details**.

--- a/docs/extensions/pre-commit.mdx
+++ b/docs/extensions/pre-commit.mdx
@@ -18,7 +18,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.166.0'
+  rev: 'v1.168.0'
   hooks:
     - id: semgrep
       entry: semgrep
@@ -51,7 +51,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.166.0'
+  rev: 'v1.168.0'
   hooks:
     - id: semgrep-ci
 ```


### PR DESCRIPTION
Link is just on the project name now.

When talking about deleting, I think we should also use "project" rather than "repository". It's a tiny bit weird now for archived items, but even if it's the repo that's archived for now, it's the project name that you search for.

Please ensure:

- [ ] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
