### PR TITLE
docs: add enterprise deployment guidance to Guardian docs

### DIFF
--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -292,6 +292,25 @@ semgrep login && semgrep install-semgrep-pro
 </Step>
 </Steps>
 
+## Enterprise deployment guide
+
+To roll Semgrep Guardian out across an organization, standardize the install so every developer's agent picks up the plugin automatically instead of relying on each person to install it by hand.
+
+### Use your agent's built-in enterprise controls
+
+Most coding agents let you pin an approved marketplace or plugin for your whole team. This is the simplest way to make Guardian available (or required) everywhere:
+
+* **Claude Code**: [Require marketplaces for your team](https://code.claude.com/docs/en/plugin-marketplaces#require-marketplaces-for-your-team)
+* **Cursor**: [Team marketplaces](https://cursor.com/docs/plugins#team-marketplaces)
+
+### Deploy through an MDM for more granularity
+
+For tighter control—enforcing settings developers cannot override, scoping rollout by device group, or combining Guardian with other managed configuration—deploy through your mobile device management (MDM) platform. Anthropic maintains a set of [MDM deployment examples and best practices](https://github.com/anthropics/claude-code/tree/main/examples/mdm) that cover managed settings for macOS (`.plist` and `.mobileconfig` profiles via Jamf, Kandji, and similar) and Windows (PowerShell file deployment or ADMX/registry policy via Intune and Group Policy), along with how to verify that managed settings are applied.
+
+### Get help with a custom rollout
+
+Reach out if you want help building something custom for your MDM or agent fleet. You can find us in Semgrep's `#mcp` [Slack community](https://go.semgrep.dev/slack).
+
 ## Additional resources
 
 * Semgrep's `#mcp` [Slack community](https://go.semgrep.dev/slack)

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -294,7 +294,7 @@ semgrep login && semgrep install-semgrep-pro
 
 ## Enterprise deployment guide
 
-To roll Semgrep Guardian out across an organization, standardize the install so every developer's agent picks up the plugin automatically instead of relying on each person to install it by hand.
+To roll out Semgrep Guardian across an organization, standardize the install so every developer's agent picks up the plugin automatically instead of relying on each developer to install it by hand.
 
 ### Use your agent's built-in enterprise controls
 

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -303,9 +303,9 @@ Most coding agents let you pin an approved marketplace or plugin for your whole 
 * **Claude Code**: [Require marketplaces for your team](https://code.claude.com/docs/en/plugin-marketplaces#require-marketplaces-for-your-team)
 * **Cursor**: [Team marketplaces](https://cursor.com/docs/plugins#team-marketplaces)
 
-### Deploy through an MDM for more granularity
+### Deploy through a mobile device management (MDM) platform for more granularity
 
-For tighter control—enforcing settings developers cannot override, scoping rollout by device group, or combining Guardian with other managed configuration—deploy through your mobile device management (MDM) platform. Anthropic maintains a set of [MDM deployment examples and best practices](https://github.com/anthropics/claude-code/tree/main/examples/mdm) that cover managed settings for macOS (`.plist` and `.mobileconfig` profiles via Jamf, Kandji, and similar) and Windows (PowerShell file deployment or ADMX/registry policy via Intune and Group Policy), along with how to verify that managed settings are applied.
+Deploy through your MDM platform to scope rollout by device group, or to combine Guardian with other managed configuration deployed via your MDM. Anthropic maintains a set of [MDM deployment examples and best practices](https://github.com/anthropics/claude-code/tree/main/examples/mdm) that cover managed settings for macOS (`.plist` and `.mobileconfig` profiles via Jamf, Kandji, and similar) and Windows (PowerShell file deployment or ADMX/registry policy via Intune and Group Policy), along with how to verify that managed settings are applied.
 
 ### Get help with a custom rollout
 

--- a/docs/guardian.mdx
+++ b/docs/guardian.mdx
@@ -309,7 +309,7 @@ Deploy through your MDM platform to scope rollout by device group, or to combine
 
 ### Get help with a custom rollout
 
-Reach out if you want help building something custom for your MDM or agent fleet. You can find us in Semgrep's `#mcp` [Slack community](https://go.semgrep.dev/slack).
+Reach out if you want help building something custom for your MDM or agent fleet. You can find us in Semgrep's `#mcp` [Slack community](https://go.semgrep.dev/slack) or check out our [support options](/support).
 
 ## Additional resources
 


### PR DESCRIPTION
## What

Adds an **Enterprise deployment guide** section to the Guardian docs (`docs/guardian.mdx`) covering how to roll Semgrep Guardian out across an organization.

The new section covers:

- **Agent-native enterprise controls** — pinning an approved marketplace/plugin for the whole team via [Claude Code required marketplaces](https://code.claude.com/docs/en/plugin-marketplaces#require-marketplaces-for-your-team) and [Cursor team marketplaces](https://cursor.com/docs/plugins#team-marketplaces).
- **MDM deployment** — for tighter control, deploying through an MDM, referencing [Anthropic's MDM deployment examples](https://github.com/anthropics/claude-code/tree/main/examples/mdm) for macOS and Windows managed settings.
- **Custom rollout help** — pointer to Semgrep's `#mcp` Slack community.

## Why

Enterprises rolling out Guardian need guidance on standardizing the install so every developer's agent picks up the plugin automatically instead of relying on manual per-person installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)