### PR TITLE
docs: mark Homebrew as best-effort in IntelliJ extension prerequisites

### DIFF
--- a/docs/extensions/pre-commit.mdx
+++ b/docs/extensions/pre-commit.mdx
@@ -18,7 +18,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.168.0'
+  rev: 'v1.169.0'
   hooks:
     - id: semgrep
       entry: semgrep
@@ -51,7 +51,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.168.0'
+  rev: 'v1.169.0'
   hooks:
     - id: semgrep-ci
 ```

--- a/docs/extensions/semgrep-intellij.mdx
+++ b/docs/extensions/semgrep-intellij.mdx
@@ -19,7 +19,7 @@ The Semgrep IntelliJ extension communicates with Semgrep command-line interface 
 # preferred: install through pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
 $ pipx install semgrep
 
-# preferred: install through uv (https://docs.astral.sh/uv/)
+# recommended for users already using uv (https://docs.astral.sh/uv/)
 $ uv tool install semgrep
 
 # best-effort: install through homebrew (maintained on a best-effort basis and can lag behind the latest release)

--- a/docs/extensions/semgrep-intellij.mdx
+++ b/docs/extensions/semgrep-intellij.mdx
@@ -22,7 +22,7 @@ $ pipx install semgrep
 # preferred: install through uv (https://docs.astral.sh/uv/)
 $ uv tool install semgrep
 
-# best-effort: install through homebrew (maintained on a best-effort basis; often lags behind the latest release)
+# best-effort: install through homebrew (maintained on a best-effort basis and can lag behind the latest release)
 $ brew install semgrep
 ```
 

--- a/docs/extensions/semgrep-intellij.mdx
+++ b/docs/extensions/semgrep-intellij.mdx
@@ -16,15 +16,23 @@ Semgrep's IntelliJ extension for Windows users is currently in beta.
 The Semgrep IntelliJ extension communicates with Semgrep command-line interface (CLI) to run scans. Install Semgrep CLI before you can use the extension. To install Semgrep CLI:
 
 ```bash
-# For macOS
-$ brew install semgrep
-
-# For Ubuntu/Windows/Linux/macOS, using pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
+# preferred: install through pipx (https://pipx.pypa.io/stable/how-to/install-pipx/)
 $ pipx install semgrep
 
-# Or, using uv (https://docs.astral.sh/uv/)
+# preferred: install through uv (https://docs.astral.sh/uv/)
 $ uv tool install semgrep
+
+# best-effort: install through homebrew (maintained on a best-effort basis; often lags behind the latest release)
+$ brew install semgrep
 ```
+
+<Info>
+**NOTE**
+
+`pipx` and `uv` are the preferred installation methods. The Homebrew formula is maintained on a best-effort basis and often lags behind the latest release.
+
+**Homebrew users:** ensure that you've [added Homebrew to your PATH](https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities).
+</Info>
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

Aligns the Semgrep IntelliJ extension's **Prerequisites** section with the quickstart guide's macOS install block:

- Reorders CLI install methods so `pipx` and `uv` are listed first (preferred), with `brew` last (best-effort).
- Adds the same `<Info>` note used in the quickstart, explaining the Homebrew formula is maintained on a best-effort basis and often lags behind the latest release, plus the reminder for Homebrew users to add Homebrew to their PATH.

Dropped the old per-OS annotation on the pipx line ("Ubuntu/Windows/Linux/macOS") to stay consistent with the quickstart phrasing.

## Test plan

- [ ] Verify rendered docs preview shows the reordered install methods and the new note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)