### PR TITLE
automatically show all CLI commands

### DIFF
--- a/docs/snippets/cli-reference/help-ci.mdx
+++ b/docs/snippets/cli-reference/help-ci.mdx
@@ -1,4 +1,4 @@
-```bash expandable
+```bash
 NAME
        semgrep ci - the recommended way to run semgrep in CI
 

--- a/docs/snippets/cli-reference/help-main.mdx
+++ b/docs/snippets/cli-reference/help-main.mdx
@@ -1,4 +1,4 @@
-```bash expandable
+```bash
 Usage: semgrep [OPTIONS] COMMAND [ARGS]...
 
   To get started quickly, run `semgrep scan --config auto`

--- a/docs/snippets/cli-reference/help-scan.mdx
+++ b/docs/snippets/cli-reference/help-scan.mdx
@@ -1,4 +1,4 @@
-```bash expandable
+```bash
 NAME
        semgrep scan - run semgrep rules on files
 


### PR DESCRIPTION
Make CLI docs automatically display everything so it's less confusing when users search the page.

Please ensure:

- [ ] A technical writer reviews the PR
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
