### PR TITLE
Add note about SMS exit codes

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -89,6 +89,8 @@ Semgrep can finish with the following exit codes:
 - **13**: The API key is invalid.
 - **14**: [Deprecated] Semgrep scan failed.
 
+When Semgrep is running in Managed Scans, you may also see other exit code values, which originate from the system that runs the scan. Please feel free to reach out to [Support](/support) for help if you see an unexpected exit code.
+
 <Tip>
 **TIP**
 

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -89,7 +89,7 @@ Semgrep can finish with the following exit codes:
 - **13**: The API key is invalid.
 - **14**: [Deprecated] Semgrep scan failed.
 
-When Semgrep is running in Managed Scans, you may also see other exit code values that originate from the system running the scan. Please reach out to [Support](/support) for help with an unexpected exit code.
+When using Semgrep Managed Scans, you may also see other exit code values that originate from the system running the scan. Please reach out to [Support](/support) for help with an unexpected exit code.
 
 <Tip>
 **TIP**

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -89,7 +89,7 @@ Semgrep can finish with the following exit codes:
 - **13**: The API key is invalid.
 - **14**: [Deprecated] Semgrep scan failed.
 
-When Semgrep is running in Managed Scans, you may also see other exit code values, which originate from the system that runs the scan. Please feel free to reach out to [Support](/support) for help if you see an unexpected exit code.
+When Semgrep is running in Managed Scans, you may also see other exit code values that originate from the system running the scan. Please reach out to [Support](/support) for help with an unexpected exit code.
 
 <Tip>
 **TIP**


### PR DESCRIPTION
Now that Managed Scan exit codes surface in scan results, we need to at least mention those are a bit different.

Please ensure:

- [x] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)

<img width="1576" height="664" alt="CleanShot 2026-07-14 at 15 15 39@2x" src="https://github.com/user-attachments/assets/993b3f9c-419c-40ee-9fb0-ec908d624fea" />

