### PR TITLE
chore(policies): Remove beta label from unified policies

### DIFF
--- a/docs/extensions/pre-commit.mdx
+++ b/docs/extensions/pre-commit.mdx
@@ -18,7 +18,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.169.0'
+  rev: 'v1.170.0'
   hooks:
     - id: semgrep
       entry: semgrep
@@ -51,7 +51,7 @@ Add the following to your `.pre-commit-config.yaml` file:
 ```yaml
 repos:
 - repo: https://github.com/semgrep/pre-commit
-  rev: 'v1.169.0'
+  rev: 'v1.170.0'
   hooks:
     - id: semgrep-ci
 ```

--- a/docs/semgrep-appsec-platform/unified-policies/overview.mdx
+++ b/docs/semgrep-appsec-platform/unified-policies/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Unified policies (beta)"
+title: "Unified policies"
 ---
 
 Unified policies allow you to choose the rules and rulesets used for Semgrep scans and define what happens to a finding after identification, such as whether a finding is monitored, generates a pull request (PR) or merge request (MR) comment, or blocks a PR or MR. With unified policies, there are two types of policy definitions available to you:


### PR DESCRIPTION
It's now GA!

### Thanks for improving Semgrep Docs

Please ensure:

- [x] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
