### PR TITLE
Remove brew as preferred local install method

### DIFF
--- a/docs/kb/semgrep-ci/ci-vs-cli.mdx
+++ b/docs/kb/semgrep-ci/ci-vs-cli.mdx
@@ -13,7 +13,7 @@ When comparing Semgrep scans in CI and CLI, ensure that you are running the same
 If you use Semgrep's Docker image in CI and are running the CLI scan locally, the best options are:
 
 - Use the Docker container locally.
-- Install Semgrep using `brew` (Mac only).
+- Install Semgrep using `pipx` or `uv`
 
 ## Branches and diff-aware scans
 

--- a/docs/kb/semgrep-ci/ci-vs-cli.mdx
+++ b/docs/kb/semgrep-ci/ci-vs-cli.mdx
@@ -13,7 +13,7 @@ When comparing Semgrep scans in CI and CLI, ensure that you are running the same
 If you use Semgrep's Docker image in CI and are running the CLI scan locally, the best options are:
 
 - Use the Docker container locally.
-- Install Semgrep using `pipx` or `uv`
+- Install Semgrep using `pipx` or `uv`.
 
 ## Branches and diff-aware scans
 


### PR DESCRIPTION
We are moving away from brew as a preferred option, so this KB should recommend the preferred local installs.

Please ensure:

~- [ ] A subject matter expert reviews the content~ XS PR, in line with other doc changes
- [ ] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)

