### PR TITLE
fix(ci): Pin mintlify broken-links checker to 4.2.696

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -80,4 +80,8 @@ jobs:
 
       - name: Check links and redirects
         working-directory: docs
-        run: npx --yes mintlify@latest broken-links --check-redirects
+        # Pinned: mintlify@latest 4.2.697+ regressed and fails to parse
+        # cheat-sheets/django-xss.mdx ("URIError: URI malformed" on the Django
+        # {% %} template syntax), breaking this check on every PR. 4.2.696 is
+        # the last version that parses it. Re-evaluate/bump when upstream fixes it.
+        run: npx --yes mintlify@4.2.696 broken-links --check-redirects


### PR DESCRIPTION
### Summary

The **Docs CI → Validate docs** job runs `npx --yes mintlify@latest broken-links`. Mintlify releases **after 4.2.696** regressed and fail to parse `docs/cheat-sheets/django-xss.mdx` with:

```
erro Syntax error - Unable to parse cheat-sheets/django-xss.mdx - URIError: URI malformed
```

The parser chokes on the bare `%` in the Django `{% autoescape off %}` template syntax. Because `broken-links` scans the whole docs set, this breaks the check on **every PR**, even ones that don't touch that file.

**Fix:** pin the checker to `mintlify@4.2.696` — the last version that parses the file cleanly, and the version used by the last passing `Validate docs` run (2026-07-14). Verified locally that 4.2.696 does not throw the `URIError` on `django-xss.mdx`.

This also removes the unpinned `@latest` (which is what let an upstream regression break CI), in line with our version-pinning guidance. A follow-up can bump the pin once Mintlify fixes the regression upstream.

### Thanks for improving Semgrep Docs

Please ensure:

- [ ] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
