### PR TITLE
docs(sca): Point firewall support to Community Slack

### DIFF
--- a/docs/semgrep-supply-chain/malware-firewall.mdx
+++ b/docs/semgrep-supply-chain/malware-firewall.mdx
@@ -166,7 +166,7 @@ It should no longer report `Semgrep mfw is protecting this machine ✅`.
 | `mfw doctor` reports that the firewall isn't protecting the machine right after install | The shell wasn't restarted, so `HTTP_PROXY` and `HTTPS_PROXY` aren't set in the current session | Restart your terminal or shell, then re-run `mfw doctor` |
 | `mfw doctor` reports an authentication error | You haven't run `mfw login`, or the short-lived bearer token has expired | Run `mfw login` again |
 | Package installs are slow or time out | The local proxy can't reach the Semgrep verdict backend because of network or firewall rules that block egress | Confirm that outbound access to Semgrep's backend is allowed; review corporate proxy or VPN settings |
-| A known-safe package is unexpectedly blocked | The backend returned a stale or incorrect verdict, or a false-positive match in the malware database | Notify us in the [Semgrep Community Slack](https://go.semgrep.dev/slack) |
+| A known-safe package is unexpectedly blocked | The backend returned a stale or incorrect verdict, or a false-positive match in the malware database | Notify us in the [Semgrep Community Slack](https://go.semgrep.dev/slack) channel |
 | `mfw doctor` isn't found, or the command isn't recognized | The install script didn't complete, or the shell `PATH` wasn't updated | Re-run the install command from [Install and verify](#install-and-verify), then restart your shell |
 
 ## Related products

--- a/docs/semgrep-supply-chain/malware-firewall.mdx
+++ b/docs/semgrep-supply-chain/malware-firewall.mdx
@@ -166,10 +166,8 @@ It should no longer report `Semgrep mfw is protecting this machine ✅`.
 | `mfw doctor` reports that the firewall isn't protecting the machine right after install | The shell wasn't restarted, so `HTTP_PROXY` and `HTTPS_PROXY` aren't set in the current session | Restart your terminal or shell, then re-run `mfw doctor` |
 | `mfw doctor` reports an authentication error | You haven't run `mfw login`, or the short-lived bearer token has expired | Run `mfw login` again |
 | Package installs are slow or time out | The local proxy can't reach the Semgrep verdict backend because of network or firewall rules that block egress | Confirm that outbound access to Semgrep's backend is allowed; review corporate proxy or VPN settings |
-| A known-safe package is unexpectedly blocked | The backend returned a stale or incorrect verdict, or a false-positive match in the malware database | Contact [Semgrep support](/support) with the ecosystem, package name, and version so Security Research can review |
+| A known-safe package is unexpectedly blocked | The backend returned a stale or incorrect verdict, or a false-positive match in the malware database | Notify us in the [Semgrep Community Slack](https://go.semgrep.dev/slack) |
 | `mfw doctor` isn't found, or the command isn't recognized | The install script didn't complete, or the shell `PATH` wasn't updated | Re-run the install command from [Install and verify](#install-and-verify), then restart your shell |
-
-If you still have issues, contact [Semgrep support](/support) with the full `mfw doctor` output.
 
 ## Related products
 


### PR DESCRIPTION
### Summary

Semgrep support isn't handling the Malware Firewall yet while it's in private beta. This removes the "contact Semgrep support" verbiage and links and points users to the community Slack instead.

Changes to `docs/semgrep-supply-chain/malware-firewall.mdx`:

- **Troubleshooting table** (false-positive block row): "Contact [Semgrep support](/support) with the ecosystem, package name, and version so Security Research can review" → "Notify us in the [Semgrep Community Slack](https://go.semgrep.dev/slack)".
- **Removed** the trailing sentence: "If you still have issues, contact [Semgrep support](/support) with the full `mfw doctor` output."

No remaining `/support` references on the page.

### Thanks for improving Semgrep Docs

Please ensure:

- [x] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Any redirects are in `docs/docs.json` if URLs changed
- [NA] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [X] Check the **Mintlify** bot preview link on this PR (requires PR to `main`): https://semgrep-ee9d73d8-amanda-mfw-remove-support-verbiage.mintlify.site/semgrep-supply-chain/malware-firewall 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
