### PR TITLE
Changes in Atlassian service accounts

### DIFF
--- a/docs/semgrep-appsec-platform/jira.mdx
+++ b/docs/semgrep-appsec-platform/jira.mdx
@@ -8,7 +8,7 @@ description: "The Semgrep Jira integration allows you to create Jira tickets bas
 
 - You must have a **Jira Cloud** plan. Jira Data Center (self-managed or on-premise) is not supported.
 - You must have at least one Jira project to set as the default location where tickets will be created.
-- Optional, but recommended: A [service account](https://support.atlassian.com/user-management/understand-service-accounts/) to set up and configure the Jira integration.
+- Optional, but recommended: An Atlassian account that is not associated with a specific human user, to set up and configure the Jira integration.
 
 ## Features
 


### PR DESCRIPTION
I guess at the time this line was added, "service" accounts must have included interactive login. Now the thing that Atlassian calls "service accounts" does not allow interactive login, so they can't actually be used with our Jira integration at the moment; the best option is just an account that isn't associated with a specific person.

Please ensure:

- [x] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
