### PR TITLE
docs: clarify that WSL is required for the MCP server

### DIFF
--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -27,6 +27,10 @@ This guide covers setup for each of the preceding products listed, but the plugi
   <Tab title="Claude Code">
     Claude Code uses Semgrep's hosted remote server by default, so you do not need to install the Semgrep CLI locally.
 
+    <Info>
+      The MCP server bundled with this plugin works on all platforms. On Windows, however, it requires [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) for the MCP server to work out of the box.
+    </Info>
+
     <Steps>
       <Step>
         Start a Claude Code instance:


### PR DESCRIPTION
The MCP Server in Guardian only works on Windows with WSL, so this PR adds clarification on that!

### Screenshot of docs preview

![image.png](https://app.graphite.com/user-attachments/assets/17551ee0-b9e1-4033-bb95-aaced46314ba.png)



### Thanks for improving Semgrep Docs

Please ensure:

- [x] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)