### PR TITLE
ci: sign bot commits in OpenAPI spec sync workflow

### DIFF
--- a/.github/workflows/update-openapi-specs.yml
+++ b/.github/workflows/update-openapi-specs.yml
@@ -63,6 +63,9 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.DOCS_BOT_TOKEN || github.token }}
+          # Commit via the GitHub API so GitHub signs the commit — the repo's
+          # "Require Signed Commits" ruleset rejects unsigned CLI commits.
+          sign-commits: true
           add-paths: |
             docs/public_v1.openapi.yaml
             docs/public_v2.openapi.yaml


### PR DESCRIPTION
## Why

The scheduled OpenAPI spec refresh ([update-openapi-specs.yml](.github/workflows/update-openapi-specs.yml), added in #2706) failed on its first run ([29986258074](https://github.com/semgrep/semgrep-docs/actions/runs/29986258074)): it fetched the specs, passed `mintlify validate`, and committed the diff, but the push was rejected —

```
remote: error: GH013: Repository rule violations found for refs/heads/chore/update-openapi-specs.
remote: - Commits must have verified signatures.
```

The repo's **Require Signed Commits** ruleset (targets all branches, no bypass actors) rejects the commit `peter-evans/create-pull-request` makes via the git CLI, which is unsigned regardless of token. Until the sync can push, the checked-in specs drift from production — e.g. `includeFirstDetectedAt` on `ListIssuesRequest` is live at https://semgrep.dev/api/v2/openapi.yaml but missing from the rendered API reference.

## What

Add `sign-commits: true` to the `create-pull-request` step (supported at the pinned v8.1.1). The action then creates the commit through GitHub's GraphQL API, which GitHub auto-signs (verified as `github-actions[bot]`, or the bot identity if `DOCS_BOT_TOKEN` is set), satisfying the ruleset.

## Verification

- `actionlint` passes on the modified workflow.
- Config-only CI change — no tests apply.
- **Post-merge:** trigger the workflow via `workflow_dispatch`; it should open the `chore/update-openapi-specs` sync PR, whose diff should include `includeFirstDetectedAt`.

Fixes APPEX-1455