### PR TITLE
docs: drop Managed Scans prerequisite for AI-powered detection

### DIFF
--- a/docs/deployment/add-ai-to-scans.mdx
+++ b/docs/deployment/add-ai-to-scans.mdx
@@ -8,7 +8,7 @@ This page provides step-by-step instructions on enabling and running an AI-power
 
 ## Prerequisites
 
-To run Semgrep Code's [AI-powered detection](/semgrep-code/overview#ai-powered-detection-beta-feature), you must have enabled [Semgrep Multimodal](/semgrep-multimodal/getting-started#enable-multimodal) for your organization.
+To run Semgrep Code's [AI-powered detection](/semgrep-code/overview#ai-powered-detection-beta), you must have enabled [Semgrep Multimodal](/semgrep-multimodal/getting-started#enable-multimodal) for your organization.
 
 <Note>
 **INFO**

--- a/docs/deployment/add-ai-to-scans.mdx
+++ b/docs/deployment/add-ai-to-scans.mdx
@@ -8,10 +8,13 @@ This page provides step-by-step instructions on enabling and running an AI-power
 
 ## Prerequisites
 
-To run Semgrep Code's [AI-powered detection](/semgrep-code/overview#ai-powered-detection-beta-feature), ensure that you meet the following requirements:
+To run Semgrep Code's [AI-powered detection](/semgrep-code/overview#ai-powered-detection-beta-feature), you must have enabled [Semgrep Multimodal](/semgrep-multimodal/getting-started#enable-multimodal) for your organization.
 
-* You have added your projects to [Semgrep Managed Scans](/getting-started/quickstart-managed-scans#add-projects-to-semgrep-managed-scans). Look for the `managed-scan` tag in the [**Projects** section of the Semgrep AppSec Platform](https://semgrep.dev/orgs/-/projects/scanning). 
-* You have enabled [Semgrep Multimodal](/semgrep-multimodal/getting-started#enable-multimodal) for your organization.
+<Note>
+**INFO**
+
+AI-powered detection analyzes your code on Semgrep's managed scanning infrastructure. Semgrep clones your repository into that environment to run the scan, even if your other scans run in your own CI.
+</Note>
 
 ## Enable or disable AI-powered detection
 
@@ -42,7 +45,7 @@ Click **Run a new scan > AI-powered detection**.
 <Step>
 A dialog appears that displays the number of projects that were selected for scanning. Click **Scan** to begin.  
 
-  * If you would like Semgrep to automatically perform an AI scan on these projects every week, select **Enable weekly scans**.
+  * If you would like Semgrep to automatically perform an AI scan on these projects every week, select **Enable weekly scans**. Weekly AI scans require that you have added the projects to [Semgrep Managed Scans](/getting-started/quickstart-managed-scans#add-projects-to-semgrep-managed-scans); look for the `managed-scan` tag in the [**Projects** section of the Semgrep AppSec Platform](https://semgrep.dev/orgs/-/projects/scanning).
 </Step>
 </Steps>
 

--- a/docs/deployment/add-ai-to-scans.mdx
+++ b/docs/deployment/add-ai-to-scans.mdx
@@ -13,7 +13,7 @@ To run Semgrep Code's [AI-powered detection](/semgrep-code/overview#ai-powered-d
 <Note>
 **INFO**
 
-AI-powered detection analyzes your code on Semgrep's managed scanning infrastructure. Semgrep clones your repository into that environment to run the scan, even if your other scans run in your own CI.
+AI-powered detection runs on Semgrep Managed Scan infrastructure. Even if your other scans run in your own CI environment, Semgrep clones your repository into the Managed Scan environment to perform AI-powered detection.
 </Note>
 
 ## Enable or disable AI-powered detection

--- a/docs/deployment/add-ai-to-scans.mdx
+++ b/docs/deployment/add-ai-to-scans.mdx
@@ -8,7 +8,7 @@ This page provides step-by-step instructions on enabling and running an AI-power
 
 ## Prerequisites
 
-To run Semgrep Code's [AI-powered detection](/semgrep-code/overview#ai-powered-detection-beta), you must have enabled [Semgrep Multimodal](/semgrep-multimodal/getting-started#enable-multimodal) for your organization.
+To run Semgrep Code's [AI-powered detection](/semgrep-code/overview#ai-powered-detection-beta), you must have [Semgrep Multimodal](/semgrep-multimodal/getting-started#enable-multimodal) enabled for your organization.
 
 <Note>
 **INFO**


### PR DESCRIPTION
## Summary

Enabling Semgrep Managed Scans is not a requirement for running an AI-powered detection scan, but this page listed it as a prerequisite. Customers pushed back after we started enforcing SMS enablement.

- Removes the Semgrep Managed Scans prerequisite. Semgrep Multimodal remains the only requirement, now inlined as a sentence since it was the sole remaining bullet.
- Adds a `<Note>` stating that AI-powered detection analyzes your code on Semgrep's managed scanning infrastructure — the underlying concern the prerequisite was standing in for.
- Moves the Managed Scans requirement down to the **Enable weekly scans** step, where it is still accurate: scheduled AI scans dispatch through the managed-scan autoscan path and do require SMS.
- Drive-by: fixes the `#ai-powered-detection-beta-feature` anchor on the rewritten line to `#ai-powered-detection-beta`, which is what the heading in `semgrep-code/overview.mdx` actually slugifies to.

Docs counterpart to the `semgrep-app` UI change that stops checking SMS status when deciding whether the on-demand AI scan option is enabled.

Part of AIENG-3065

## Test plan

- [ ] Docs team review of the wording, particularly the infrastructure disclosure
- [ ] Links resolve: `#ai-powered-detection-beta`, `#enable-multimodal`, `#add-projects-to-semgrep-managed-scans`
- [ ] `<Note>` renders (matches the `<Note>` + `**INFO**` convention used elsewhere in the repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)