### PR TITLE
Broker: tip to remind token users to always include the token

### DIFF
--- a/docs/semgrep-ci/network-broker.mdx
+++ b/docs/semgrep-ci/network-broker.mdx
@@ -407,7 +407,7 @@ inbound:
     baseURL: https://GITHUB_BASE_URL/api/v3
 ```
 
-Subsequent entries for the same SCM require you to modify `allowlist` and add specific information needed for the HTTP requests. The following is a sample allowlist for additional GitHub entries:
+Subsequent entries for the same SCM type (e.g. a second GitHub Enterprise Server instance) require you to modify `allowlist` and add specific information needed for the HTTP requests. The following is a sample allowlist for additional GitHub entries:
 
 ```yaml
 inbound:
@@ -430,3 +430,5 @@ inbound:
         Authorization: "Bearer GITHUB_PAT"
     ...
 ```
+
+If you are setting the SCM token in the Network Broker config, rather than in Semgrep AppSec Platform, the token must be specified in all entries referring to the same base URL. Missing token entries may result in authentication errors.

--- a/docs/semgrep-ci/network-broker.mdx
+++ b/docs/semgrep-ci/network-broker.mdx
@@ -407,7 +407,7 @@ inbound:
     baseURL: https://GITHUB_BASE_URL/api/v3
 ```
 
-Subsequent entries for the same SCM type (e.g. a second GitHub Enterprise Server instance) require you to modify `allowlist` and add specific information needed for the HTTP requests. The following is a sample allowlist for additional GitHub entries:
+Subsequent entries for the same SCM type, such as a second GitHub Enterprise Server instance, require you to modify `allowlist` and add specific information needed for the HTTP requests. The following is a sample allowlist for additional GitHub entries:
 
 ```yaml
 inbound:

--- a/docs/semgrep-ci/network-broker.mdx
+++ b/docs/semgrep-ci/network-broker.mdx
@@ -431,4 +431,4 @@ inbound:
     ...
 ```
 
-If you are setting the SCM token in the Network Broker config, rather than in Semgrep AppSec Platform, the token must be specified in all entries referring to the same base URL. Missing token entries may result in authentication errors.
+If you are seeing authorization issues but are confident the token provided in your Network Broker configuration has the correct permissions, review all entries in the allowlist to be sure that they specify the correct token.


### PR DESCRIPTION
Clarify that if the broker config specifies a token for a given SCM base URL, the right token has to appear in all inbound/allowlist entries or errors can occur.

Covers token use, but just a troubleshooting tip, so no direct security implications.

Please ensure:

- [x] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
