### PR TITLE
clarify behavior of provisionally ignored automation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -728,7 +728,8 @@
                       "kb/semgrep-appsec-platform/scan-duration-discrepancy",
                       "kb/semgrep-appsec-platform/search-filter-sort-findings",
                       "kb/semgrep-appsec-platform/semgrep-login-cli-tenant",
-                      "kb/semgrep-appsec-platform/sso-attribute-error"
+                      "kb/semgrep-appsec-platform/sso-attribute-error",
+                      "/kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored"
                     ]
                   },
                   {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -729,7 +729,7 @@
                       "kb/semgrep-appsec-platform/search-filter-sort-findings",
                       "kb/semgrep-appsec-platform/semgrep-login-cli-tenant",
                       "kb/semgrep-appsec-platform/sso-attribute-error",
-                      "/kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored"
+                      "kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored"
                     ]
                   },
                   {

--- a/docs/kb/semgrep-appsec-platform.mdx
+++ b/docs/kb/semgrep-appsec-platform.mdx
@@ -78,4 +78,7 @@ title: "Semgrep AppSec Platform"
   <Card title="SAML SSO error BadRequest: Missing attribute" href="/kb/semgrep-appsec-platform/sso-attribute-error" icon="file">
     Ensure that you're sending the required name and email attributes to Semgrep AppSec Platform.
   </Card>
+  <Card title="Findings in open status instead of provisionially ignored when flagged as false positives" href="/kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored" icon="file">
+    Learn why some findings flagged as **False positives** might still be in **Open** status.
+  </Card>
 </CardGroup>

--- a/docs/kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored.mdx
+++ b/docs/kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored.mdx
@@ -1,0 +1,11 @@
+---
+title: Why are some of my findings in Open status instead of Provisionially ignored when Semgrep has also flagged the findings as False positives?
+---
+
+Occasionally, you might see findings that Semgrep Multimodal has flagged as **False positives** in **Open** status instead of **Provisionally ignored**. This can happen if the AI analysis takes an extended amount of time:
+
+1. Semgrep scans your project and identifies a finding.
+2. Semgrep Multimodal analyzes your finding to try to auto-triage it.
+3. If auto-triage analysis results are returned in time and the finding is a **False positive**, Semgrep can use this information to set the finding's status to **Provisionally ignored**.
+4. If auto-triage results aren't returned in time, Semgrep sets the finding's status as **Open**.
+5. If auto-triage results return at a later time, indicating that the finding is a **False positive**, Semgrep flags the finding accordingly but does *not* update the status of the finding.

--- a/docs/kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored.mdx
+++ b/docs/kb/semgrep-appsec-platform/findings-in-open-not-provisionally-ignored.mdx
@@ -1,8 +1,8 @@
 ---
-title: Why are some of my findings in Open status instead of Provisionially ignored when Semgrep has also flagged the findings as False positives?
+title: Why are some of my findings in Open status instead of Provisionally ignored when Semgrep has also flagged the findings as False positives?
 ---
 
-Occasionally, you might see findings that Semgrep Multimodal has flagged as **False positives** in **Open** status instead of **Provisionally ignored**. This can happen if the AI analysis takes an extended amount of time:
+Occasionally, you might see findings that Semgrep Multimodal has flagged as **False positives** in **Open** status instead of **Provisionally ignored**. This can happen if the AI analysis takes too long:
 
 1. Semgrep scans your project and identifies a finding.
 2. Semgrep Multimodal analyzes your finding to try to auto-triage it.


### PR DESCRIPTION
Related: [Linear](https://linear.app/semgrep/issue/PLAT-447/false-positive-code-findings-stay-open-instead-of-provisionally)

Please ensure:

- [x] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
