### PR TITLE
Add note about restricted triage by comment in public repos

### DIFF
--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -281,7 +281,7 @@ You can turn off a specific rule or ruleset to prevent Semgrep Code from using i
 You can triage your Semgrep AppSec Platform findings displayed as comments in PRs and MRs by replying with another comment.
 
 <Note>
-For security reasons, triage by comment is not permitted on public repos, except for GitLab.com, GitLab Self-Managed, and GitHub Enterprise Server.
+For security reasons, you can't triage through PR or MR comments in public repositories. This restriction does not apply to GitLab.com, GitLab Self-Managed, and GitHub Enterprise Server.
 </Note>
 
 Before proceeding, ensure that you have:

--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -280,6 +280,10 @@ You can turn off a specific rule or ruleset to prevent Semgrep Code from using i
 
 You can triage your Semgrep AppSec Platform findings displayed as comments in PRs and MRs by replying with another comment.
 
+<Note>
+For security reasons, triage by comment is not permitted on public repos, except for GitLab.com, GitLab Self-Managed, and GitHub Enterprise Server.
+</Note>
+
 Before proceeding, ensure that you have:
 
 - One or more repositories hosted by a [Semgrep-supported source code manager (SCM)](/getting-started/scm-support).


### PR DESCRIPTION
You can't triage by comment in public repos on most SCMs; somehow we lost this info in a prior update.

Please ensure:

- [ ] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)

This change does touch on security being a reason for the restriction, but it doesn't change security behavior at all.