### PR TITLE
Add supported ecosystem sources that aren't deps.dev

### DIFF
--- a/docs/semgrep-supply-chain/license-compliance.mdx
+++ b/docs/semgrep-supply-chain/license-compliance.mdx
@@ -86,7 +86,7 @@ Semgrep uses [deps.dev](https://deps.dev/) as the primary source for license dat
 
 In addition to deps.dev, Semgrep currently uses [Packagist](https://packagist.org/) for PHP licenses and [Rubygems](https://rubygems.org/) for Ruby licenses.
 
-For SwiftPM, Semgrep detects licenses asynchronously by attempting to retrieve the data from the source repository. This method is best-effort and delays detection capability until after the first scan. See support details and caveat at [Features for supported languages](/requirements-and-feature-support#features-for-supported-languages).
+For SwiftPM, Semgrep detects licenses asynchronously by attempting to retrieve the data from the source repository. This method is best-effort and delays detection capability until after the first scan. See support details and caveat at [Features for supported languages](/semgrep-supply-chain/requirements-and-feature-support#features-for-supported-languages).
 
 ## License categories
 

--- a/docs/semgrep-supply-chain/license-compliance.mdx
+++ b/docs/semgrep-supply-chain/license-compliance.mdx
@@ -84,6 +84,8 @@ Semgrep uses [deps.dev](https://deps.dev/) as the primary source for license dat
 
 [deps.dev](https://deps.dev/) aggregates license metadata from package registry APIs, such as PyPI and npm. This metadata is provided by package maintainers through their manifest files and may be missing, incomplete, or inaccurate. If the license data displayed in Semgrep AppSec Platform for a particular package is missing or doesn't show the expected value, the data provided by the package maintainer to populate the package registry API is likely incomplete or incorrect.
 
+In addition to deps.dev, Semgrep currently uses [Packagist](https://packagist.org/) for PHP licenses and [Rubygems](https://rubygems.org/) for Ruby licenses.
+
 ## License categories
 
 Semgrep Supply Chain can identify the following licenses and license categories.

--- a/docs/semgrep-supply-chain/license-compliance.mdx
+++ b/docs/semgrep-supply-chain/license-compliance.mdx
@@ -86,6 +86,8 @@ Semgrep uses [deps.dev](https://deps.dev/) as the primary source for license dat
 
 In addition to deps.dev, Semgrep currently uses [Packagist](https://packagist.org/) for PHP licenses and [Rubygems](https://rubygems.org/) for Ruby licenses.
 
+For SwiftPM, Semgrep detects licenses asynchronously by attempting to retrieve the data from the source repository. This method is best-effort and delays detection capability until after the first scan. See support details and caveat at [Features for supported languages](/requirements-and-feature-support#features-for-supported-languages).
+
 ## License categories
 
 Semgrep Supply Chain can identify the following licenses and license categories.


### PR DESCRIPTION
It is definitely mostly helpful to have deps.dev explained but we do still pull from other sources for PHP and Ruby and making that clear will also help.

Please ensure:

- [x] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [x] This change has no security implications
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
