### PR TITLE
Add MegaLinter to the "Semgrep as an engine" list

### DIFF
--- a/docs/extensions/overview.mdx
+++ b/docs/extensions/overview.mdx
@@ -30,6 +30,7 @@ Many other tools have capabilities powered by Semgrep. Add yours [with a pull re
   <Card title="GitLab SAST" icon="gitlab" href="https://docs.gitlab.com/ee/user/application_security/sast/#multi-project-support" horizontal />
   <Card title="GuardDog" icon="github" href="https://github.com/datadog/guarddog" horizontal />
   <Card title="libsast" icon="github" href="https://github.com/ajinabraham/libsast" horizontal />
+  <Card title="MegaLinter" icon="globe" href="https://megalinter.io/latest/descriptors/repository_semgrep/" horizontal />
   <Card title="mobsfscan" icon="github" href="https://github.com/MobSF/mobsfscan" horizontal />
   <Card title="nodejsscan" icon="github" href="https://github.com/ajinabraham/nodejsscan" horizontal />
   <Card title="SecObserve" icon="github" href="https://github.com/SecObserve/SecObserve" horizontal />


### PR DESCRIPTION
Hi! Taking up the invite on the Extensions page to add tools via PR :)

[MegaLinter](https://megalinter.io) is an open-source linters aggregator for CI that ships Semgrep as one of its bundled analyzers — details on the [Semgrep descriptor page](https://megalinter.io/latest/descriptors/repository_semgrep/).

This just adds a card for it in the "Semgrep as an engine" section, alphabetically between libsast and mobsfscan. Thanks!