### PR TITLE
Document the hooks Semgrep Guardian registers

### DIFF
--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -248,6 +248,24 @@ See [Kiro docs](https://kiro.dev/docs/mcp/) for more info.
   </Tab>
 </Tabs>
 
+## What hooks does Semgrep Guardian use?
+
+Guardian uses different hooks depending on the IDE you use it in.
+
+### Claude Code
+
+In Claude Code, the Guardian plugin registers three hooks:
+
+| Hook | What it does |
+| --- | --- |
+| `PreToolUse` | Prevents malware installation. Looks up each package to confirm it isn't malicious before the agent downloads it. |
+| `PostToolUse` | Scans the code your agent just wrote for hardcoded secrets and software vulnerabilities. |
+| `SessionStart` | Starts the Semgrep login flow if you aren't already authenticated. |
+
+### Other IDEs
+
+Other IDEs connect to Guardian through the Semgrep MCP Server. If your IDE supports a post-write or post-tool hook, you can point it at `semgrep mcp -k post-tool-cli-scan -a <ide-name>` to scan generated code automatically, as shown in the [Devin (Windsurf)](#connect-to-your-ide) setup. Otherwise, the agent calls Guardian's MCP tools directly and no hooks are involved.
+
 ## What rules does Semgrep Guardian scan with?
 
 Guardian uses different rules depending on the environment in which you use it:

--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -264,7 +264,7 @@ In Claude Code, the Guardian plugin registers three hooks:
 
 ### Other IDEs
 
-Other IDEs connect to Guardian through the Semgrep MCP Server. If your IDE supports a post-write or post-tool hook, you can point it at `semgrep mcp -k post-tool-cli-scan -a <ide-name>` to scan generated code automatically, as shown in the [Devin (Windsurf)](#connect-to-your-ide) setup. Otherwise, the agent calls Guardian's MCP tools directly and no hooks are involved.
+Other IDEs connect to Guardian through the Semgrep MCP Server. In these IDEs, Guardian is called on a best-effort basis, since it depends on the agent remembering to call it. Deploy Guardian alongside a skill to ensure that the agent calls Semgrep reliably.
 
 ## What rules does Semgrep Guardian scan with?
 


### PR DESCRIPTION
Adds a **What hooks does Semgrep Guardian use?** section to the Guardian overview, just above the existing rules section.

Verified against the `guardian-dev` repo (`plugin.go`, `pretooluse.go`, `posttooluse.go`, `build/templates/hooks.json`):

- `PreToolUse` — package lookup to prevent malware installation
- `PostToolUse` — scans written code for secrets and vulnerabilities
- `SessionStart` — starts the Semgrep login flow

Note: the plugin templates still register a `UserPromptSubmit` hook, but per @milan-semgrep that hook has been removed, so it is intentionally not documented. Worth checking whether `build/templates/hooks.json` is stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)