### PR TITLE
fix(docs.json): drop nav entry for relocated incident-response page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -693,7 +693,6 @@
                     "root": "kb/semgrep-supply-chain",
                     "pages": [
                       "kb/semgrep-supply-chain/exclude-rule",
-                      "kb/semgrep-supply-chain/incident-response",
                       "kb/semgrep-supply-chain/scanning_multiple_lockfiles",
                       "kb/semgrep-supply-chain/ssc-lockfiles-circleci",
                       "kb/semgrep-supply-chain/ssc-python-lockfiles",


### PR DESCRIPTION
Removes one stale `docs.json` nav entry: `kb/semgrep-supply-chain/incident-response`, a page that #2765 relocated to `docs/semgrep-supply-chain/incident-response.mdx`.

Mintlify treats a nav entry with no backing file as a validation warning, and `mintlify validate` exits non-zero on warnings. That has been failing the validate step of the scheduled OpenAPI spec sync ever since — the Aug 10, 11 and 12 runs all failed, so no spec refresh PR has opened in three weekdays.

`npx mintlify validate` goes from exit 1 to exit 0 with this line removed.

The page itself was never broken: it renders at its new location, is listed in the Supply Chain nav group, and the old `/kb/` URL still redirects.
