### PR TITLE
fix comma in the experimental endpoint callout copy

### DIFF
--- a/scripts/mirror_openapi.py
+++ b/scripts/mirror_openapi.py
@@ -55,7 +55,7 @@ import yaml
 CALLOUTS = {
     "experimental": (
         "<Warning>This endpoint is **experimental**. It may change or be "
-        "removed without notice, and is not covered by API stability "
+        "removed without notice and is not covered by API stability "
         "guarantees.</Warning>"
     ),
     "beta": (


### PR DESCRIPTION
Updates the experimental/beta notice `without notice, and is not covered` → `without notice and is not covered`. They're right — "It" is the shared subject of a compound predicate, so it takes no comma.
