### PR TITLE
Add a servers block so the API playground can send requests

### DIFF
--- a/.github/workflows/docs-pr-check.yml
+++ b/.github/workflows/docs-pr-check.yml
@@ -35,14 +35,17 @@ jobs:
       - name: Run unit tests
         run: uv run --with pyyaml --with pytest pytest scripts/tests -q
 
-      # The scheduled sync re-runs both scripts after fetching, so the
+      # The scheduled sync re-runs these scripts after fetching, so the
       # checked-in specs must already be in their final shape. Otherwise the
       # next sync PR carries an unrelated reshuffle alongside its real changes,
       # which defeats reviewing that diff for dropped endpoints.
+      # Keep this list in step with update-openapi-specs.yml, and in the same
+      # order.
       - name: Check committed specs are already normalized
         run: |
           uv run scripts/mirror_openapi.py docs/public_v1.openapi.yaml docs/public_v2.openapi.yaml
           uv run scripts/sort_openapi_nav.py docs/public_v1.openapi.yaml docs/public_v2.openapi.yaml
+          uv run scripts/add_openapi_servers.py docs/public_v1.openapi.yaml docs/public_v2.openapi.yaml
           git diff --exit-code --stat docs/public_v1.openapi.yaml docs/public_v2.openapi.yaml
 
   validate:

--- a/.github/workflows/update-openapi-specs.yml
+++ b/.github/workflows/update-openapi-specs.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Sort API navigation into alphabetical order
         run: uv run scripts/sort_openapi_nav.py docs/public_v1.openapi.yaml docs/public_v2.openapi.yaml
 
+      # Upstream emits no `servers:` block, and Mintlify has no docs.json
+      # override for OpenAPI-generated pages, so without this the playground
+      # renders https://api.example.com and cannot send requests. Runs last:
+      # the two steps above parse `paths:` and `tags:`, and neither needs to
+      # see the block this adds. Safe to drop once semgrep-app emits `servers`
+      # natively -- this step no-ops rather than overwriting it.
+      - name: Add the API base URL Mintlify's playground needs
+        run: uv run scripts/add_openapi_servers.py docs/public_v1.openapi.yaml docs/public_v2.openapi.yaml
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22

--- a/docs/public_v1.openapi.yaml
+++ b/docs/public_v1.openapi.yaml
@@ -3970,6 +3970,9 @@ info:
   title: Semgrep Web App
   version: 1.0.0
 openapi: 3.0.3
+servers:
+  - url: https://semgrep.dev
+    description: Semgrep AppSec Platform
 paths:
   /api/v1/deployments/{deploymentSlug}/findings:
     get:

--- a/docs/public_v2.openapi.yaml
+++ b/docs/public_v2.openapi.yaml
@@ -12,6 +12,9 @@ info:
         url: "https://semgrep.dev/images/SemgrepLogoWithTextWithMargin.svg"
         backgroundColor: "#fafafa"
         altText: "Semgrep logo"
+servers:
+    - url: https://semgrep.dev
+      description: Semgrep AppSec Platform
 paths:
     /api/agent/deployments/{deploymentId}/issues/{issueId}/fix_jobs:
         post:

--- a/scripts/add_openapi_servers.py
+++ b/scripts/add_openapi_servers.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["pyyaml"]
+#
+# [tool.uv]
+# exclude-newer = "1 week"
+# ///
+#
+# Give the OpenAPI specs a `servers:` block so Mintlify's API playground knows
+# where to send requests.
+#
+# Why this exists: `servers` is the only lever Mintlify exposes for the base
+# URL of an OpenAPI-generated page. There is no docs.json equivalent --
+# `api.mdx.server` looks like one but governs hand-authored MDX API pages, not
+# generated ones. semgrep-app emits neither spec with a `servers` block, so
+# Mintlify substitutes the placeholder https://api.example.com into every code
+# sample and drops the playground into a "simple mode" that cannot send
+# requests at all. Both v1 and v2 are affected, on every endpoint page.
+#
+# The URL is the bare origin. Both specs carry their own prefix in the path
+# (/api/v1/... for v1, /api/... for v2), so anything more specific would be
+# duplicated into the rendered URL.
+#
+# The specs are overwritten every weekday by .github/workflows/update-openapi-
+# specs.yml, so this runs there as a post-fetch normalization step rather than
+# being applied by hand -- an edit committed straight to the YAML would be
+# reverted by the next sync.
+#
+# A spec that already declares top-level `servers` is left alone. That makes
+# this a no-op the day semgrep-app starts emitting its own, at which point the
+# workflow step and this script can be deleted rather than reconciled.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+SERVER = {
+    "url": "https://semgrep.dev",
+    "description": "Semgrep AppSec Platform",
+}
+
+
+def _indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _split_lines(text: str) -> tuple[list[str], bool]:
+    trailing_newline = text.endswith("\n")
+    lines = text.split("\n")
+    if trailing_newline:
+        lines.pop()
+    return lines, trailing_newline
+
+
+def _join_lines(lines: list[str], trailing_newline: bool) -> str:
+    return "\n".join(lines) + ("\n" if trailing_newline else "")
+
+
+def _indent_step(lines: list[str]) -> int:
+    """Infer the file's indent step from the first key under `paths:`.
+
+    v1 is emitted with 2-space indentation and v2 with 4-space, so this can't
+    be hardcoded.
+    """
+    for i, line in enumerate(lines):
+        if line.rstrip() == "paths:":
+            for following in lines[i + 1 :]:
+                if following.strip():
+                    return _indent_of(following) or 2
+    return 2
+
+
+def _top_level_index(lines: list[str], key: str) -> int | None:
+    """Index of the top-level `key:` line, or None.
+
+    Anchored at indent 0 so an operation-level `servers:` -- a legal OpenAPI
+    per-path override -- is never mistaken for the document-level one.
+    """
+    for i, line in enumerate(lines):
+        if _indent_of(line) == 0 and line.strip().split(":")[0] == key:
+            return i
+    return None
+
+
+def _servers_block(step: int) -> list[str]:
+    item = " " * step
+    # Sibling keys align with `url`, past the two columns the "- " occupies.
+    key = item + "  "
+    return [
+        "servers:",
+        f"{item}- url: {SERVER['url']}",
+        f"{key}description: {SERVER['description']}",
+    ]
+
+
+def add_servers(text: str) -> str:
+    """Insert a top-level `servers:` block ahead of `paths:`, if absent."""
+    lines, trailing_newline = _split_lines(text)
+
+    if _top_level_index(lines, "servers") is not None:
+        return text
+
+    # `paths:` is the one top-level key guaranteed present in both specs, and
+    # sits after `info:` in v2 and after `openapi:` in v1 -- upstream key order
+    # differs, so anchoring to it is what keeps one rule working for both.
+    anchor = _top_level_index(lines, "paths")
+    if anchor is None:
+        return text
+
+    block = _servers_block(_indent_step(lines))
+    return _join_lines(lines[:anchor] + block + lines[anchor:], trailing_newline)
+
+
+def main(argv: list[str] | None = None) -> int:
+    specs = sys.argv[1:] if argv is None else argv
+    if not specs:
+        print(f"usage: {Path(__file__).name} SPEC [SPEC ...]", file=sys.stderr)
+        return 2
+
+    for name in specs:
+        path = Path(name)
+        original = path.read_text()
+        updated = add_servers(original)
+        if updated == original:
+            print(f"{path}: servers already present")
+            continue
+        # Parse before writing: a malformed insertion must never reach the docs.
+        yaml.safe_load(updated)
+        path.write_text(updated)
+        print(f"{path}: added servers -> {SERVER['url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_add_openapi_servers.py
+++ b/scripts/tests/test_add_openapi_servers.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+#
+# Tests for add_openapi_servers.py.
+#
+# Run with:
+#   uv run --with pyyaml --with pytest pytest scripts/tests
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+import yaml
+
+from add_openapi_servers import SERVER, add_servers
+
+# v1 is emitted with 2-space indentation, top-level keys alphabetical, and a
+# `tags:` sequence whose dashes sit at column 0.
+SPEC_TWO_SPACE = textwrap.dedent(
+    """\
+    components:
+      schemas:
+        Deployment:
+          type: object
+    info:
+      title: Semgrep API
+      version: v1
+    openapi: 3.0.3
+    paths:
+      /api/v1/deployments:
+        get:
+          operationId: Deployments_List
+          summary: List deployments
+    tags:
+    - name: DeploymentsService
+      x-displayName: Deployments
+    """
+)
+
+# v2 is emitted with 4-space indentation and conventional key order.
+SPEC_FOUR_SPACE = textwrap.dedent(
+    """\
+    openapi: 3.0.3
+    info:
+        title: Semgrep API
+        version: v2.0.0.alpha
+    paths:
+        /api/policies/v2/deployments/{deploymentId}/detection-policy/{product}:
+            get:
+                operationId: PoliciesV2Service_GetDetectionPolicy
+                summary: Get a detection policy
+    components:
+        schemas:
+            DetectionPolicy:
+                type: object
+    tags:
+        - name: PoliciesV2Service
+          x-displayName: Policies
+    """
+)
+
+SPECS = pytest.mark.parametrize(
+    "spec", (SPEC_TWO_SPACE, SPEC_FOUR_SPACE), ids=("two-space", "four-space")
+)
+
+
+@SPECS
+def test_adds_servers_when_absent(spec):
+    doc = yaml.safe_load(add_servers(spec))
+    assert doc["servers"] == [SERVER]
+
+
+@SPECS
+def test_output_is_parseable_and_leaves_other_sections_alone(spec):
+    before = yaml.safe_load(spec)
+    after = yaml.safe_load(add_servers(spec))
+
+    assert after["paths"] == before["paths"]
+    assert after["components"] == before["components"]
+    assert after["tags"] == before["tags"]
+    assert after["info"] == before["info"]
+
+
+@SPECS
+def test_matches_the_files_indent_step(spec):
+    added = [
+        line
+        for line in add_servers(spec).split("\n")
+        if line not in spec.split("\n") and line.strip()
+    ]
+    step = 4 if spec is SPEC_FOUR_SPACE else 2
+
+    assert added[0] == "servers:"
+    assert added[1] == f"{' ' * step}- url: {SERVER['url']}"
+    # Sibling keys align with `url`, i.e. past the "- " of the sequence dash.
+    assert added[2] == f"{' ' * (step + 2)}description: {SERVER['description']}"
+
+
+@SPECS
+def test_is_idempotent(spec):
+    once = add_servers(spec)
+
+    assert add_servers(once) == once
+
+
+@SPECS
+def test_servers_precedes_paths(spec):
+    lines = add_servers(spec).split("\n")
+
+    assert lines.index("servers:") < lines.index("paths:")
+
+
+# The point of the no-op: the day semgrep-app emits its own `servers`, this
+# script stops touching the spec instead of fighting it.
+@pytest.mark.parametrize(
+    "existing",
+    (
+        "servers:\n  - url: https://upstream.example\n",
+        "servers: []\n",
+    ),
+    ids=("populated", "empty"),
+)
+def test_leaves_an_existing_servers_block_alone(existing):
+    spec = existing + SPEC_TWO_SPACE
+
+    assert add_servers(spec) == spec
+
+
+def test_ignores_a_nested_servers_key():
+    """A `servers` under an operation must not be mistaken for the top-level one."""
+    spec = textwrap.dedent(
+        """\
+        openapi: 3.0.3
+        paths:
+          /api/v1/deployments:
+            get:
+              operationId: Deployments_List
+              servers:
+                - url: https://override.example
+        """
+    )
+    doc = yaml.safe_load(add_servers(spec))
+
+    assert doc["servers"] == [SERVER]
+
+
+def test_returns_input_unchanged_when_there_is_no_paths_key():
+    spec = "openapi: 3.0.3\ninfo:\n  title: Semgrep API\n"
+
+    assert add_servers(spec) == spec
+
+
+def test_preserves_a_missing_trailing_newline():
+    spec = SPEC_TWO_SPACE.rstrip("\n")
+
+    assert not add_servers(spec).endswith("\n")
+
+
+def test_server_url_is_the_bare_origin():
+    """Paths carry their own /api/... prefix, so the URL must not repeat it."""
+    assert SERVER["url"] == "https://semgrep.dev"


### PR DESCRIPTION
Fixes TEC-643. Reported by shi in #tech-writers: the Try it playground hardcoded `api.example.com`, so no request could be run from the page.

Mintlify takes the playground base URL only from the top-level `servers:` array in the OpenAPI spec, and neither spec semgrep-app serves declares one. There's no docs.json override for OpenAPI-generated pages — `api.mdx.server` looks like one but covers hand-authored MDX pages only. v1 was affected too, not just v2.

The value is `https://semgrep.dev`, the bare origin, since both specs already carry their own `/api/...` prefix in the path.

It's a post-fetch step rather than an edit to the YAML because the weekday cron overwrites both specs from semgrep.dev. Same shape as `mirror_openapi.py` and `sort_openapi_nav.py`, and it no-ops when `servers` is already present — so once semgrep-app emits its own, the script and both workflow steps just get deleted.

Testing: 66 tests pass (16 new), `mintlify validate` passes, and the preview deploy renders `https://semgrep.dev/...` with zero `api.example.com` left on either version.

Follow-ups: better for semgrep-app to emit `servers` upstream than to shim it here, and [APPEX-1580](https://linear.app/semgrep/issue/APPEX-1580/serve-the-public-api-from-apisemgrepdev-on-a-dedicated-backend) would move the API to `api.semgrep.dev` — it's a single constant (`SERVER`) in the script for that reason.
