### PR TITLE
update developer triage and triage via comment setting

### DIFF
--- a/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
+++ b/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
@@ -5,5 +5,5 @@ title: "Missing PR or MR comments from Semgrep Multimodal"
 Semgrep Multimodal messages appear in PR or MR comments only for rules in remediation policies configured to leave comments. Ensure that you have:
 
 - Configured your [remediation policy](/semgrep-appsec-platform/unified-policies/get-started#manage-remediation-policies) with either the **Block merge and comment on PR/MR** or **Comment on PR/MR** action.
-- Enabled the **Allow developers to triage findings** toggle in Semgrep AppSec Platform by going to **Settings > General**.
-- Enabled PR/MR comment triage.
+
+If comments still aren't appearing, review [Why is my repository not receiving PR or MR comments?](/kb/semgrep-appsec-platform/missing-pr-comments), including whether the **Noise filter for Code PR/MR comments** setting has categorized the finding as a likely false positive.

--- a/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
+++ b/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
@@ -2,8 +2,6 @@
 title: "Missing PR or MR comments from Semgrep Multimodal"
 ---
 
-Semgrep Multimodal messages appear in PR or MR comments only for rules in remediation policies configured to leave comments. Ensure that you have:
-
-- Configured your [remediation policy](/semgrep-appsec-platform/unified-policies/get-started#manage-remediation-policies) with either the **Block merge and comment on PR/MR** or **Comment on PR/MR** action.
+Semgrep Multimodal messages appear in PR or MR comments only for rules in remediation policies configured to leave comments. Ensure that you have [configured your remediation policy](/semgrep-appsec-platform/unified-policies/get-started#manage-remediation-policies) with either the **Block merge and comment on PR/MR** or **Comment on PR/MR** action.
 
 If comments still aren't appearing, review [Why is my repository not receiving PR or MR comments?](/kb/semgrep-appsec-platform/missing-pr-comments), including whether the **Noise filter for Code PR/MR comments** setting has categorized the finding as a likely false positive.

--- a/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
+++ b/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Missing PR or MR comments from Semgrep Multimodal."
+title: "Missing PR or MR comments from Semgrep Multimodal"
 ---
 
-Semgrep Multimodal messages only appear in your PR comments for rules within policies where the defined action is to leave a comment. Ensure that:
+Semgrep Multimodal messages appear in PR or MR comments only for rules in remediation policies configured to leave comments. Ensure that you have:
 
-- You have [modified your remediation policies](/semgrep-appsec-platform/unified-policies/get-started#manage-remediation-policies) so that the action triggered when Semgrep identifies a finding and the policy conditions have been met is either **Block merge and comment on PR/MR** or **Comment on PR/MR**.
-- You have turned on the **Allow developers to triage findings** toggle in Semgrep AppSec Platform by going to **Settings > General**.
-- You have enabled the checkbox for PR/MR comment triage.
+- Configured your [remediation policy](/semgrep-appsec-platform/unified-policies/get-started#manage-remediation-policies) with either the **Block merge and comment on PR/MR** or **Comment on PR/MR** action.
+- Enabled the **Allow developers to triage findings** toggle in Semgrep AppSec Platform by going to **Settings > General**.
+- Enabled PR/MR comment triage.

--- a/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
+++ b/docs/kb/semgrep-multimodal/missing-pr-mr-comments.mdx
@@ -5,4 +5,5 @@ title: "Missing PR or MR comments from Semgrep Multimodal."
 Semgrep Multimodal messages only appear in your PR comments for rules within policies where the defined action is to leave a comment. Ensure that:
 
 - You have [modified your remediation policies](/semgrep-appsec-platform/unified-policies/get-started#manage-remediation-policies) so that the action triggered when Semgrep identifies a finding and the policy conditions have been met is either **Block merge and comment on PR/MR** or **Comment on PR/MR**.
-- You have turned on the **Default developer triage permissions** toggle in Semgrep AppSec Platform by going to **Settings > General**.
+- You have turned on the **Allow developers to triage findings** toggle in Semgrep AppSec Platform by going to **Settings > General**.
+- You have enabled the checkbox for PR/MR comment triage.

--- a/docs/semgrep-appsec-platform/bitbucket-cloud-pr-comments.mdx
+++ b/docs/semgrep-appsec-platform/bitbucket-cloud-pr-comments.mdx
@@ -145,7 +145,7 @@ Toggle the **Incoming webhooks** setting on.
 </Step>
 </Steps>
 
-Once you've successfully enabled webhooks, the **Allow developers to triage findings** toggle is on, and the checkbox for PR/MR comment triage is enabled, developers can triage Semgrep findings from Bitbucket Cloud.
+Once you've enabled webhooks, turned on the **Allow developers to triage findings** toggle, and enabled triage through code review comments, developers can triage Semgrep findings from Bitbucket Cloud.
 
 ### Set up the configuration file
 

--- a/docs/semgrep-appsec-platform/bitbucket-cloud-pr-comments.mdx
+++ b/docs/semgrep-appsec-platform/bitbucket-cloud-pr-comments.mdx
@@ -145,7 +145,7 @@ Toggle the **Incoming webhooks** setting on.
 </Step>
 </Steps>
 
-Once you've successfully enabled webhooks and the **Default developer triage permissions** toggle is on, developers can triage Semgrep findings from Bitbucket Cloud.
+Once you've successfully enabled webhooks, the **Allow developers to triage findings** toggle is on, and the checkbox for PR/MR comment triage is enabled, developers can triage Semgrep findings from Bitbucket Cloud.
 
 ### Set up the configuration file
 

--- a/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.mdx
+++ b/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.mdx
@@ -84,7 +84,7 @@ Toggle the **Incoming webhooks** setting on.
 </Step>
 </Steps>
 
-Once you've successfully enabled webhooks and the **Default developer triage permissions** toggle is on, developers can triage Semgrep findings from Bitbucket Data Center.
+Once you've successfully enabled webhooks, the **Allow developers to triage findings** toggle is on, and the checkbox for PR/MR comment triage is enabled, developers can triage Semgrep findings from Bitbucket Data Center.
 
 ## Configure PR comments
 

--- a/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.mdx
+++ b/docs/semgrep-appsec-platform/bitbucket-data-center-pr-comments.mdx
@@ -84,7 +84,7 @@ Toggle the **Incoming webhooks** setting on.
 </Step>
 </Steps>
 
-Once you've successfully enabled webhooks, the **Allow developers to triage findings** toggle is on, and the checkbox for PR/MR comment triage is enabled, developers can triage Semgrep findings from Bitbucket Data Center.
+Once you've enabled webhooks, turned on the **Allow developers to triage findings** toggle, and enabled triage through code review comments, developers can triage Semgrep findings from Bitbucket Data Center.
 
 ## Configure PR comments
 

--- a/docs/semgrep-appsec-platform/gitlab-mr-comments.mdx
+++ b/docs/semgrep-appsec-platform/gitlab-mr-comments.mdx
@@ -90,7 +90,7 @@ Toggle the **Incoming webhooks** setting on.
 </Step>
 </Steps>
 
-Once you've successfully enabled webhooks, the **Allow developers to triage findings** toggle is on, and the checkbox for PR/MR comment triage is enabled, you can change the role for the token you provide to Semgrep to one that's more restrictive, such as `Developer`.
+Once you've enabled webhooks, turned on the **Allow developers to triage findings** toggle, and enabled triage through code review comments, you can change the role for the token you provide to Semgrep to one that's more restrictive, such as `Developer`.
 
 ### Configure comments for Semgrep Code
 

--- a/docs/semgrep-appsec-platform/gitlab-mr-comments.mdx
+++ b/docs/semgrep-appsec-platform/gitlab-mr-comments.mdx
@@ -90,7 +90,7 @@ Toggle the **Incoming webhooks** setting on.
 </Step>
 </Steps>
 
-Once you've successfully enabled webhooks and the **Default developer triage permissions** toggle is on, you can change the role for the token you provide to Semgrep to one that's more restrictive, such as `Developer`.
+Once you've successfully enabled webhooks, the **Allow developers to triage findings** toggle is on, and the checkbox for PR/MR comment triage is enabled, you can change the role for the token you provide to Semgrep to one that's more restrictive, such as `Developer`.
 
 ### Configure comments for Semgrep Code
 

--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -290,7 +290,8 @@ Before proceeding, ensure that you have:
 - Configured [PR or MR comments](/category/pr-or-mr-comments) for your SCM.
 - Enabled the option in your Semgrep organization settings.
     i. Click **Settings**. This takes you to the **General > Global** settings tab.
-    ii. Enable the toggle under **Default developer triage permissions**.
+    ii. Enable the toggle under **Allow developers to triage findings**.
+    iii. Enable the checkbox for PR/MR comments.
 - _For SCMs other than GitHub:_
   - Granted Semgrep permission to interact with pull requests and create webhooks for your SCM.
   - Enabled the **Incoming webhooks** option on the SCM connection.

--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -291,7 +291,7 @@ Before proceeding, ensure that you have:
 - Enabled the option in your Semgrep organization settings.
     i. Click **Settings**. This takes you to the **General > Global** settings tab.
     ii. Enable the toggle under **Allow developers to triage findings**.
-    iii. Enable the checkbox for PR/MR comments.
+    iii. Enable the checkbox for code review comments.
 - _For SCMs other than GitHub:_
   - Granted Semgrep permission to interact with pull requests and create webhooks for your SCM.
   - Enabled the **Incoming webhooks** option on the SCM connection.

--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -291,7 +291,7 @@ Before proceeding, ensure that you have:
 - Enabled the option in your Semgrep organization settings.
     i. Click **Settings**. This takes you to the **General > Global** settings tab.
     ii. Enable the toggle under **Allow developers to triage findings**.
-    iii. Enable the checkbox for code review comments.
+    iii. Enable the **Triage through code review comments** checkbox.
 - _For SCMs other than GitHub:_
   - Granted Semgrep permission to interact with pull requests and create webhooks for your SCM.
   - Enabled the **Incoming webhooks** option on the SCM connection.

--- a/docs/semgrep-supply-chain/malicious-dependencies.mdx
+++ b/docs/semgrep-supply-chain/malicious-dependencies.mdx
@@ -62,7 +62,7 @@ After reviewing your findings, you can choose one of the following actions:
 <Warning>
 **CAUTION**
 
-If you have configured your policies to display malicious dependency findings to your developers and enabled **Settings > General > Global > Default developer triage permissions**, your developers can triage these findings as **Ignored**.
+If you have configured your policies to display malicious dependency findings to your developers and enabled **Settings > General > Global > Allow developers to triage findings**, your developers can triage these findings as **Ignored**.
 </Warning>
 
 ## Create Jira tickets


### PR DESCRIPTION
### Thanks for improving Semgrep Docs

Please ensure:

- [x] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Any redirects are in `docs/docs.json` if URLs changed
- [x] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
