### PR TITLE
docs(guardian): simplify Claude Code install to one command

### DIFF
--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -19,21 +19,19 @@ Start with the **Claude Code** tab. That path uses Semgrep's hosted remote plugi
 
 <Tabs>
   <Tab title="Claude Code">
-    Uses Claude Code [hooks](https://code.claude.com/docs/en/hooks) and [plugins](https://code.claude.com/docs/en/plugins). Claude Code uses Semgrep's hosted remote server by default, so you do not need to install the Semgrep CLI locally.
-
-    <Info>
-      The MCP server bundled with this plugin works on all platforms. On Windows, however, it requires [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) for the MCP server to work out of the box.
-    </Info>
-
     Install the Guardian plugin from the Claude official marketplace:
 
     ```bash
     claude plugin install semgrep@claude-plugins-official
     ```
 
-    Then start a new Claude Code session to begin the OAuth login flow.
+    Start a new Claude Code session (`claude`) to log in to Semgrep.
 
-    The plugin registers a post-tool hook so Claude Code scans every file it writes.
+    This integration is powered by Claude Code [hooks](https://code.claude.com/docs/en/hooks) and [plugins](https://code.claude.com/docs/en/plugins). It uses Semgrep's hosted remote server by default, so you do not need to install the Semgrep CLI locally.
+
+    <Info>
+      **For Windows machines:** requires [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) to work. Native Windows is unsupported.
+    </Info>
 
     <Accordion title="Run Semgrep Guardian locally">
       The remote server is the recommended default. If you need to run Semgrep locally instead, you can install the local plugin from the [`semgrep/guardian-local`](https://github.com/semgrep/guardian-local) repo.

--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -27,7 +27,7 @@ Start with the **Claude Code** tab. That path uses Semgrep's hosted remote plugi
 
     Start a new Claude Code session (`claude`) to log in to Semgrep.
 
-    This integration is powered by Claude Code [hooks](https://code.claude.com/docs/en/hooks) and [plugins](https://code.claude.com/docs/en/plugins). It uses Semgrep's hosted remote server by default, so you do not need to install the Semgrep CLI locally.
+    This integration uses Claude Code [hooks](https://code.claude.com/docs/en/hooks) and [plugins](https://code.claude.com/docs/en/plugins). By default, it uses Semgrep's hosted remote server, so you don't need to install the Semgrep CLI locally.
 
     <Info>
       **For Windows machines:** requires [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) to work. Native Windows is unsupported.

--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -25,39 +25,14 @@ Start with the **Claude Code** tab. That path uses Semgrep's hosted remote plugi
       The MCP server bundled with this plugin works on all platforms. On Windows, however, it requires [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) for the MCP server to work out of the box.
     </Info>
 
-    <Steps>
-      <Step>
-        Start a Claude Code instance:
+    Install the Guardian plugin from the Claude official marketplace:
 
-        ```bash
-        claude
-        ```
-      </Step>
-      <Step>
-        Open the plugin manager:
+    ```bash
+    claude plugin install semgrep@claude-plugins-official
+    ```
 
-        ```bash
-        /plugin
-        ```
-      </Step>
-      <Step>
-        Go to **Discover**, search for **Semgrep**, and click **Install**.
-      </Step>
-      <Step>
-        Tell Claude to load the plugin:
+    Then start a new Claude Code session to begin the OAuth login flow.
 
-        ```bash
-        /reload-plugins
-        ```
-      </Step>
-      <Step>
-        Start a new session in Claude to begin the OAuth login flow:
-
-        ```bash
-        /clear
-        ```
-      </Step>
-    </Steps>
     The plugin registers a post-tool hook so Claude Code scans every file it writes.
 
     <Accordion title="Run Semgrep Guardian locally">

--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -19,7 +19,7 @@ Start with the **Claude Code** tab. That path uses Semgrep's hosted remote plugi
 
 <Tabs>
   <Tab title="Claude Code">
-    Install the Guardian plugin from the Claude official marketplace:
+    Install the Guardian plugin from the Claude Marketplace:
 
     ```bash
     claude plugin install semgrep@claude-plugins-official

--- a/docs/semgrep-guardian/overview.mdx
+++ b/docs/semgrep-guardian/overview.mdx
@@ -30,7 +30,7 @@ Start with the **Claude Code** tab. That path uses Semgrep's hosted remote plugi
     This integration uses Claude Code [hooks](https://code.claude.com/docs/en/hooks) and [plugins](https://code.claude.com/docs/en/plugins). By default, it uses Semgrep's hosted remote server, so you don't need to install the Semgrep CLI locally.
 
     <Info>
-      **For Windows machines:** requires [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) to work. Native Windows is unsupported.
+      **For Windows machines:** [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) is required. Native Windows is unsupported.
     </Info>
 
     <Accordion title="Run Semgrep Guardian locally">


### PR DESCRIPTION
Rewrites the Guardian **Claude Code** tab around a single install command, replacing the five-steps with 

```bash
claude plugin install semgrep@claude-plugins-official
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)