### PR TITLE
[TEC-646] Set up GTM and GA4 for Semgrep docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -16,8 +16,8 @@
   },
   "favicon": "/favicon.svg",
   "integrations": {
-    "ga4": {
-      "measurementId": "G-XYYV814DDN"
+    "gtm": {
+      "tagId": "GTM-NNHHMTCL"
     }
   },
   "navigation": {


### PR DESCRIPTION
- Added Google Tag Manager to semgrep docs.json.
- It loads GA4 as a Google tag inside GTM, so tags can be managed centrally without redeploying docs.

With GA4 configured in GTM, the direct ga4 entry in docs.json is redundant and would inflate metrics.


To do after merge:

- [ ] Use GTM Preview on a docs URL and confirm GA4 - Semgrep Docs fires
- [ ] Confirm page views appear in GA4 Realtime
- [ ] Confirm only one GA4 hit per page load (no double-counting)

