### PR TITLE
feat(sca): add webhooks for sci

### DIFF
--- a/docs/semgrep-appsec-platform/webhooks.mdx
+++ b/docs/semgrep-appsec-platform/webhooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Enable webhooks"
 sidebarTitle: "Webhooks"
-description: "Webhooks are a generic method for Semgrep AppSec Platform to post JSON-formatted findings after each scan to your URL endpoint."
+description: "Webhooks are a generic method for Semgrep AppSec Platform to post JSON-formatted objects to your URL endpoint."
 ---
 
 <Tip>
@@ -10,14 +10,14 @@ description: "Webhooks are a generic method for Semgrep AppSec Platform to post 
 - To integrate with Slack, use the [Semgrep Slack app](/semgrep-appsec-platform/slack-notifications). The webhook setup described in this guide does not work for Slack integrations.
 </Tip>
 
-Semgrep sends two types of JSON objects:
+Semgrep sends three different types of JSON objects:
 
-
-`semgrep_scan` JSON object<br/><br/>
-A `semgrep_scan` object contains information about the CI job and other scan parameters, such as ignored files. Semgrep sends a single `semgrep_scan` object **every time a scan is run**. This includes diff-aware scans, full scans, and scans that have no findings.
-
-`semgrep_finding` JSON object<br/><br/>
-A `semgrep_finding` object is a single record of a new finding. Semgrep sends new `semgrep_finding` objects based on how you have configured your notifications in Policies. See [Set up webhooks](#set-up-webhooks) to learn more.
+* **`semgrep_scan`**: Information about the CI job and other scan parameters, such as ignored files.
+  * Sent **every time a scan is run**, including diff-aware scans, full scans, and scans that have no findings.
+* **`semgrep_finding`**: A single record of a new finding.
+  * Sent based on how you have configured your notifications in Unified Policies. See [Create a remediation policy](/semgrep-appsec-platform/unified-policies/get-started#create-a-remediation-policy).
+* **`semgrep_supply_chain_incident`**: Information about a Supply Chain incident declared by Semgrep's Security Research team, including whether any of your projects are affected.
+  * Sent if configured for the **Early notification for Supply Chain incidents** policy. See [Supply Chain incidents](/semgrep-supply-chain/incident-notifications).
 
 ## Set up webhooks
 
@@ -44,11 +44,7 @@ Create a webhook integration:
 <Step>
 Turn notifications on:
 
-   i. Click **Rules > Policies > <Icon icon="gear" iconType="solid"/> Rule Modes**.
-
-   ii. Click the **Edit** button of the Rule Mode for which you want to receive webhook notifications. For example, if you want to be notified of all blocking findings through webhooks, click the **Edit** button of the **Block** mode.
-
-   iii. Repeat the previous step for all Rule Modes that you want to receive notifications for.
+   i. When creating or editing the desired policy, click **Add action > Call a webhook**, then select the webhook integration you created.
 </Step>
 </Steps>
 
@@ -98,7 +94,6 @@ See [Findings in CI](/semgrep-ci/findings-ci) for more information about how Sem
 
 ## Semgrep findings object
 
-Currently, only Semgrep Code (SAST) findings are sent through webhooks. The `numeric_id` field represents the finding's ID in Semgrep AppSec Platform.
 
 The following is an example of a `semgrep_finding` object sent by Semgrep:
 
@@ -179,6 +174,8 @@ The following is an example of a `semgrep_finding` object sent by Semgrep:
   }
 ]
 ```
+The `numeric_id` field represents the finding's ID in Semgrep AppSec Platform.
+
 
 ## Semgrep scan object
 
@@ -234,3 +231,80 @@ The following is an example of a `semgrep_scan` object sent by Semgrep:
   }
 }
 ```
+
+## Semgrep supply chain incident object
+
+The following is an example of a `semgrep_supply_chain_incident` object sent by Semgrep:
+
+```json expandable
+[
+    {
+        "semgrep_supply_chain_incident": {
+            "schema_version": 1,
+            "incident_id": 67,
+            "deployment_id": 1,
+            "title": "Embedded Malicious Code in append-only-vec",
+            "description": "Two popular Rust crates, arrayref (244M downloads) and append-only-vec (4M downloads), were compromised by an attacker who injected a malicious dependency on a typosquat package called proc-macro1 that downloads and executes a remote payload at build time. Simply compiling a project that depends on either crate is sufficient to trigger the infection.",
+            "advisories_url": "https://semgrep.dev/orgs/returntocorp/advisories?f=CAAQGRoHGgAiACoBQw",
+            "blog_url": "https://semgrep.dev/blog/2026/rust-crates-arrayref-append-only-vec-compromised-proc-macro1/",
+            "is_affected": true,
+            "incident_packages": {
+                "items": [
+                    {
+                        "name": "append-only-vec",
+                        "version": "==0.1.9",
+                        "ecosystem": "cargo"
+                    },
+                    {
+                        "name": "arrayref",
+                        "version": "==0.3.10",
+                        "ecosystem": "cargo"
+                    },
+                    {
+                        "name": "proc-macro-en",
+                        "version": "==1.0.10",
+                        "ecosystem": "cargo"
+                    },
+                    {
+                        "name": "proc-macro1",
+                        "version": "==1.0.107",
+                        "ecosystem": "cargo"
+                    },
+                ],
+                "total_count": 4,
+                "truncated": false
+            },
+            "matching_projects": {
+                "items": [
+                    {
+                        "repository_id": 1234,
+                        "repository_name": "semgrep/example-repo-1"
+                    },
+                    {
+                        "repository_id": 5678,
+                        "repository_name": "semgrep/example-repo-2"
+                    }
+                ],
+                "total_count": 2,
+                "truncated": false
+            },
+            "metadata": {
+                "dispatched_at": "2026-08-31T20:31:29.654203+00:00"
+            }
+        }
+    }
+]
+```
+
+<Note>
+**SCHEMA COMPATABILITY**
+
+Semgrep may add new fields to the payload at any time without changing the `schema_version`. Customers must ignore unrecognized fields. `schema_version` is only incremented for breaking changes, such as removing or renaming fields, or changing an existing field's type or meaning.
+</Note> 
+
+The `incident_packages` field details which dependencies are affected by an incident and `matching_projects` lists the projects that used those packages as of their last full scan. For large incidents or deployments with many projects, Semgrep truncates `items` and sets `truncated` while reporting the full number under `total_count`. Visit `advisories_url` for the most up-to-date information. 
+
+Each `incident_id` uniquely identifies an incident.
+
+The `description` and `blog_url` fields are optional and can be null. 
+

--- a/docs/semgrep-appsec-platform/webhooks.mdx
+++ b/docs/semgrep-appsec-platform/webhooks.mdx
@@ -269,7 +269,7 @@ The following is an example of a `semgrep_supply_chain_incident` object sent by 
                         "name": "proc-macro1",
                         "version": "==1.0.107",
                         "ecosystem": "cargo"
-                    },
+                    }
                 ],
                 "total_count": 4,
                 "truncated": false

--- a/docs/semgrep-appsec-platform/webhooks.mdx
+++ b/docs/semgrep-appsec-platform/webhooks.mdx
@@ -12,12 +12,11 @@ description: "Webhooks are a generic method for Semgrep AppSec Platform to post 
 
 Semgrep sends three different types of JSON objects:
 
-* **`semgrep_scan`**: Information about the CI job and other scan parameters, such as ignored files.
-  * Sent **every time a scan is run**, including diff-aware scans, full scans, and scans that have no findings.
-* **`semgrep_finding`**: A single record of a new finding.
-  * Sent based on how you have configured your notifications in Unified Policies. See [Create a remediation policy](/semgrep-appsec-platform/unified-policies/get-started#create-a-remediation-policy).
-* **`semgrep_supply_chain_incident`**: Information about a Supply Chain incident declared by Semgrep's Security Research team, including whether any of your projects are affected.
-  * Sent if configured for the **Early notification for Supply Chain incidents** policy. See [Supply Chain incidents](/semgrep-supply-chain/incident-notifications).
+| Object | Description | When it's sent |
+| --- | --- | --- |
+| `semgrep_scan` | Information about the CI job and other scan parameters, such as ignored files. | **Every time a scan is run**, including diff-aware scans, full scans, and scans that have no findings. |
+| `semgrep_finding` | A single record of a new finding. | Based on how you have configured your notifications in Unified Policies. See [Create a remediation policy](/semgrep-appsec-platform/unified-policies/get-started#create-a-remediation-policy). |
+| `semgrep_supply_chain_incident` | Information about a Supply Chain incident declared by Semgrep's Security Research team, including whether any of your projects are affected. | If configured for the **Early notification for Supply Chain incidents** policy. See [Supply Chain incidents](/semgrep-supply-chain/incident-notifications). |
 
 ## Set up webhooks
 

--- a/docs/semgrep-appsec-platform/webhooks.mdx
+++ b/docs/semgrep-appsec-platform/webhooks.mdx
@@ -10,7 +10,7 @@ description: "Webhooks are a generic method for Semgrep AppSec Platform to post 
 - To integrate with Slack, use the [Semgrep Slack app](/semgrep-appsec-platform/slack-notifications). The webhook setup described in this guide does not work for Slack integrations.
 </Tip>
 
-Semgrep sends three different types of JSON objects:
+Semgrep sends three types of JSON objects:
 
 | Object | Description | When it's sent |
 | --- | --- | --- |

--- a/docs/semgrep-appsec-platform/webhooks.mdx
+++ b/docs/semgrep-appsec-platform/webhooks.mdx
@@ -233,7 +233,7 @@ The following is an example of a `semgrep_scan` object sent by Semgrep:
 
 ## Semgrep supply chain incident object
 
-The following is an example of a `semgrep_supply_chain_incident` object sent by Semgrep:
+The following example shows a `semgrep_supply_chain_incident` object sent by Semgrep:
 
 ```json expandable
 [

--- a/docs/semgrep-appsec-platform/webhooks.mdx
+++ b/docs/semgrep-appsec-platform/webhooks.mdx
@@ -298,7 +298,7 @@ The following example shows a `semgrep_supply_chain_incident` object sent by Sem
 <Note>
 **SCHEMA COMPATABILITY**
 
-Semgrep may add new fields to the payload at any time without changing the `schema_version`. Customers must ignore unrecognized fields. `schema_version` is only incremented for breaking changes, such as removing or renaming fields, or changing an existing field's type or meaning.
+Semgrep may add new fields to the payload at any time without changing the `schema_version`. Configure your webhook endpoint to ignore unrecognized fields. Semgrep increments the `schema_version` only for breaking changes, such as removing or renaming fields, or changing the type or meaning of an existing field.
 </Note> 
 
 The `incident_packages` field details which dependencies are affected by an incident and `matching_projects` lists the projects that used those packages as of their last full scan. For large incidents or deployments with many projects, Semgrep truncates `items` and sets `truncated` while reporting the full number under `total_count`. Visit `advisories_url` for the most up-to-date information. 

--- a/docs/semgrep-supply-chain/incident-notifications.mdx
+++ b/docs/semgrep-supply-chain/incident-notifications.mdx
@@ -6,7 +6,7 @@ description: "Get notifications when Semgrep declares a new Supply Chain inciden
 
 Semgrep's Security Research team monitors the open source ecosystem and responds in real time when a package is compromised, publishing an [Advisory](/semgrep-supply-chain/advisories) as soon as an incident is confirmed.
 
-If you've configured the **Early notification for Supply Chain incidents** policy, Semgrep automatically posts to a Slack channel or webhook of your choosing within minutes of declaring the incident. You don't have to look for the news yourself: Semgrep checks the compromised package versions against your projects' most recent dependency data and tells you whether any of them are affected in the same notification.
+If you've configured the **Early notification for Supply Chain incidents** policy, Semgrep automatically posts to a Slack channel or webhook of your choosing within minutes of declaring the incident. Semgrep checks the compromised package versions against your projects' most recent dependency data and tells you whether any of them are affected in the same notification. 
 
 You are notified every time Semgrep declares a new supply chain incident, whether or not any of your projects use the affected packages.
 

--- a/docs/semgrep-supply-chain/incident-notifications.mdx
+++ b/docs/semgrep-supply-chain/incident-notifications.mdx
@@ -1,19 +1,19 @@
 ---
 title: "Supply Chain incident notifications and response"
 sidebarTitle: "Get Supply Chain incident notifications"
-description: "Get notifications in Slack when Semgrep declares a new Supply Chain incident, learn whether it affects your projects, and respond."
+description: "Get notifications when Semgrep declares a new Supply Chain incident, learn whether it affects your projects, and respond."
 ---
 
 Semgrep's Security Research team monitors the open source ecosystem and responds in real time when a package is compromised, publishing an [Advisory](/semgrep-supply-chain/advisories) as soon as an incident is confirmed.
 
-If you've configured the **Early notification for Supply Chain incidents** policy, Semgrep automatically posts to a Slack channel of your choosing within minutes of declaring the incident. You don't have to look for the news yourself: Semgrep checks the compromised package versions against your projects' most recent dependency data and tells you whether any of them are affected in the same notification.
+If you've configured the **Early notification for Supply Chain incidents** policy, Semgrep automatically posts to a Slack channel or webhook of your choosing within minutes of declaring the incident. You don't have to look for the news yourself: Semgrep checks the compromised package versions against your projects' most recent dependency data and tells you whether any of them are affected in the same notification.
 
 You are notified every time Semgrep declares a new supply chain incident, whether or not any of your projects use the affected packages.
 
 ## Prerequisites
 
 Ensure that: 
-* You have enabled [Slack notifications from Semgrep](/semgrep-appsec-platform/slack-notifications).
+* You have either enabled [Slack notifications](/semgrep-appsec-platform/slack-notifications) or set up [webhooks](/semgrep-appsec-platform/webhooks).
 * Your organization uses [Unified Policies](/semgrep-appsec-platform/unified-policies/overview).
 
 ## Set up incident notifications
@@ -23,9 +23,7 @@ Ensure that:
 </Frame>
 
 <Steps>
-<Step>
-In your Slack workspace, find or create a channel for Semgrep notifications. Then, run `/semgrep_add_channel` in the channel to make it available to your policies. See [Receive Slack notifications](/semgrep-appsec-platform/slack-notifications#set-up-notifications-for-findings-in-slack) for more information.
-</Step>
+
 <Step>
 In Semgrep AppSec Platform, go to **Rules & Policies > Policies**.
 </Step>
@@ -33,7 +31,21 @@ In Semgrep AppSec Platform, go to **Rules & Policies > Policies**.
 Find the policy named **Early notification for Supply Chain incidents**. Click its **<Icon icon="ellipsis" /> icon**, then select **Edit policy**.
 </Step>
 <Step>
-Go to **Actions**. Click **Add action > Send a Slack message**, and select the Slack channel you configured at the beginning of the setup process.
+Set up which **Actions** occur when a Supply Chain incident is declared by clicking on the **Add action** button. You can choose multiple **Actions**, including: 
+<CardGroup>  
+  <Card
+  title="Send a Slack message"
+  icon="paper-plane"
+  href="/semgrep-appsec-platform/slack-notifications"
+  horizontal
+  />
+  <Card
+  title="Call a webhook"
+  icon="globe"
+  href="/semgrep-appsec-platform/webhooks"
+  horizontal
+  />
+</CardGroup>
 </Step>
 <Step>
 Click **Update**.

--- a/docs/semgrep-supply-chain/incident-response.mdx
+++ b/docs/semgrep-supply-chain/incident-response.mdx
@@ -5,7 +5,7 @@ description: "How to respond to a malicious dependency incident using Semgrep Su
 
 ## 0. Configure notifications for supply chain incidents
 
-Configure [Supply Chain incident notifications and response](/semgrep-supply-chain/incident-notifications) so Semgrep proactively posts to Slack within minutes of declaring an incident and tells you whether any of your projects are affected. If you've already set this up, you can skip the following manual steps and go straight to the notification's **View incident advisories** button.
+Configure [Supply Chain incident notifications and response](/semgrep-supply-chain/incident-notifications) so Semgrep posts to Slack or a webhook within minutes of declaring an incident and tells you whether any of your projects are affected. If you've already set this up, you can skip the following manual steps and go straight to the notification's **View incident advisories** button.
 
 The rest of this document describes the manual process, which is useful if you haven't configured notifications or want to investigate a package independently of an automatic notification.
 

--- a/docs/semgrep-supply-chain/overview.mdx
+++ b/docs/semgrep-supply-chain/overview.mdx
@@ -90,7 +90,7 @@ Policies, which are scoped on a per-project basis, allow you to define the condi
 
 Semgrep can [detect malicious dependencies](/semgrep-supply-chain/malicious-dependencies), which are treated as critical severity findings. If you have set up your [policies](/semgrep-appsec-platform/unified-policies/overview) to block critical severity findings, Semgrep prevents developers from merging pull requests or merge requests with malicious dependencies.
 
-You can also configure [Supply Chain incident notifications](/semgrep-supply-chain/incident-notifications) to get notified in Slack within minutes whenever Semgrep declares a new Supply Chain incident and whether it affects your projects.
+You can also configure [Supply Chain incident notifications](/semgrep-supply-chain/incident-notifications) to get notified within minutes whenever Semgrep declares a new Supply Chain incident, including whether it affects your projects.
 
 ### Dependency search
 


### PR DESCRIPTION
Updates docs to include that webhooks can be configured for Supply Chain incidents. 

Closes SC-3838

### Thanks for improving Semgrep Docs

Please ensure:

- [X] A subject matter expert reviews the content
- [X] A technical writer reviews the PR
- [X] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
