### PR TITLE
fix bitbucket header on missing PR comments page

### DIFF
--- a/docs/kb/semgrep-appsec-platform/missing-pr-comments.mdx
+++ b/docs/kb/semgrep-appsec-platform/missing-pr-comments.mdx
@@ -47,7 +47,7 @@ The GitLab token should have `api` scope. See [Enable GitLab merge request comme
 
 The `api` scoped token must be provided to Semgrep through the SCM connection. Semgrep no longer supports tokens provided in the GitLab CI/CD pipeline.
 
-#### Bitbucket
+### Bitbucket
 
 The Bitbucket token must be a repository access token or a workspace access token. See [Enable Bitbucket pull request comments](/category/bitbucket-pr-comments) for details.
 


### PR DESCRIPTION
I noticed this when I was reviewing another change - Bitbucket got nested under GitLab.

<img width="286" height="191" alt="CleanShot 2026-08-25 at 13 18 18" src="https://github.com/user-attachments/assets/4daddf06-63a2-4beb-897c-1be1ddf30e98" />


Please ensure:

- [ ] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
