### PR TITLE
Correct joining steps for both SCM & SSO

### DIFF
--- a/docs/deployment/create-account-and-orgs.mdx
+++ b/docs/deployment/create-account-and-orgs.mdx
@@ -244,7 +244,7 @@ Click **Join organization**.
 <Tip>
 **TIP**
 
-Semgrep admins can also [send developers invites to join their Semgrep org](/deployment/teams/manage#invite-a-user-through-email). Invites streamline the process of joining the org, but access via the authentication provider is still a pre-requisite for joining.
+Semgrep admins can also [send developers invites to join their Semgrep org](/deployment/teams/manage#invite-a-user-through-email). An invite makes it easier to join the org, but developers must still have access through the authentication provider.
 </Tip>
 
 ### Delete an existing org

--- a/docs/deployment/create-account-and-orgs.mdx
+++ b/docs/deployment/create-account-and-orgs.mdx
@@ -211,7 +211,7 @@ Click the organization name displayed at the top of the **navigation bar** to ex
 Click **Add org > Join an organization**.
 </Step>
 <Step>
-Provide the name of the organization you'd like to join. Then, click **Join**.
+Provide the slug of the organization you'd like to join. You can get this value from an organization admin. Then, click **Join**.
 </Step>
 </Steps>
 </Tab>
@@ -223,7 +223,19 @@ To join an existing org through your SSO provider:
 Sign in to [ Semgrep AppSec Platform](https://semgrep.dev/login) with the account credentials specified by your admin.
 </Step>
 <Step>
-You are automatically signed in to all organizations that your admin has set up for you.
+You are automatically signed in to the primary organization that your admin has set up for you.
+</Step>
+<Step>
+To join additional organizations, click the organization name displayed at the top of the **navigation bar** to expand the drop-down menu.
+</Step>
+<Step>
+Click **Add org > Join an organization**.
+</Step>
+<Step>
+Select an organization from the list of organizations to join.
+</Step>
+<Step>
+Click **Join organization**.
 </Step>
 </Steps>
 </Tab>

--- a/docs/deployment/create-account-and-orgs.mdx
+++ b/docs/deployment/create-account-and-orgs.mdx
@@ -244,7 +244,7 @@ Click **Join organization**.
 <Tip>
 **TIP**
 
-Semgrep admins can also [send developers invites to join their Semgrep org](/deployment/teams/manage#invite-a-user-through-email).
+Semgrep admins can also [send developers invites to join their Semgrep org](/deployment/teams/manage#invite-a-user-through-email). Invites streamline the process of joining the org, but access via the authentication provider is still a pre-requisite for joining.
 </Tip>
 
 ### Delete an existing org


### PR DESCRIPTION
Since user join "V2" the steps to join an org are a little different. I've tested these but recommend having an auth SME review (someone from Platform Services). Also make sure it's clear that invites streamline the process but don't bypass it.

Please ensure:

- [ ] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [x] This change has no security implications - although it describes org access processes, it doesn't change them or provide any non-public details
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
