### PR TITLE
Cover removed & replaced findings

### DIFF
--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -50,6 +50,7 @@ Findings can also be **removed**. Semgrep considers a finding removed if it is n
 
 - The rule that detected the finding is no longer enabled in the policy.
 - The rule that detected the finding was updated in a way that it no longer detects the finding.
+- The rule that detected the finding was updated and still matches the code, but identifies the issue as a [new finding](/semgrep-code/remove-duplicates#how-semgrep-distinguishes-between-new-and-duplicate-findings). The original finding is marked as **Removed** and a new finding is opened with the new version of the rule.
 - The file path where the finding appeared is no longer found. The file path was deleted, renamed, added to a `.semgrepignore` file, added to a `.gitignore` file, or added to the list of ignored paths in Semgrep AppSec Platform.
 - For GitHub organization accounts: the pull request or merge request where the finding was detected has been closed without merging.
 

--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -54,8 +54,6 @@ Findings can also be **removed**. Semgrep considers a finding removed if it is n
 - The file path where the finding appeared is no longer found. The file path was deleted, renamed, added to a `.semgrepignore` file, added to a `.gitignore` file, or added to the list of ignored paths in Semgrep AppSec Platform.
 - For GitHub organization accounts: the pull request or merge request where the finding was detected has been closed without merging.
 
-Additionally, if the rule that detected the finding is updated in such a way that the matched pattern significantly changes, new findings will be opened for that rule in the next scan, and the older findings will be marked removed. Essentially, the new findings supersede the old findings.
-
 Your removed findings do not count toward the fix rate or the number of findings. The removed findings also do not appear in Semgrep AppSec Platform.
 
 ### Triage behavior across refs and branches

--- a/docs/semgrep-code/triage-remediation.mdx
+++ b/docs/semgrep-code/triage-remediation.mdx
@@ -53,6 +53,8 @@ Findings can also be **removed**. Semgrep considers a finding removed if it is n
 - The file path where the finding appeared is no longer found. The file path was deleted, renamed, added to a `.semgrepignore` file, added to a `.gitignore` file, or added to the list of ignored paths in Semgrep AppSec Platform.
 - For GitHub organization accounts: the pull request or merge request where the finding was detected has been closed without merging.
 
+Additionally, if the rule that detected the finding is updated in such a way that the matched pattern significantly changes, new findings will be opened for that rule in the next scan, and the older findings will be marked removed. Essentially, the new findings supersede the old findings.
+
 Your removed findings do not count toward the fix rate or the number of findings. The removed findings also do not appear in Semgrep AppSec Platform.
 
 ### Triage behavior across refs and branches


### PR DESCRIPTION
We had a bullet point covering findings no longer detected due to rule change, but not one explaining that rule changes can also lead to findings being removed but also replaced. If you have a way of saying that which would fit in a bullet, I'm very open to it!

Please ensure:

- [x] A subject matter expert reviews the content (it me)
- [x] A technical writer reviews the PR
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
