### PR TITLE
mark exception requests feature as beta

### DIFF
--- a/docs/semgrep-appsec-platform/developer-exception-requests.mdx
+++ b/docs/semgrep-appsec-platform/developer-exception-requests.mdx
@@ -46,7 +46,7 @@ Developer exception requests is a Semgrep feature that allows you to request tha
     ## Review responses to your requests
 
     **For requests initiated in a PR or MR comment:** Once an admin has reviewed and responded to your request, Semgrep posts a follow-up comment to the existing PR or MR comment thread.
-
+    
     If the admin has **approved** your request and the finding involved was a blocking finding, you can rescan your PR or MR to unblock it. The finding's status in Semgrep AppSec Platform also changes to **Ignored**. If the finding was *not* a blocking finding, the status of the finding in AppSec Platform changes to **Ignored**.
 
     If your request is **denied**, the PR comment informs you of this. The finding's status in Semgrep AppSec Platform changes to **To fix**, indicating that you must address the finding before proceeding.
@@ -59,10 +59,10 @@ Developer exception requests is a Semgrep feature that allows you to request tha
     ## Enable developer exception requests
 
     To enable exception requests:
-
+    
     1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) with an admin account.
     1. Go to [**Rules & Policies > Policies**](https://semgrep.dev/orgs/-/policies), and ensure that you're on the **Remediation** tab.
-    1. [Create a new remediation policy](/semgrep-appsec-platform/unified-policies/get-started#create-a-remediation-policy), or modify an existing remediation policy by finding the policy of interest, then clicking **<Icon icon="ellipsis" /> icon** to open the policy definition.
+    1. [Create a new remediation policy](/semgrep-appsec-platform/unified-policies/get-started#create-a-remediation-policy), or modify an existing remediation policy by finding the policy of interest, then clicking **<Icon icon="ellipsis" /> icon** to open the policy definition. 
     1. In the policy defintion, go to **Action**. Then, ensure that one of the actions you select is **Require developer exception requests** and you provide the handle of the person who approves the requests.
 
     Once you enable exception requests:
@@ -74,7 +74,7 @@ Developer exception requests is a Semgrep feature that allows you to request tha
 
     Semgrep admins can review and approve or deny exception requests in Semgrep AppSec Platform.
 
-    1. Log in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login). Ensure that the account you're using has been granted admin privileges.
+    1. Log in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login). Ensure that the account you're using has been granted admin privileges. 
     1. Go to the **Findings** page for the product of interest: [Code](https://semgrep.dev/orgs/-/findings), [Supply Chain](https://semgrep.dev/orgs/-/supply-chain), or [Secrets](https://semgrep.dev/orgs/-/secrets).
     1. Click on the **Pending approval** tab to view all pending requests.
 
@@ -83,5 +83,4 @@ Developer exception requests is a Semgrep feature that allows you to request tha
     When you deny an exception request, Semgrep posts a new comment to the PR or MR to inform the developer that their request was denied. The finding's status in Semgrep AppSec Platform changes to **To fix** to indicate that the finding must be addressed through code changes.
 
     </Tab>
-
 </Tabs>

--- a/docs/semgrep-appsec-platform/developer-exception-requests.mdx
+++ b/docs/semgrep-appsec-platform/developer-exception-requests.mdx
@@ -1,5 +1,5 @@
 ---
-title: Developer exception requests
+title: Developer exception requests (beta)
 ---
 
 Developer exception requests is a Semgrep feature that allows you to request that a finding be triaged as **Ignored** if you think it is safe to ignore, a false positive, or an acceptable risk.
@@ -46,7 +46,7 @@ Developer exception requests is a Semgrep feature that allows you to request tha
     ## Review responses to your requests
 
     **For requests initiated in a PR or MR comment:** Once an admin has reviewed and responded to your request, Semgrep posts a follow-up comment to the existing PR or MR comment thread.
-    
+
     If the admin has **approved** your request and the finding involved was a blocking finding, you can rescan your PR or MR to unblock it. The finding's status in Semgrep AppSec Platform also changes to **Ignored**. If the finding was *not* a blocking finding, the status of the finding in AppSec Platform changes to **Ignored**.
 
     If your request is **denied**, the PR comment informs you of this. The finding's status in Semgrep AppSec Platform changes to **To fix**, indicating that you must address the finding before proceeding.
@@ -59,10 +59,10 @@ Developer exception requests is a Semgrep feature that allows you to request tha
     ## Enable developer exception requests
 
     To enable exception requests:
-    
+
     1. Sign in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login) with an admin account.
     1. Go to [**Rules & Policies > Policies**](https://semgrep.dev/orgs/-/policies), and ensure that you're on the **Remediation** tab.
-    1. [Create a new remediation policy](/semgrep-appsec-platform/unified-policies/get-started#create-a-remediation-policy), or modify an existing remediation policy by finding the policy of interest, then clicking **<Icon icon="ellipsis" /> icon** to open the policy definition. 
+    1. [Create a new remediation policy](/semgrep-appsec-platform/unified-policies/get-started#create-a-remediation-policy), or modify an existing remediation policy by finding the policy of interest, then clicking **<Icon icon="ellipsis" /> icon** to open the policy definition.
     1. In the policy defintion, go to **Action**. Then, ensure that one of the actions you select is **Require developer exception requests** and you provide the handle of the person who approves the requests.
 
     Once you enable exception requests:
@@ -74,7 +74,7 @@ Developer exception requests is a Semgrep feature that allows you to request tha
 
     Semgrep admins can review and approve or deny exception requests in Semgrep AppSec Platform.
 
-    1. Log in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login). Ensure that the account you're using has been granted admin privileges. 
+    1. Log in to [<i class="fas fa-external-link fa-xs"></i> Semgrep AppSec Platform](https://semgrep.dev/login). Ensure that the account you're using has been granted admin privileges.
     1. Go to the **Findings** page for the product of interest: [Code](https://semgrep.dev/orgs/-/findings), [Supply Chain](https://semgrep.dev/orgs/-/supply-chain), or [Secrets](https://semgrep.dev/orgs/-/secrets).
     1. Click on the **Pending approval** tab to view all pending requests.
 
@@ -83,4 +83,5 @@ Developer exception requests is a Semgrep feature that allows you to request tha
     When you deny an exception request, Semgrep posts a new comment to the PR or MR to inform the developer that their request was denied. The finding's status in Semgrep AppSec Platform changes to **To fix** to indicate that the finding must be addressed through code changes.
 
     </Tab>
+
 </Tabs>

--- a/docs/semgrep-appsec-platform/unified-policies/get-started.mdx
+++ b/docs/semgrep-appsec-platform/unified-policies/get-started.mdx
@@ -28,9 +28,7 @@ When you have completed the migration process, you are redirected to the new **P
 </Steps>
 
 <note>
-  <strong>Note:</strong> Email notifications are not supported by Unified
-  Policies. If you currently have an email integration set up, no additional
-  emails will be sent after you migrate to Unified Policies.
+  <strong>Note:</strong> Email notifications are not supported by Unified Policies. If you currently have an email integration set up, no additional emails will be sent after you migrate to Unified Policies.
 </note>
 
 ## Create a remediation policy
@@ -91,9 +89,9 @@ To create a policy that defines the automated responses to security findings:
          />
       </CardGroup>
 
-1.  Click **Create & Enable** to save and proceed, so that Semgrep uses your new policy the next time you scan a project within its scope. Otherwise, click **Create** to save your changes without enabling the policy.
-    </Step>
-    </Steps>
+   1. Click **Create & Enable** to save and proceed, so that Semgrep uses your new policy the next time you scan a project within its scope. Otherwise, click **Create** to save your changes without enabling the policy.
+</Step>
+</Steps>
 
 ## Configure default remediation policies
 
@@ -168,7 +166,7 @@ On the **Edit policy** page, you can:
 - Define the **Scope**, which is the set of projects to which the policy applies.
 - Define the **Conditions** that trigger the policy.
 - Choose the **Actions** that occur if there are findings that trigger the policy.
-    </Step>
+</Step>
 <Step>
 Click **Update** to save and proceed.
 </Step>

--- a/docs/semgrep-appsec-platform/unified-policies/get-started.mdx
+++ b/docs/semgrep-appsec-platform/unified-policies/get-started.mdx
@@ -28,7 +28,9 @@ When you have completed the migration process, you are redirected to the new **P
 </Steps>
 
 <note>
-  <strong>Note:</strong> Email notifications are not supported by Unified Policies. If you currently have an email integration set up, no additional emails will be sent after you migrate to Unified Policies.
+  <strong>Note:</strong> Email notifications are not supported by Unified
+  Policies. If you currently have an email integration set up, no additional
+  emails will be sent after you migrate to Unified Policies.
 </note>
 
 ## Create a remediation policy
@@ -82,16 +84,16 @@ To create a policy that defines the automated responses to security findings:
          horizontal
          />
          <Card
-         title="Require developer exception requests"
+         title="Require developer exception requests (beta)"
          icon="lock-open"
          href="/semgrep-appsec-platform/developer-exception-requests"
          horizontal
          />
       </CardGroup>
 
-   1. Click **Create & Enable** to save and proceed, so that Semgrep uses your new policy the next time you scan a project within its scope. Otherwise, click **Create** to save your changes without enabling the policy.
-</Step>
-</Steps>
+1.  Click **Create & Enable** to save and proceed, so that Semgrep uses your new policy the next time you scan a project within its scope. Otherwise, click **Create** to save your changes without enabling the policy.
+    </Step>
+    </Steps>
 
 ## Configure default remediation policies
 
@@ -166,7 +168,7 @@ On the **Edit policy** page, you can:
 - Define the **Scope**, which is the set of projects to which the policy applies.
 - Define the **Conditions** that trigger the policy.
 - Choose the **Actions** that occur if there are findings that trigger the policy.
-</Step>
+    </Step>
 <Step>
 Click **Update** to save and proceed.
 </Step>


### PR DESCRIPTION
Atul spotted that we aren't marking this feature as beta! `(beta)` seems to be the standard for this. I added it to the title on the exception request page and in the getting started card.

Please ensure:

- [ ] A subject matter expert reviews the content
- [x] A technical writer reviews the PR
- [ ] This change has no security implications or else you have pinged the security team
- [ ] Any redirects are in `docs/docs.json` if URLs changed
- [ ] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
