### PR TITLE
docs(malware-firewall private beta): Add Java support

### DIFF
--- a/docs/semgrep-supply-chain/malware-firewall.mdx
+++ b/docs/semgrep-supply-chain/malware-firewall.mdx
@@ -17,7 +17,7 @@ The Semgrep Malware Firewall prevents malicious packages from being installed on
 The firewall has the following parts:
 
 1. A lightweight **client proxy** that runs on every machine. 
-    - You set it up once with `mfw install`. For most package managers, it sets the standard proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` so they respect it automatically—no per-tool configuration is needed. For example, you don't need to set up `tool.uv.index` manually for `uv`. Java build tools (Maven and Gradle) are handled differently, because the JVM ignores those environment variables—see the note below.
+    - You set it up once with `mfw install`. For most package managers, it sets the standard proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` so they respect it automatically; no per-tool configuration is needed. For example, you don't need to set up `tool.uv.index` manually for `uv`. Java build tools (Maven and Gradle) are handled differently, because the JVM ignores those environment variables.
     - It watches traffic to known package registry URLs such as `registry.npmjs.org` (npm) and `repo.maven.apache.org` (Maven Central), identifies package-download requests specifically—including tarballs, wheels, JARs, and similar artifacts—and gates those artifact requests on a response from the Semgrep backend before the download completes. 
     - All other traffic is proxied through transparently.
 2. The Semgrep-operated **malware firewall backend**, which receives requests from the local proxy containing an ecosystem, package name, and version, and replies with a verdict.

--- a/docs/semgrep-supply-chain/malware-firewall.mdx
+++ b/docs/semgrep-supply-chain/malware-firewall.mdx
@@ -17,11 +17,15 @@ The Semgrep Malware Firewall prevents malicious packages from being installed on
 The firewall has the following parts:
 
 1. A lightweight **client proxy** that runs on every machine. 
-    - You set it up once with `mfw install`. It sets the standard proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` so package managers respect it automatically—no per-tool configuration is needed. For example, you don't need to set up `tool.uv.index` manually for `uv`. 
-    - It watches traffic to known package registry URLs such as `registry.npmjs.org`, identifies package-download requests specifically—including tarballs, wheels, and similar artifacts—and gates those artifact requests on a response from the Semgrep backend before the download completes. 
+    - You set it up once with `mfw install`. For most package managers, it sets the standard proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` so they respect it automatically—no per-tool configuration is needed. For example, you don't need to set up `tool.uv.index` manually for `uv`. Java build tools (Maven and Gradle) are handled differently, because the JVM ignores those environment variables—see the note below.
+    - It watches traffic to known package registry URLs such as `registry.npmjs.org` (npm) and `repo.maven.apache.org` (Maven Central), identifies package-download requests specifically—including tarballs, wheels, JARs, and similar artifacts—and gates those artifact requests on a response from the Semgrep backend before the download completes. 
     - All other traffic is proxied through transparently.
 2. The Semgrep-operated **malware firewall backend**, which receives requests from the local proxy containing an ecosystem, package name, and version, and replies with a verdict.
 3. The **malware database** that is continuously updated from a variety of threat feeds and maintained by Semgrep's security research team. 
+
+<Note>
+Java build tools don't read `HTTP_PROXY` or `HTTPS_PROXY`, so `mfw` routes Maven and Gradle through their command-line shims instead: Maven through a generated `--global-settings` file, and Gradle through JVM proxy system properties, both applied automatically on each run. You still don't configure anything by hand, but only `mvn` and `gradle` commands run through your shell are gated. If a build already sets its own proxy—for example a `systemProp.https.proxyHost` in `gradle.properties`, or an active `<proxy>` in your Maven `settings.xml`—`mfw` leaves that run ungated rather than override it. Because Gradle keys its cache by checksum, dependencies already in `~/.gradle/caches` aren't re-fetched, so coverage starts at the next cache miss.
+</Note>
 
 The request cycle:
 
@@ -52,7 +56,7 @@ Semgrep AppSec Platform shows basic firewall reporting, including scanned and bl
 
 ## Supported languages
 
-The firewall works with projects written in Go, JavaScript, Python, and Rust.
+The firewall works with projects written in Go, Java, JavaScript, Python, and Rust. Java support covers both Maven and Gradle.
 
 ## Install and verify
 
@@ -145,14 +149,21 @@ Use a known-safe demo package to confirm that the firewall blocks malicious inst
 
 Both these packages should be blocked by the Semgrep Malware Firewall. If either install succeeds, the firewall isn't intercepting traffic correctly. Review the `mfw doctor` output, and see [Troubleshoot `mfw doctor` failures](#troubleshoot-mfw-doctor-failures).
 
+<Note>
+The demo malware package is published to PyPI only. There's no equivalent artifact on Maven Central yet, so Java (Maven and Gradle) installs can't be checked with a demo package. Use `mfw doctor` to confirm the firewall is active, and see [Determine whether a specific dependency version is malicious](#determine-whether-a-specific-dependency-version-is-malicious) to query the backend for a specific Maven coordinate.
+</Note>
+
 ## Determine whether a specific dependency version is malicious
 
 The `mfw api` command can be used to determine if a specific version of a package is malicious:
 
 ```bash
-mfw api command <ecosystem> <package_name> <version>
-# example usage: mfw api pypi pydantic 2.13.4
+mfw api <ecosystem> <package_name> <version>
+# Python example: mfw api pypi pydantic 2.13.4
+# Java example:   mfw api maven com.google.guava:guava 33.0.0-jre
 ```
+
+For Java, the ecosystem is `maven` (for both Maven and Gradle projects) and the package name is the `groupId:artifactId` coordinate, such as `com.google.guava:guava`.
 
 ## Uninstall the firewall
 

--- a/docs/semgrep-supply-chain/malware-firewall.mdx
+++ b/docs/semgrep-supply-chain/malware-firewall.mdx
@@ -4,63 +4,39 @@ description: "The Semgrep Malware Firewall prevents malicious packages from bein
 hidden: true
 ---
 
-<Note>
-Semgrep Malware Firewall is in **private beta**.
-</Note>
-
 ## Overview
 
-The Semgrep Malware Firewall prevents malicious packages from being installed on your machine. It sits in front of your package installs, checks each requested package against Semgrep's continuously updated database of known malware, and blocks anything that matches.
-
-## How it works
-
-The firewall has the following parts:
-
-1. A lightweight **client proxy** that runs on every machine. 
-    - You set it up once with `mfw install`. For most package managers, it sets the standard proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` so they respect it automatically; no per-tool configuration is needed. For example, you don't need to set up `tool.uv.index` manually for `uv`. Java build tools (Maven and Gradle) are handled differently, because the JVM ignores those environment variables.
-    - It watches traffic to known package registry URLs such as `registry.npmjs.org` (npm) and `repo.maven.apache.org` (Maven Central), identifies package-download requests specifically—including tarballs, wheels, JARs, and similar artifacts—and gates those artifact requests on a response from the Semgrep backend before the download completes. 
-    - All other traffic is proxied through transparently.
-2. The Semgrep-operated **malware firewall backend**, which receives requests from the local proxy containing an ecosystem, package name, and version, and replies with a verdict.
-3. The **malware database** that is continuously updated from a variety of threat feeds and maintained by Semgrep's security research team. 
+The Semgrep Malware Firewall checks package downloads against Semgrep's continuously updated malware database and blocks known malicious packages before they install on your machine.
 
 <Note>
-Java build tools don't read `HTTP_PROXY` or `HTTPS_PROXY`, so `mfw` routes Maven and Gradle through their command-line shims instead: Maven through a generated `--global-settings` file, and Gradle through JVM proxy system properties, both applied automatically on each run. You still don't configure anything by hand, but only `mvn` and `gradle` commands run through your shell are gated. If a build already sets its own proxy—for example a `systemProp.https.proxyHost` in `gradle.properties`, or an active `<proxy>` in your Maven `settings.xml`—`mfw` leaves that run ungated rather than override it. Because Gradle keys its cache by checksum, dependencies already in `~/.gradle/caches` aren't re-fetched, so coverage starts at the next cache miss.
+Semgrep Malware Firewall is in **private beta**. To use it, you need an active Semgrep account and [Semgrep Guardian](/guardian) enabled. Contact [Semgrep Support](/support) if you need access.
 </Note>
 
-The request cycle:
-
-1. On install, the firewall runs `mfw login` to sign you in. Each verdict request is then authenticated with a short-lived bearer token.
-2. When you run a normal package install, the local proxy intercepts every package the installer tries to fetch.
-3. The proxy asks the Semgrep backend whether the specific version of that package is malicious.
-4. The backend matches the version to the malware database and returns a verdict.
-5. If the package is safe, the install proceeds normally. If it matches known malware, the proxy blocks the download and reports why.
-
-### Advisory and database sync objectives
-
-- For active, high-severity supply chain incidents, Semgrep's security research team works to issue and deploy an advisory as soon as a threat is identified rather than waiting for it to be published to sources like the [Open Source Vulnerabilities](https://osv.dev) (OSV) database.
-- For all other findings, the malware database syncs from OSV every 2 hours.
-
-### Cooldowns
-
-The firewall doesn't currently support configuring a cooldown period before a newly published package version can be installed. You can configure cooldowns at the package-manager level. See [cooldowns.dev](https://cooldowns.dev/) for a guide across ecosystems.
-
-## Reporting
-
-Semgrep AppSec Platform shows basic firewall reporting, including scanned and blocked dependencies, in the **Malware firewall** section of the **Dashboard**.
+The firewall runs locally on each developer machine as a lightweight client proxy. It sits in front of package installs and gates downloads on a verdict from Semgrep's backend.
 
 ## Prerequisites
 
-- You must have an active Semgrep account
-- You must have [Semgrep Guardian](/guardian) enabled
-- You must have access to a macOS or Linux terminal or shell
+To use the Semgrep Malware Firewall, you must meet the following requirements:
 
-## Supported languages
+- Have an active Semgrep account
+- Enable [Semgrep Guardian](/guardian)
+- Have access to a macOS or Linux terminal or shell
 
-The firewall works with projects written in Go, Java, JavaScript, Python, and Rust. Java support covers both Maven and Gradle.
+## Supported package managers
+
+The firewall monitors package-manager traffic to known registries, not source code in your repository. When a package manager fetches an artifact, the firewall checks the specific package version before the download completes.
+
+| Ecosystem | Package managers | Limitations |
+| :--- | :--- | :--- |
+| JavaScript | npm and other package managers that respect `HTTP_PROXY` and `HTTPS_PROXY` | None |
+| Python | `pip`, `uv` | Demo test package is available on PyPI only |
+| Java | Maven (`mvn`), Gradle | Doesn't use proxy environment variables. See [Maven and Gradle proxy behavior](#maven-and-gradle-proxy-behavior). |
+| Go | Go modules (`go`) | None |
+| Rust | Cargo | None |
 
 ## Install and verify
 
-You can install the firewall with the Semgrep Guardian skill or manually with the install script. If you already use [Semgrep Guardian](/guardian), the `/install-mfw` skill is the quickest path — it installs and configures everything for you.
+You can install the firewall with the Semgrep Guardian skill or manually with the install script. If you already use [Semgrep Guardian](/guardian), the `/install-mfw` skill is the quickest path, which installs and configures everything for you.
 
 <Tabs>
   <Tab title="With Semgrep Guardian">
@@ -138,32 +114,97 @@ Use a known-safe demo package to confirm that the firewall blocks malicious inst
     <Step>
     **Expected result:** the install is blocked. The firewall should intercept and reject the package.
     </Step>
-    <Step>
-    To test with a second package manager, repeat with pip:
-
-    ```bash
-    pip install --no-cache semgrep-malware-demo-aws-cred-read
-    ```
-    </Step>
 </Steps>
 
-Both these packages should be blocked by the Semgrep Malware Firewall. If either install succeeds, the firewall isn't intercepting traffic correctly. Review the `mfw doctor` output, and see [Troubleshoot `mfw doctor` failures](#troubleshoot-mfw-doctor-failures).
+The install should be blocked by the Semgrep Malware Firewall. If the install succeeds, the firewall isn't intercepting traffic correctly. Review the `mfw doctor` output, and see [Troubleshooting](#troubleshooting).
 
-<Note>
-The demo malware package is published to PyPI only. There's no equivalent artifact on Maven Central yet, so Java (Maven and Gradle) installs can't be checked with a demo package. Use `mfw doctor` to confirm the firewall is active, and see [Determine whether a specific dependency version is malicious](#determine-whether-a-specific-dependency-version-is-malicious) to query the backend for a specific Maven coordinate.
-</Note>
-
-## Determine whether a specific dependency version is malicious
-
-The `mfw api` command can be used to determine if a specific version of a package is malicious:
+**Optional:** repeat the test with `pip`:
 
 ```bash
-mfw api <ecosystem> <package_name> <version>
-# Python example: mfw api pypi pydantic 2.13.4
-# Java example:   mfw api maven com.google.guava:guava 33.0.0-jre
+pip install --no-cache semgrep-malware-demo-aws-cred-read
+```
+
+If you run both tests, both installation attempts should be blocked.
+
+<Note>
+The demo malware package is published to PyPI only. There's no equivalent artifact on Maven Central yet, so Java (Maven and Gradle) installs can't be checked with a demo package. Use `mfw doctor` to confirm the firewall is active, and see [Check a dependency](#check-a-dependency) to query the backend for a specific Maven coordinate.
+</Note>
+
+## Check a dependency
+
+Use `mfw api` to determine whether a specific version of a package is malicious.
+
+**Python example:**
+
+```bash
+mfw api pypi pydantic 2.13.4
+```
+
+**Java example:**
+
+```bash
+mfw api maven com.google.guava:guava 33.0.0-jre
 ```
 
 For Java, the ecosystem is `maven` (for both Maven and Gradle projects) and the package name is the `groupId:artifactId` coordinate, such as `com.google.guava:guava`.
+
+## View firewall activity
+
+Semgrep AppSec Platform shows basic firewall reporting, including scanned and blocked dependencies, in the **Malware firewall** section of the **Dashboard**.
+
+## How the firewall works
+
+The firewall has three parts:
+
+1. A lightweight **client proxy** that runs on every machine. You set it up once with `mfw install`. For most package managers, it sets the standard proxy environment variables `HTTP_PROXY` and `HTTPS_PROXY` so they respect it automatically; no per-tool configuration is needed. For example, you don't need to set up `tool.uv.index` manually for `uv`. It watches traffic to known package registry URLs such as `registry.npmjs.org` (npm) and `repo.maven.apache.org` (Maven Central), identifies package-download requests (including tarballs, wheels, JARs, and similar artifacts), and gates those requests on a response from the Semgrep backend before the download completes. All other traffic is proxied through transparently.
+2. The Semgrep-operated **malware firewall backend**, which receives requests from the local proxy containing an ecosystem, package name, and version, and replies with a verdict.
+3. The **malware database**, continuously updated from a variety of threat feeds and maintained by Semgrep's security research team.
+
+### Request cycle
+
+1. On install, the firewall runs `mfw login` to sign you in. Each verdict request is then authenticated with a short-lived bearer token.
+2. When you run a normal package install, the local proxy intercepts every package the installer tries to fetch.
+3. The proxy asks the Semgrep backend whether the specific version of that package is malicious.
+4. The backend matches the version to the malware database and returns a verdict.
+5. If the package is safe, the install proceeds normally. If it matches known malware, the proxy blocks the download and reports why.
+
+## Limitations and special cases
+
+### Maven and Gradle proxy behavior
+
+Java build tools don't read `HTTP_PROXY` or `HTTPS_PROXY`. Instead, `mfw` routes them through command-line shims:
+
+- **Maven**: a generated `--global-settings` file, applied automatically on each run
+- **Gradle**: JVM proxy system properties, applied automatically on each run
+
+You still don't configure anything by hand. Only `mvn` and Gradle commands invoked from your shell are gated.
+
+### Existing Gradle dependencies aren't re-fetched
+
+Gradle keys its cache by checksum. Dependencies already in `~/.gradle/caches` aren't re-fetched, so coverage starts at the next cache miss.
+
+### User-configured proxies bypass gating
+
+If a build already sets its own proxy (for example, `systemProp.https.proxyHost` in `gradle.properties`, or an active `<proxy>` in your Maven `settings.xml`), `mfw` doesn't gate that run rather than override the existing configuration.
+
+### No built-in cooldown configuration
+
+The firewall doesn't currently support configuring a cooldown period before a newly published package version can be installed. You can configure cooldowns at the package-manager level. See [cooldowns.dev](https://cooldowns.dev/) for a guide across ecosystems.
+
+### How quickly malware data is updated
+
+- For active, high-severity supply chain incidents, Semgrep's security research team works to issue and deploy an advisory as soon as a threat is identified rather than waiting for it to be published to sources like the [Open Source Vulnerabilities](https://osv.dev) (OSV) database.
+- For all other findings, the malware database syncs from OSV every 2 hours.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Suggested fix |
+| :--- | :--- | :--- |
+| `mfw doctor` reports that the firewall isn't protecting the machine right after install | The shell wasn't restarted, so `HTTP_PROXY` and `HTTPS_PROXY` aren't set in the current session | Restart your terminal or shell, then re-run `mfw doctor` |
+| `mfw doctor` reports an authentication error | You haven't run `mfw login`, or the short-lived bearer token has expired | Run `mfw login` again |
+| Package installs are slow or time out | The local proxy can't reach the Semgrep verdict backend because of network or firewall rules that block egress | Confirm that outbound access to Semgrep's backend is allowed; review corporate proxy or VPN settings |
+| A known-safe package is unexpectedly blocked | The backend returned a stale or incorrect verdict, or a false-positive match in the malware database | Notify us in the [Semgrep Community Slack](https://go.semgrep.dev/slack) channel |
+| `mfw doctor` isn't found, or the command isn't recognized | The install script didn't complete, or the shell `PATH` wasn't updated | Re-run the install command from [Install and verify](#install-and-verify), then restart your shell |
 
 ## Uninstall the firewall
 
@@ -182,13 +223,3 @@ mfw doctor
 ```
 
 It should no longer report `Semgrep mfw is protecting this machine ✅`.
-
-## Troubleshoot `mfw doctor` failures
-
-| Symptom | Likely cause | Suggested fix |
-| :--- | :--- | :--- |
-| `mfw doctor` reports that the firewall isn't protecting the machine right after install | The shell wasn't restarted, so `HTTP_PROXY` and `HTTPS_PROXY` aren't set in the current session | Restart your terminal or shell, then re-run `mfw doctor` |
-| `mfw doctor` reports an authentication error | You haven't run `mfw login`, or the short-lived bearer token has expired | Run `mfw login` again |
-| Package installs are slow or time out | The local proxy can't reach the Semgrep verdict backend because of network or firewall rules that block egress | Confirm that outbound access to Semgrep's backend is allowed; review corporate proxy or VPN settings |
-| A known-safe package is unexpectedly blocked | The backend returned a stale or incorrect verdict, or a false-positive match in the malware database | Notify us in the [Semgrep Community Slack](https://go.semgrep.dev/slack) channel |
-| `mfw doctor` isn't found, or the command isn't recognized | The install script didn't complete, or the shell `PATH` wasn't updated | Re-run the install command from [Install and verify](#install-and-verify), then restart your shell |


### PR DESCRIPTION
### Thanks for improving Semgrep Docs

## What & why

Malware Firewall (private beta) now supports **Java (Maven and Gradle)**. This updates the [Malware Firewall private beta page](https://docs.semgrep.dev/semgrep-supply-chain/malware-firewall) to reflect Java support.

## Changes

1. **Supported languages** — added Java, and noted that Java support covers both Maven and Gradle.

Before:
<img width="629" height="109" alt="Screenshot 2026-08-31 at 3 03 48 PM" src="https://github.com/user-attachments/assets/278f27ef-efc5-4d7f-88db-3bafa6a831e7" />

After:
<img width="757" height="122" alt="Screenshot 2026-08-31 at 3 03 22 PM" src="https://github.com/user-attachments/assets/8041d41e-62dc-4224-bddc-aaabd6ffb214" />

2. **"How it works", step 1** — added `repo.maven.apache.org` (Maven Central) to the list of watched registries (alongside `registry.npmjs.org`) added JARs to the artifact examples, and corrected the proxy claim for Java.

Before:
<img width="749" height="464" alt="Screenshot 2026-08-31 at 3 17 05 PM" src="https://github.com/user-attachments/assets/93a82a1b-c614-4eea-8fa9-b079776d5d3a" />

After:
<img width="753" height="733" alt="Screenshot 2026-08-31 at 3 16 59 PM" src="https://github.com/user-attachments/assets/6755426a-c112-44c1-862c-ed8ba4bc4523" />

3. **`mfw api`** — documented the Java ecosystem string `maven` and a Java example 

Before:
<img width="773" height="252" alt="Screenshot 2026-08-31 at 3 10 51 PM" src="https://github.com/user-attachments/assets/05969f40-1c5a-4f54-867f-ecb4320a0896" />

After:
<img width="774" height="361" alt="Screenshot 2026-08-31 at 3 10 59 PM" src="https://github.com/user-attachments/assets/b4a894b0-5be3-439d-8b59-7ef242399135" />

## Deliberately NOT changed 

- **IDE / IntelliJ coverage:** the handoff said coverage "extends to IntelliJ," but the `mfw` code says the opposite — `src/setup/install.rs` (`resolve_jdk`): *"skips IDE-bundled JREs, since nothing injects proxy settings into IDE-embedded Maven anyway."* mfw gates the **command-line** `mvn`/`gradle`; IDE-embedded builds are **not** automatically gated. I did **not** add an IDE section, to avoid documenting the opposite of what ships. **Please confirm whether IDE coverage actually shipped** and, if so, how.
- **Prerequisites:** no JDK or Gradle version floor is enforced in the code (JDK 8 through modern are handled; pre-8.8 Gradle degrades gracefully), so prerequisites are unchanged.
- **Private beta banner:** left as-is per direction.

## Screenshots

Before/after of the rendered page from a local `mintlify dev` build: https://semgrep-ee9d73d8-amanda-fix-update-mfw-private-beta-docs.mintlify.site/semgrep-supply-chain/malware-firewall 

Please ensure:

- [ ] A subject matter expert reviews the content (esp. the IDE-coverage question above)
- [ ] A technical writer reviews the PR
- [x] This change has no security implications
- [x} Check the **Mintlify** bot preview link on this PR
