### PR TITLE
Refine Semgrep proxy information

### DIFF
--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -74,7 +74,7 @@ export HTTP_PROXY="http://10.10.1.10:3128"
 export HTTPS_PROXY="http://10.10.1.10:1080"
 ```
 
-If the proxy variables are set but empty, Semgrep will treat them as if they were not set, and will make direct HTTP requests. Semgrep will attempt to add the protocol to an otherwise-valid proxy without a protocol.
+If the proxy environment variables are set but empty, Semgrep treats them as unset and makes direct HTTP requests. If a valid proxy is missing a protocol, Semgrep attempts to add one.
 
 ## Exit codes
 

--- a/docs/cli-reference.mdx
+++ b/docs/cli-reference.mdx
@@ -56,9 +56,9 @@ The Semgrep command line tool supports a `.semgrepignore` file that follows `.gi
 
 In addition to `.semgrepignore` there are several methods to set up ignore patterns. See [Ignoring files, folders, or code](/ignoring-files-folders-code).
 
-## Connect to Semgrep Registry through a proxy
+## Connect to Semgrep Registry and other endpoints through a proxy
 
-Semgrep uses the Python3 `requests` library. Set the following environment variables to point to your proxy:
+Semgrep uses the Python3 `requests` library and OCaml's `cohttp`. Both support proxy settings using the following standard environment variables:
 
 ```bash
 export HTTP_PROXY="HTTP_PROXY_URL"
@@ -73,6 +73,8 @@ export HTTP_PROXY="http://10.10.1.10:3128"
 
 export HTTPS_PROXY="http://10.10.1.10:1080"
 ```
+
+If the proxy variables are set but empty, Semgrep will treat them as if they were not set, and will make direct HTTP requests. Semgrep will attempt to add the protocol to an otherwise-valid proxy without a protocol.
 
 ## Exit codes
 


### PR DESCRIPTION
I'm making some changes to proxy handling, and need to reflect that in the docs. 

The section title change also makes it clearer that a proxy is used/useful for any outside calls, not just the registry. The only link to this section is in past release notes (Oct 2022) so I haven't updated it but can.

Please ensure:

- [ ] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)
