### PR TITLE
docs(api-reference): publish the API deprecation policy

### DIFF
--- a/docs/api-reference/v1/Deprecation-Policy.mdx
+++ b/docs/api-reference/v1/Deprecation-Policy.mdx
@@ -1,0 +1,10 @@
+---
+title: "Deprecation Policy"
+description: "How much notice you get before a Semgrep API endpoint changes, how you will hear about it, and what happens at sunset."
+---
+
+{/* Shared with the other API version -- edit /snippets/api-deprecation-policy.mdx */}
+
+import ApiDeprecationPolicy from "/snippets/api-deprecation-policy.mdx"
+
+<ApiDeprecationPolicy/>

--- a/docs/api-reference/v1/Deprecation-Policy.mdx
+++ b/docs/api-reference/v1/Deprecation-Policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deprecation Policy"
-description: "How much notice you get before a Semgrep API endpoint changes, how you will hear about it, and what happens at sunset."
+description: "Learn how Semgrep communicates API deprecations, including notice periods and endpoint removal timelines."
 ---
 
 {/* Shared with the other API version -- edit /snippets/api-deprecation-policy.mdx */}

--- a/docs/api-reference/v2/Deprecation-Policy.mdx
+++ b/docs/api-reference/v2/Deprecation-Policy.mdx
@@ -1,0 +1,10 @@
+---
+title: "Deprecation Policy"
+description: "How much notice you get before a Semgrep API endpoint changes, how you will hear about it, and what happens at sunset."
+---
+
+{/* Shared with the other API version -- edit /snippets/api-deprecation-policy.mdx */}
+
+import ApiDeprecationPolicy from "/snippets/api-deprecation-policy.mdx"
+
+<ApiDeprecationPolicy/>

--- a/docs/api-reference/v2/Deprecation-Policy.mdx
+++ b/docs/api-reference/v2/Deprecation-Policy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Deprecation Policy"
-description: "How much notice you get before a Semgrep API endpoint changes, how you will hear about it, and what happens at sunset."
+description: "Learn how Semgrep communicates API deprecations, including notice periods and endpoint removal timelines."
 ---
 
 {/* Shared with the other API version -- edit /snippets/api-deprecation-policy.mdx */}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -618,7 +618,8 @@
                   "api-reference/v1/Introduction",
                   "api-reference/v1/Authentication",
                   "api-reference/v1/Terms-of-Use",
-                  "api-reference/v1/Changelog"
+                  "api-reference/v1/Changelog",
+                  "api-reference/v1/Deprecation-Policy"
                 ]
               },
               {
@@ -640,7 +641,8 @@
                   "api-reference/v2/Introduction",
                   "api-reference/v2/Authentication",
                   "api-reference/v2/Terms-of-Use",
-                  "api-reference/v2/Changelog"
+                  "api-reference/v2/Changelog",
+                  "api-reference/v2/Deprecation-Policy"
                 ]
               },
               {

--- a/docs/snippets/api-deprecation-policy.mdx
+++ b/docs/snippets/api-deprecation-policy.mdx
@@ -2,7 +2,7 @@
 
 APIs change. This policy tells you how much warning you get before a change breaks your integration.
 
-In short: **stable endpoints get 6 months' notice before a breaking change, and 3 months before an already-deprecated optional field is removed.** After the deadline passes, the endpoint returns `410 Gone` with a machine-readable pointer to its replacement — it does not start returning wrong or partial data.
+In short: **stable endpoints get 6 months' notice before a breaking change or a removal.** After the deadline passes, the endpoint returns `410 Gone` with a machine-readable pointer to its replacement — it does not start returning wrong or partial data.
 
 ## What this policy covers
 
@@ -10,7 +10,7 @@ This policy applies to every endpoint documented on [docs.semgrep.dev](https://d
 
 | Maturity | What we promise | Notice before removal or a breaking change |
 | --- | --- | --- |
-| **Stable** | Fully covered by this policy. | 6 months (breaking), 3 months (non-breaking removal) |
+| **Stable** | Fully covered by this policy. | 6 months |
 | **Beta** | Documented and supported. We keep it backwards compatible while it is in beta, but it may still be renamed or removed. | 30 days |
 | **Experimental** | Use at your own risk. Published so you can see what is coming, but it may change or disappear at any time, without notice. | None |
 

--- a/docs/snippets/api-deprecation-policy.mdx
+++ b/docs/snippets/api-deprecation-policy.mdx
@@ -1,0 +1,33 @@
+## What this policy promises
+
+APIs change. This policy tells you how much warning you get before a change breaks your integration.
+
+In short: **stable endpoints get 6 months' notice before a breaking change, and 3 months before an already-deprecated optional field is removed.** After the deadline passes, the endpoint returns `410 Gone` with a machine-readable pointer to its replacement — it does not start returning wrong or partial data.
+
+## What this policy covers
+
+This policy applies to every endpoint documented on [docs.semgrep.dev](https://docs.semgrep.dev/), according to its maturity level.
+
+| Maturity | What we promise | Notice before removal or a breaking change |
+| --- | --- | --- |
+| **Stable** | Fully covered by this policy. | 6 months (breaking), 3 months (non-breaking removal) |
+| **Beta** | Documented and supported. We keep it backwards compatible while it is in beta, but it may still be renamed or removed. | 30 days |
+| **Experimental** | Use at your own risk. Published so you can see what is coming, but it may change or disappear at any time, without notice. | None |
+
+Each endpoint's maturity is shown as a badge in the API reference and as a badge extension in the OpenAPI spec.
+
+**Not covered:** undocumented endpoints. If an endpoint does not appear in the published API reference, it is not part of the supported API, no matter what your browser's network tab shows. That includes internal endpoints used by the Semgrep web app and by the Semgrep CLI. Those change without notice, and building against them is not supported.
+
+### The one exception: urgent security and legal changes
+
+If continuing to serve an endpoint or a field would expose customer data, create a security risk, or violate a legal obligation, we may change it with less notice than the table above — occasionally with none. This is the only exception, we do not use it for convenience, and when we invoke it we will tell you what changed and why as soon as we are able to.
+
+## Finding out what is deprecated today
+
+- The API changelog records every deprecation on the day it ships, tagged
+  **Deprecated**. Each version's changelog is an RSS feed — subscribe to the
+  [v1](/api-reference/v1/Changelog) or [v2](/api-reference/v2/Changelog) feed
+  and you will hear about a deprecation without having to come back and check.
+- The API reference lists deprecated endpoints with their sunset dates.
+- Any deprecated endpoint you call returns `Deprecation` and `Sunset` headers, so grepping your own logs for those headers tells you exactly what your integration depends on.
+- If you are unsure whether something you rely on is covered by this policy, contact [support@semgrep.com](mailto:support@semgrep.com) and we will confirm in writing.

--- a/docs/snippets/api-deprecation-policy.mdx
+++ b/docs/snippets/api-deprecation-policy.mdx
@@ -1,33 +1,34 @@
 ## What this policy promises
 
-APIs change. This policy tells you how much warning you get before a change breaks your integration.
+APIs change over time. This policy explains how much notice you'll receive before a breaking change affects your integration.
 
-In short: **stable endpoints get 6 months' notice before a breaking change or a removal.** After the deadline passes, the endpoint returns `410 Gone` with a machine-readable pointer to its replacement — it does not start returning wrong or partial data.
+<Note>
+  In summary, **stable endpoints receive at least 6 months' notice before a breaking change or a removal.** After the deprecation period ends, the endpoint returns `410 Gone` with a machine-readable pointer to its replacement. It never returns incorrect or partial data.
+</Note>
 
 ## What this policy covers
 
 This policy applies to every endpoint documented on [docs.semgrep.dev](https://docs.semgrep.dev/), according to its maturity level.
 
-| Maturity | What we promise | Notice before removal or a breaking change |
+| Maturity | What to expect | Notice before a breaking change or removal |
 | --- | --- | --- |
-| **Stable** | Fully covered by this policy. | 6 months |
-| **Beta** | Documented and supported. We keep it backwards compatible while it is in beta, but it may still be renamed or removed. | 30 days |
-| **Experimental** | Use at your own risk. Published so you can see what is coming, but it may change or disappear at any time, without notice. | None |
+| **Stable** | Covered by the Semgrep API deprecation policy. | 6 months |
+| **Beta** | Supported and documented. Semgrep maintains backward compatibility during the beta period, but the endpoint may still be renamed or removed. | 30 days |
+| **Experimental** | Published to help you preview functionality. Experimental endpoints may change, be renamed, or be removed at any time without notice. | None |
 
 Each endpoint's maturity is shown as a badge in the API reference and as a badge extension in the OpenAPI spec.
 
-**Not covered:** undocumented endpoints. If an endpoint does not appear in the published API reference, it is not part of the supported API, no matter what your browser's network tab shows. That includes internal endpoints used by the Semgrep web app and by the Semgrep CLI. Those change without notice, and building against them is not supported.
+**Undocumented endpoints are not covered**. If an endpoint does not appear in the published API reference, it is not part of the supported API, regardless of what you see in your browser's network tab. This includes internal endpoints used by Semgrep AppSec Platform and the Semgrep CLI. These endpoints may change or be removed without notice and are not supported for customer integrations.
 
 ### The one exception: urgent security and legal changes
 
-If continuing to serve an endpoint or a field would expose customer data, create a security risk, or violate a legal obligation, we may change it with less notice than the table above — occasionally with none. This is the only exception, we do not use it for convenience, and when we invoke it we will tell you what changed and why as soon as we are able to.
+If continuing to support an endpoint or field would expose customer data, create a security risk, or violate a legal obligation, Semgrep may make changes with less notice than described above, or in rare cases, without notice.
 
-## Finding out what is deprecated today
+This is the only exception to the deprecation policy. Semgrep does not invoke it for convenience. When invoked, Semgrep will communicate what changed and why as soon as possible.
 
-- The API changelog records every deprecation on the day it ships, tagged
-  **Deprecated**. Each version's changelog is an RSS feed — subscribe to the
-  [v1](/api-reference/v1/Changelog) or [v2](/api-reference/v2/Changelog) feed
-  and you will hear about a deprecation without having to come back and check.
-- The API reference lists deprecated endpoints with their sunset dates.
-- Any deprecated endpoint you call returns `Deprecation` and `Sunset` headers, so grepping your own logs for those headers tells you exactly what your integration depends on.
-- If you are unsure whether something you rely on is covered by this policy, contact [support@semgrep.com](mailto:support@semgrep.com) and we will confirm in writing.
+## Identify deprecated endpoints
+
+- Subscribe to the API changelog: Every deprecation is announced in the changelog on the day it ships and is tagged as Deprecated. Each API version has its own RSS feed. Subscribe to the [v1](/api-reference/v1/Changelog) or [v2](/api-reference/v2/Changelog) feed to receive deprecation notices automatically.
+- Check the API reference: The API reference marks deprecated endpoints and includes their sunset dates.
+- Monitor deprecation headers: Deprecated endpoints include `Deprecation` and `Sunset` response headers. Monitoring these headers in your application logs helps identify any deprecated endpoints that your integration still depends on.
+- Contact Semgrep if you're unsure: If you're unsure whether an endpoint or feature is covered by this policy, contact [support@semgrep.com](mailto:support@semgrep.com)

--- a/docs/snippets/api-deprecation-policy.mdx
+++ b/docs/snippets/api-deprecation-policy.mdx
@@ -3,32 +3,76 @@
 APIs change over time. This policy explains how much notice you'll receive before a breaking change affects your integration.
 
 <Note>
-  In summary, **stable endpoints receive at least 6 months' notice before a breaking change or a removal.** After the deprecation period ends, the endpoint returns `410 Gone` with a machine-readable pointer to its replacement. It never returns incorrect or partial data.
+  In summary, **stable endpoints receive at least 180 days' notice before a breaking change or a removal.** After the deprecation period ends, the endpoint returns `410 Gone` and points you at its replacement. It never returns incorrect or partial data.
 </Note>
 
 ## What this policy covers
 
 This policy applies to every endpoint documented on [docs.semgrep.dev](https://docs.semgrep.dev/), according to its maturity level.
+Each endpoint's maturity is shown as a badge in the API reference and as a badge extension in the OpenAPI spec.
 
 | Maturity | What to expect | Notice before a breaking change or removal |
 | --- | --- | --- |
-| **Stable** | Covered by the Semgrep API deprecation policy. | 6 months |
+| **Stable** | Supported and documented. Expected to evolve and improve without breaking changes. | 180 days |
 | **Beta** | Supported and documented. Semgrep maintains backward compatibility during the beta period, but the endpoint may still be renamed or removed. | 60 days |
 | **Experimental** | Published to help you preview functionality. Experimental endpoints may change, be renamed, or be removed at any time without notice. | None |
 
-Each endpoint's maturity is shown as a badge in the API reference and as a badge extension in the OpenAPI spec.
-
 **Undocumented endpoints are not covered**. If an endpoint does not appear in the published API reference, it is not part of the supported API, regardless of what you see in your browser's network tab. This includes internal endpoints used by Semgrep AppSec Platform and the Semgrep CLI. These endpoints may change or be removed without notice and are not supported for customer integrations.
 
-### The one exception: urgent security and legal changes
+### What counts as a breaking change
 
-If continuing to support an endpoint or field would expose customer data, create a security risk, or violate a legal obligation, Semgrep may make changes with less notice than described above, or in rare cases, without notice.
+On a stable endpoint, Semgrep does not do any of the following without the full notice period:
 
-This is the only exception to the deprecation policy. Semgrep does not invoke it for convenience. When invoked, Semgrep will communicate what changed and why as soon as possible.
+- Remove or rename the endpoint, or change its URL path or HTTP method.
+- Remove or rename a field in a response, whether or not that field is optional.
+- Change the type of an existing field, or narrow the set of values it accepts.
+- Add a new required request parameter, or make an existing optional one required.
+- Change the meaning of an existing field without changing its name.
+
+Semgrep may make the following changes at any time, so build your integration to tolerate them:
+
+- Add a new endpoint, or a new optional request parameter.
+- Add a new field to a response. Parse responses so that unrecognized fields are ignored rather than treated as an error.
+- Add a new value to an existing enum, unless that enum is documented as closed.
+- Change the order of items in a response where no order is documented.
+- Change human-readable text, such as an `error` message, that is not documented as stable.
+
+### Exception: unavoidable urgent changes
+
+If continuing to support an endpoint, field, or other aspect of API behavior would expose customer data, create a security risk, or violate an obligation, Semgrep may make changes with less notice than described above, or in rare cases without notice.
+
+Semgrep will not invoke this exception lightly. When invoked, Semgrep will communicate what changed and why as soon as possible.
 
 ## Identify deprecated endpoints
 
 - Subscribe to the API changelog: Every deprecation is announced in the changelog on the day it ships and is tagged as Deprecated. Each API version has its own RSS feed. Subscribe to the [v1](/api-reference/v1/Changelog) or [v2](/api-reference/v2/Changelog) feed to receive deprecation notices automatically.
 - Check the API reference: The API reference marks deprecated endpoints and includes their sunset dates.
 - Monitor deprecation headers: Deprecated endpoints include `Deprecation` and `Sunset` response headers. Monitoring these headers in your application logs helps identify any deprecated endpoints that your integration still depends on.
-- Contact Semgrep if you're unsure: If you're unsure whether an endpoint or feature is covered by this policy, contact [support@semgrep.com](mailto:support@semgrep.com)
+- Contact Semgrep if you're unsure: If you're unsure whether an endpoint or feature is covered by this policy, contact [support@semgrep.com](mailto:support@semgrep.com) and Semgrep will confirm in writing.
+
+## What happens at sunset
+
+Once an endpoint's sunset date arrives, it stops serving data and returns `410 Gone`. Semgrep does not silently leave a sunset endpoint running, and it never responds with partial or stale data in place of the data you asked for.
+
+A sunset response looks like this:
+
+```http
+HTTP/1.1 410 Gone
+Content-Type: application/json
+Deprecation: Tue, 01 Sep 2026 00:00:00 GMT
+Sunset: Mon, 01 Mar 2027 00:00:00 GMT
+Link: </api/v2/issues>; rel="successor-version"
+
+{
+  "error": "This endpoint was removed on 2027-03-01. Use GET /api/v2/issues instead."
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `Deprecation` | The date the deprecation became public, as an HTTP date. This is when the notice period started. |
+| `Sunset` | The date the endpoint stopped serving data, as an HTTP date, per [RFC 8594](https://www.rfc-editor.org/rfc/rfc8594). |
+| `Link` | The replacement endpoint, with the relation `successor-version`. Parse this rather than the `error` string when you need to route to the replacement automatically. |
+| `error` | A human-readable explanation. Its wording is not stable, so don't match on it. |
+
+When an endpoint is removed with no replacement, the `Link` header is omitted and the `error` string says that no replacement exists. The `Deprecation` and `Sunset` headers are also sent on successful responses throughout the notice period, not only at sunset.

--- a/docs/snippets/api-deprecation-policy.mdx
+++ b/docs/snippets/api-deprecation-policy.mdx
@@ -13,7 +13,7 @@ This policy applies to every endpoint documented on [docs.semgrep.dev](https://d
 | Maturity | What to expect | Notice before a breaking change or removal |
 | --- | --- | --- |
 | **Stable** | Covered by the Semgrep API deprecation policy. | 6 months |
-| **Beta** | Supported and documented. Semgrep maintains backward compatibility during the beta period, but the endpoint may still be renamed or removed. | 30 days |
+| **Beta** | Supported and documented. Semgrep maintains backward compatibility during the beta period, but the endpoint may still be renamed or removed. | 60 days |
 | **Experimental** | Published to help you preview functionality. Experimental endpoints may change, be renamed, or be removed at any time without notice. | None |
 
 Each endpoint's maturity is shown as a badge in the API reference and as a badge extension in the OpenAPI spec.

--- a/docs/snippets/api-deprecation-policy.mdx
+++ b/docs/snippets/api-deprecation-policy.mdx
@@ -45,14 +45,14 @@ Semgrep will not invoke this exception lightly. When invoked, Semgrep will commu
 
 ## Identify deprecated endpoints
 
-- Subscribe to the API changelog: Every deprecation is announced in the changelog on the day it ships and is tagged as Deprecated. Each API version has its own RSS feed. Subscribe to the [v1](/api-reference/v1/Changelog) or [v2](/api-reference/v2/Changelog) feed to receive deprecation notices automatically.
+- Subscribe to the API changelog: Every deprecation is announced in the changelog on the day it ships, marked **Deprecated**, and filed under **Potentially breaking** so that it still appears when you filter the changelog for changes that can affect your integration. Each API version has its own RSS feed. Subscribe to the [v1](/api-reference/v1/Changelog) or [v2](/api-reference/v2/Changelog) feed to receive deprecation notices automatically.
 - Check the API reference: The API reference marks deprecated endpoints and includes their sunset dates.
 - Monitor deprecation headers: Deprecated endpoints include `Deprecation` and `Sunset` response headers. Monitoring these headers in your application logs helps identify any deprecated endpoints that your integration still depends on.
 - Contact Semgrep if you're unsure: If you're unsure whether an endpoint or feature is covered by this policy, contact [support@semgrep.com](mailto:support@semgrep.com) and Semgrep will confirm in writing.
 
 ## What happens at sunset
 
-Once an endpoint's sunset date arrives, it stops serving data and returns `410 Gone`. Semgrep does not silently leave a sunset endpoint running, and it never responds with partial or stale data in place of the data you asked for.
+Once an endpoint's sunset date arrives, it stops serving data and returns `410 Gone`. The removal is recorded in the changelog on the day it happens, so the end of an endpoint's life is announced the same way its deprecation was. Semgrep does not silently leave a sunset endpoint running, and it never responds with partial or stale data in place of the data you asked for.
 
 A sunset response looks like this:
 


### PR DESCRIPTION
## What this adds

A **Deprecation Policy** page for the public API, sitting next to the changelog in both versions:

- `/api-reference/v1/Deprecation-Policy`
- `/api-reference/v2/Deprecation-Policy`

It answers one customer question: *how much warning do I get before a Semgrep API change breaks my integration?* Short version — stable endpoints get 6 months' notice for a breaking change, beta gets 30 days, experimental gets none, and undocumented endpoints aren't covered at all. At the deadline the endpoint returns `410 Gone` rather than quietly serving wrong data.

The text is the customer-facing half of the policy drafted in APPEX-956. The internal appendix — notice channels, the 410-vs-301 decision record, known gaps — is not published.

## One change from the draft

The policy was written before we decided to ship a changelog, so its "how do I find out what's deprecated" list had no way for a customer to be told proactively — only the reference, response headers, and emailing support. It now leads with the changelog and its RSS feed, which records every deprecation on the day it ships.

## Notes for review

- The body lives in a snippet imported by both version pages, so v1 and v2 can't drift apart.
- **Omitted on purpose:** the in-app banner and admin email that the draft names as commitments. Neither exists yet, so publishing them would promise channels we can't serve.
- **Still needs Product and Legal/Compliance sign-off** per the APPEX-956 checklist — this is a public commitment, so please don't merge on a docs review alone.

## Test plan

- [x] `npx mintlify@latest validate` passes

Stacked on #2796 — this page links to the changelog pages that PR adds, so it should merge after it.
