### PR TITLE
docs: document in-tree grammar upgrades

### DIFF
--- a/docs/contributing/contributing-code.mdx
+++ b/docs/contributing/contributing-code.mdx
@@ -125,7 +125,75 @@ There are some features that cross through both OCaml and Python code. You will 
 * Add a new language
 * Change error reporting
 
-Go to [semgrep-core contributing](/contributing/semgrep-core-contributing). It will direct you to [semgrep-cli contributing](/contributing/semgrep-contributing) when appropriate. 
+Go to [semgrep-core contributing](/contributing/semgrep-core-contributing). It will direct you to [semgrep-cli contributing](/contributing/semgrep-contributing) when appropriate.
+
+### Update a language grammar
+
+Tree-sitter grammar pins and wrappers live in the Semgrep repository under
+`libs/ocaml-tree-sitter-semgrep/`. See
+[How to upgrade the grammar for a language](/contributing/updating-a-grammar)
+for the full process.
+
+To update Python:
+
+<Steps>
+<Step>
+Edit the `python` entry in
+`libs/ocaml-tree-sitter-semgrep/lang/upstream-grammars.json`. Change `commit`
+to the upstream SHA; change `tree_sitter` only if a different CLI is required:
+
+```json
+"python": {
+  "commit": "NEW_UPSTREAM_COMMIT_SHA",
+  "regen": ["python"],
+  "tree_sitter": "0.26.3",
+  "url": "https://github.com/tree-sitter/tree-sitter-python.git"
+}
+```
+</Step>
+<Step>
+Adjust
+`libs/ocaml-tree-sitter-semgrep/lang/semgrep-grammars/src/semgrep-python/`
+if the wrapper must change, and add corpus cases under its `test/corpus/`.
+</Step>
+<Step>
+From the repository root:
+
+```bash
+make test-grammar-python
+make regen-grammar-python
+```
+</Step>
+<Step>
+Run `make core` and `make test`. If the CST changed, update
+`languages/python/tree-sitter/Parse_python_tree_sitter.ml`. Commit the
+registry, wrapper, tests, and generated
+`languages/python/tree-sitter/semgrep-python/` files. Never commit fetched
+`tree-sitter-*` clones.
+</Step>
+</Steps>
+
+Commands accept either a registry key or a regeneration destination. They can
+differ. TypeScript's registry entry regenerates two destinations:
+
+```json
+"typescript": {
+  "commit": "75b3874edb2dc714fb1fd77a32013d0f8699989f",
+  "depends_on": ["javascript"],
+  "regen": ["typescript", "tsx"],
+  "tree_sitter": "0.22.6",
+  "url": "https://github.com/tree-sitter/tree-sitter-typescript.git"
+}
+```
+
+```bash
+make test-grammar-typescript
+make regen-grammar-typescript
+make regen-grammar-tsx
+```
+
+To add a language, see
+[How to add support for a new language](/contributing/adding-a-language).
 
 ## Development workflow
 

--- a/docs/contributing/updating-a-grammar.mdx
+++ b/docs/contributing/updating-a-grammar.mdx
@@ -1,204 +1,133 @@
 ---
 title: "How to upgrade the grammar for a language"
+sidebarTitle: "Upgrade a language grammar"
 ---
 
-Like for adding a language, most of these instructions happen in
-[ocaml-tree-sitter-semgrep](https://github.com/semgrep/ocaml-tree-sitter-semgrep).
+Run all commands from the **Semgrep repository root**, which contains
+`languages/`, `src/`, and `libs/`. Paths below are relative to that root.
 
-Let's assume we are upgrading the grammar for the programming language `$PL`.
-(Consider adding an environment variable to your shell to make copying some of the commands below easier).
+```bash
+ots=libs/ocaml-tree-sitter-semgrep
+```
 
-## Summary (ocaml-tree-sitter)
+There are three parts to a grammar change:
 
-In ocaml-tree-sitter:
+| Part | Location | Purpose |
+| --- | --- | --- |
+| Upstream grammar | `$ots/lang/upstream-grammars.json` | Pins the source repository, commit, and tree-sitter CLI version. |
+| Semgrep wrapper | `$ots/lang/semgrep-grammars/src/semgrep-<name>/` | Extends the upstream grammar with pattern syntax such as `$X` and `...`. |
+| Generated parser | `languages/<language>/tree-sitter/semgrep-<dest>/` | Contains the C and OCaml parser files used by Semgrep. |
+
+A registry **key** identifies an upstream grammar. A **destination** identifies
+one generated parser. They are usually identical (`python`), but one key can
+produce several destinations (`typescript` produces `typescript` and `tsx`).
+`test-grammar` tests a key and its dialects; `regen-grammar` writes one destination
+from that key's `regen` list.
+
+If you have questions, reach out on the [Semgrep Community Slack](https://go.semgrep.dev/slack).
+
+## Prepare the tools
+
+Complete the repository's normal development setup first (`make setup`,
+`pre-commit install`, and `make all`). Grammar development also needs Node.js,
+Cargo, clang/clang++, and Git LFS on `PATH`.
+
+The normal setup installs the OCaml dependencies through `semgrep.opam` and its
+lockfile, including the pinned `tree-sitter` package. No separate setup in the
+grammar directory is needed.
+
+`make test-grammar-<name>` and `make regen-grammar-<dest>` build the current
+generator automatically and provision the selected tree-sitter CLI under
+`$ots/core/tree-sitter-<version>/` on demand. The registry's `tree_sitter` field
+selects that CLI; `$ots/core/tree-sitter-version` independently selects Semgrep's
+shared runtime library. Adding a CLI version only requires updating the registry;
+the provisioner downloads its published release binary automatically.
+
+## Upgrade an existing grammar
+
+The example below updates Python. Replace `python` with your language's
+registry key and destination.
+
 <Steps>
 <Step>
-Update submodule `tree-sitter-$PL`.
+Edit the language's `commit` in `$ots/lang/upstream-grammars.json`.
+Change `tree_sitter` only if the new grammar needs a different CLI version.
+
+```json
+"python": {
+  "commit": "NEW_UPSTREAM_COMMIT_SHA",
+  "regen": ["python"],
+  "tree_sitter": "0.26.3",
+  "url": "https://github.com/tree-sitter/tree-sitter-python.git"
+}
+```
 </Step>
 <Step>
-From `lang/`, run `./test-lang $PL`.
+Adjust the wrapper if the new upstream grammar requires it, and add
+regression cases to the wrapper corpus.
+
+For Python, edit `$ots/lang/semgrep-grammars/src/semgrep-python/grammar.js`
+and add cases to
+`$ots/lang/semgrep-grammars/src/semgrep-python/test/corpus/semgrep.txt`.
+The FGA wrapper is a small example of Semgrep pattern extensions.
 </Step>
 <Step>
-From `lang/`, ask a Semgrep team developer to run `./release $PL`.
+Test the grammar, then regenerate the parser:
+
+```bash
+make test-grammar-python
+make regen-grammar-python
+```
+
+Testing fetches the pinned upstream sources and rebuilds the wrapper before
+checking its corpus and generated OCaml parser. Regeneration copies the parser
+into `languages/` and refreshes its `fyi/` provenance files.
+</Step>
+<Step>
+Rebuild and test Semgrep. If the CST changed, update the mapper next to the
+generated parser, using generated `lib/Boilerplate.ml` as a guide:
+
+```bash
+make core
+make test
+```
+
+For Python, the mapper is
+`languages/python/tree-sitter/Parse_python_tree_sitter.ml`.
+Commit the registry change, wrapper changes, tests, and generated files under
+`languages/python/tree-sitter/semgrep-python/`.
+Do not edit generated parser files by hand, and never commit the fetched
+upstream clone or intermediate `$ots/lang/python/ocaml-src/` and `src/`
+build outputs.
 </Step>
 </Steps>
-In semgrep:
-<Steps>
-<Step>
-In the semgrep repo, update submodule `semgrep-$PL`.
-</Step>
-<Step>
-In the semgrep repo, update the OCaml code that maps the CST to the generic AST.
-</Step>
-</Steps>
-In the end, **make sure the generated code used by the main branch of
-semgrep can be regenerated** from the main branch of ocaml-tree-sitter:
-<Steps>
-<Step>
-Merge your semgrep branch.
-</Step>
-<Step>
-Merge your ocaml-tree-sitter branch.
-</Step>
-</Steps>
 
-## Components
+For wrapper-only changes, skip step 1.
 
-Here are the main components:
+### Multiple destinations
 
-* the OCaml code generator
-  [ocaml-tree-sitter](https://github.com/semgrep/ocaml-tree-sitter-semgrep):
-  generates OCaml parsing code from tree-sitter grammars extended
-  with `...` and such. Publishes code into the git repos of the
-  form `semgrep-$PL`.
-* the original tree-sitter grammar `tree-sitter-$PL` e.g.,
-  [tree-sitter-ruby](https://github.com/tree-sitter/tree-sitter-ruby):
-  the original tree-sitter grammar for the language.
-  This is the git submodule `lang/semgrep-grammars/src/tree-sitter-$PL`
-  in ocaml-tree-sitter. It is installed at the project's root
-  in `node_modules` by invoking `npm install`.
-* syntax extensions to support semgrep patterns, such as ellipses
-  (`...`) and metavariables (`$FOO`).
-  This is `lang/semgrep-grammars/src/semgrep-$PL`. It can be tested from
-  that folder with `make && make test`.
-* an automatically-modified grammar for language `$PL` in `lang/$PL`.
-  It is modified so as to accommodate various requirements of the
-  ocaml-tree-sitter code generator. `lang/$PL/src` and
-  `lang/$PL/ocaml-src` contain the C/C++/OCaml code that will be published
-  into `semgrep-$PL` e.g.
-  [semgrep-ruby](https://github.com/semgrep/semgrep-ruby)
-  and used by semgrep.
-* [semgrep-$PL](https://github.com/semgrep/semgrep-ruby):
-  provides generated OCaml/C parsers as a dune project. Is a submodule
-  of semgrep.
-* [semgrep](https://github.com/semgrep/semgrep): uses the parsers
-  provided by `semgrep-$PL`, which produce a CST. The
-  program's CST or pattern's CST is further transformed into an AST
-  suitable for pattern matching.
+For a key with multiple destinations, run `regen-grammar` once for each
+destination. TypeScript's registry entry is:
 
-Make sure the above is clear in your mind before proceeding further.
-If you have questions, the best way is to reach out on the [Semgrep
-Community Slack channel](https://go.semgrep.dev/slack).
-
-## Before upgrading
-
-Make sure the `grammar.js` file or equivalent source files
-defining the grammar are included in the `fyi.list` file in
-`ocaml-tree-sitter/lang/$PL`.
-
-Why: It is important for tracking and _understanding_ the changes made at the
-source.
-
-How: See [How to add support for a new language](/contributing/adding-a-language).
-
-## Upgrade the tree-sitter-$PL submodule
-
-Say you want to upgrade (or downgrade) `tree-sitter-$PL` from some old
-commit to commit `602f12b`. This uses the git submodule way, without
-anything weird. The commands might be something like this:
-
-```bash
-git submodule update --init --recursive --depth 1
-git checkout -b upgrade-$PL
-cd lang/semgrep-grammars/src/tree-sitter-$PL
-git fetch origin --unshallow
-git checkout 602f12b
-cd ..
+```json
+"typescript": {
+  "commit": "75b3874edb2dc714fb1fd77a32013d0f8699989f",
+  "depends_on": ["javascript"],
+  "regen": ["typescript", "tsx"],
+  "tree_sitter": "0.22.6",
+  "url": "https://github.com/tree-sitter/tree-sitter-typescript.git"
+}
 ```
 
-## Testing
-
-First, build and install ocaml-tree-sitter normally, based on the
-instructions found in the [main README](https://github.com/semgrep/ocaml-tree-sitter-semgrep/blob/main/README.md).
-
 ```bash
-./configure
-make setup
-make
-make install
+make test-grammar-typescript
+make regen-grammar-typescript
+make regen-grammar-tsx
 ```
 
-Then, build support for your language in `lang/`. The following
-commands will build and test the language:
-
-```bash
-cd lang
-  ./test-lang $PL
-```
-
-<Warning>
-**CAUTION**
-
-Check the generated code for the presence of `Blank` nodes. Those
-correspond to [missing tokens](https://github.com/tree-sitter/tree-sitter/issues/1151).
-</Warning>
-
-
-Check with:
-```bash
-grep Blank lang/$PL/ocaml-src/lib/CST.ml
-```
-If anything comes up, you must modify the grammar so as to create
-a named rule for the node of the `Blank` kind. Eventually, the generated
-`CST.ml` should not have `Blank` nodes anymore but a token type instead.
-Where a `Blank` node exists, we won't be able to get a token or its location
-at parsing time.
-
-If this works, we're all set. Commit the new commit for the
-`tree-sitter-$PL` submodule:
-```bash
-git status
-git commit semgrep-languages/semgrep-$PL
-git push origin upgrade-$PL
-```
-
-Then make a pull request to merge this into ocaml-tree-sitter's
-main branch. It's ok to merge at this point, even if the generated code
-hasn't been exported (**Publishing** section below) or if you haven't
-done the necessary changes in semgrep (**Semgrep integration** below).
-
-We can now consider publishing the code to `semgrep-$PL`.
-
-## Publishing
-
-_Please [ask someone at Semgrep, Inc. to run this step](https://github.com/semgrep/ocaml-tree-sitter-semgrep/blob/main/doc/release.md)._
-
-From the `lang` folder of ocaml-tree-sitter, we'll perform the
-release. This step redoes some of the work that was done earlier and
-checks that everything is clean before committing and pushing the
-changes to semgrep-$PL.
-
-```bash
-cd lang
-  ./release --dry-run $PL  # dry-run release
-  ...                    # 'git status' will show changes for language $PL
-  ./release $PL  # commits and pushes to semgrep-$PL
-```
-
-This step is safe. Semgrep at this point is unaffected by those
-changes. There is now a new commit at
-`https://github.com/semgrep/semgrep-$PL` e.g.
-https://github.com/semgrep/semgrep-javascript.
-The [`fyi/` folder](https://github.com/semgrep/semgrep-javascript/tree/main/fyi)
-contains original files from which the code was generated.
-[`fyi/versions`](https://github.com/semgrep/semgrep-javascript/blob/main/fyi/versions)
-shows the last change for each file, allowing you to check that you
-got the correct version of `grammar.js` or some other source file.
-
-## Semgrep integration
-
-From the semgrep repository, point the submodule for `semgrep-$PL` to the
-latest commit from the "Publishing" step. Then rebuild semgrep-core,
-which will normally fail if the grammar changed. If the source
-`grammar.js` was included in the `fyi` folder for `semgrep-$PL` (as it
-should), `git diff HEAD^` should help figure out the changes since the
-last version.
-
-## Conclusion
-
-The main difficulty is to understand how the different git projects
-interact and to not make mistakes when dealing with git submodules,
-which takes a bit of practice.
+Entries with `regen: []` do not produce a parser for Semgrep. If you change a
+grammar used by another entry's `depends_on`, also test and regenerate that
+consumer (for example, `cpp` after changing `c`).
 
 ## See also
 


### PR DESCRIPTION
### Thanks for improving Semgrep Docs

Please ensure:

- [x] A subject matter expert reviews the content
- [ ] A technical writer reviews the PR
- [x] This change has no security implications or else you have pinged the security team
- [x] Any redirects are in `docs/docs.json` if URLs changed
- [x] If you edited `docs/extensions/pre-commit.md.template.mdx`, CI regenerates `pre-commit.mdx` on this PR (no manual `run-build-scripts` needed)
- [ ] Check the **Mintlify** bot preview link on this PR (requires PR to `main`)

## Summary

- Rewrite [updating-a-grammar](https://semgrep.dev/docs/contributing/updating-a-grammar/) for the in-tree registry / `test-grammar` / `regen-grammar` workflow (no ocaml-tree-sitter submodules or `semgrep-$PL` publish step).
- Paths are relative to the open-source Semgrep repo (`libs/…`, not `OSS/libs/…`).
- Each upgrade step includes a Python example, including a registry entry; TypeScript shows a multi-destination `regen` list.
- Add a short matching section to contributing-code that points at the full page.

## Test plan

- [ ] Check the Mintlify preview: commands, paths, and registry JSON match the Semgrep repo layout after the OTS fold.
- [ ] Confirm `make test-grammar-python`, `make regen-grammar-python`, `make test-grammar-typescript`, `make regen-grammar-typescript`, and `make regen-grammar-tsx` are valid from the Semgrep repo root.
- [ ] Confirm no `OSS/` prefixes remain on this page.


Made with [Cursor](https://cursor.com)