### PR TITLE
Document minimal data retention support for Agentic Workflows

### DIFF
--- a/docs/semgrep-multimodal/privacy.mdx
+++ b/docs/semgrep-multimodal/privacy.mdx
@@ -102,7 +102,7 @@ If you want to further limit data retention for Semgrep Multimodal, you can cont
 AI responses are still stored as required to provide functionality.
 
 <Note>
-Organizations enrolled in the minimal data retention policy cannot run [Semgrep Agentic Workflows](/workflows/overview). Please contact your Semgrep account executive for more information.
+Organizations enrolled in the minimal data retention policy can run [Semgrep Agentic Workflows](/workflows/overview).
 </Note>
 
 > **When should I use this?**  
@@ -125,7 +125,7 @@ The table below compares default data handling with the minimal data retention p
 | AI responses (other features) | Stored for up to 6 months to provide functionality and access to prior results | Stored only as required to provide functionality, with reduced persistence |
 | Memories | Stored for the lifetime of the account; may include user-provided content and small code snippets | No change |
 | AI-powered detection data | Full file analysis, context documentation, derived context, and scan reports may be stored and reused | No change |
-| External storage (Semgrep-managed S3) | Used for certain data | Not used, except for AI-powered detection derived context, uploaded context documents and scan reports |
+| External storage (Semgrep-managed S3) | Used for certain data | Not used, except for AI-powered detection derived context, uploaded context documents, scan and workflow job reports |
 | Data deletion | Available upon request | Available upon request |
 
 

--- a/docs/semgrep-multimodal/privacy.mdx
+++ b/docs/semgrep-multimodal/privacy.mdx
@@ -73,7 +73,7 @@ Data stored may include:
 - Uploaded context documentation
 - Scan reports, including metadata such as file names and, in some cases, code snippets
 
-Uploaded context documentation, scan reports, and derived context about the source code are persistently stored in a Semgrep-managed Amazon S3 bucket. Context documentation may be reused in future scans. 
+Uploaded context documentation, scan reports, workflow job reports, and derived context about the source code are persistently stored in a Semgrep-managed Amazon S3 bucket. Context documentation may be reused in future scans. 
 
 Source data is retained for up to 6 months unless otherwise noted. Semgrep will provide at least 30 days’ notice before making changes to retention policies.
 
@@ -130,12 +130,12 @@ The table below compares default data handling with the minimal data retention p
 
 
 
-### Exceptions for AI-powered detection scans
+### Exceptions for AI-powered detection scans and Agentic Workflows
 
-Under the minimal data retention policy, the following behavior remains unchanged for AI-powered detection scans:
+Under the minimal data retention policy, the following behavior remains unchanged for AI-powered detection scans and [Agentic Workflows](/workflows/overview):
 
 - If you upload context documentation to enhance AI-powered detection scans, these files are persistently stored in a Semgrep-managed Amazon S3 bucket to enable reuse across future AI-powered detection scans.
-- AI-powered detection scan reports are stored in a Semgrep-managed Amazon S3 bucket. These reports may contain metadata such as file names and, in some cases, code snippets included in issue descriptions.
+- AI-powered detection scan reports and Agentic Workflows job reports are stored in a Semgrep-managed Amazon S3 bucket. These reports may contain metadata such as file names and, in some cases, code snippets included in issue descriptions.
 - Context discovered during scans is stored in a Semgrep-managed Amazon S3 bucket. This can include detected facts about the codebase, such as languages, frameworks, and structured data about relevant code features, including file names and symbols.
 
 Responses from Semgrep's AI model vendors are stored in the Semgrep database solely for providing Multimodal functionality. For instance, AI-generated remediation advice is stored so users can access it in the Semgrep AppSec Platform. However, code snippets are never retained to improve future prompts.

--- a/docs/workflows/get-started.mdx
+++ b/docs/workflows/get-started.mdx
@@ -28,7 +28,7 @@ If your deployment is not ready, Semgrep AppSec Platform shows an activation pro
 During the beta:
 
 - CI-based execution is not supported. Agentic Workflows runs as a Semgrep-hosted service.
-- Agentic Workflows does not support non-default AI providers or bring your own key (BYOK). If you use these configurations, you cannot run Agentic Workflows.
+- Agentic Workflows requires Semgrep's default AI providers. Bring your own key (BYOK) and custom AI providers are not supported.
 
 If your organization meets one of these criteria, contact your Semgrep account executive for more information.
 

--- a/docs/workflows/get-started.mdx
+++ b/docs/workflows/get-started.mdx
@@ -28,7 +28,7 @@ If your deployment is not ready, Semgrep AppSec Platform shows an activation pro
 During the beta:
 
 - CI-based execution is not supported. Agentic Workflows runs as a Semgrep-hosted service.
-- You must leave the default AI providers enabled. Agentic Workflows does not support bring your own key (BYOK) or [minimal data retention (MDR)](/semgrep-multimodal/privacy#minimal-data-retention-policy-optional). If you use these configurations, you cannot run Agentic Workflows.
+- Agentic Workflows does not support non-default AI providers or bring your own key (BYOK). If you use these configurations, you cannot run Agentic Workflows.
 
 If your organization meets one of these criteria, contact your Semgrep account executive for more information.
 


### PR DESCRIPTION
Agentic Workflows now runs for organizations enrolled in the minimal data retention policy. The nine workflows the beta offers declare support for it (semgrep/workflows#2363), and the SDK keeps code, prompts, and model output out of Semgrep's observability tools during a run (semgrep/workflows#2293, semgrep/workflows#2287, semgrep/workflows#2355, semgrep/workflows#2145). Both are in production.

Two pages say otherwise, and the privacy page's storage row is incomplete once these customers can run a job:

- **`docs/workflows/get-started.mdx`** pairs the policy with BYOK in one unsupported-configurations bullet. BYOK is still unsupported, so the bullet keeps the AI provider requirement and drops the policy.
- **`docs/semgrep-multimodal/privacy.mdx`** tells enrolled organizations to contact their account executive because Workflows cannot run. It now says they can.
- **`docs/semgrep-multimodal/privacy.mdx`** lists what still reaches Semgrep-managed S3 under the policy, and workflow job reports were missing. Each job writes one, holding the issues it produced — file names and, in some cases, code snippets — and that is the same with or without the policy. This is a new disclosure about stored customer data, so it wants a privacy reviewer rather than a docs-only review.

The product change that matches this is semgrep/semgrep-app#31778, which removes the activation prompt telling these organizations that Workflows cannot run. **Merge that first.**

### Suggested release note

For the shipping week, under **Changed**:

> - [Semgrep Agentic Workflows](/workflows/overview) can now run for organizations enrolled in the minimal data retention policy. During a run, Semgrep does not log or capture your code, prompts, or model output in its observability tools.

---

### Please ensure

- [x] A subject matter expert (SME) reviews the content
- [x] A technical writer reviews the content or PR
- [x] This change has no security implications or else you have pinged the security team — **see the privacy reviewer note above**
- [x] Redirects are added if the PR changes page URLs — no URLs change
- [x] If you have changed any header tag links, update all instances of that link — no anchors change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
